### PR TITLE
docs: add comprehensive rustdocs with TTM invariant doctests

### DIFF
--- a/src/algebra/difference.rs
+++ b/src/algebra/difference.rs
@@ -1,17 +1,110 @@
+//! Difference operator for set subtraction.
+//!
+//! The difference operator (also called "minus" or "except") returns tuples
+//! that are in the first relation but not in the second relation.
+//!
+//! # TTM Compliance
+//!
+//! - Relations must be type-compatible (identical headings)
+//! - Result contains tuples from first relation not in second
+//! - Set semantics are maintained
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::Relation;
+//! use relvar::tuple;
+//!
+//! let heading = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String);
+//!
+//! let rel_type = RelationType::new(heading);
+//!
+//! let mut all_employees = Relation::new(rel_type.clone());
+//! all_employees.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+//! all_employees.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+//!
+//! let mut terminated = Relation::new(rel_type);
+//! terminated.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+//!
+//! let active = all_employees.difference(&terminated).unwrap();
+//! assert_eq!(active.cardinality(), 1);  // Only Alice remains
+//! ```
+
 use crate::values::Relation;
 use thiserror::Error;
 
+/// Errors that can occur during difference operations.
 #[derive(Debug, Error)]
 pub enum DifferenceError {
+    /// The two relations have incompatible types (different headings).
+    ///
+    /// Difference requires both relations to have exactly the same heading
+    /// (attribute names and types).
     #[error("Relations must have the same type (heading) for difference")]
     TypeMismatch,
 }
 
-/// Difference operation (MINUS in SQL)
 impl Relation {
-    /// Set difference with another relation
-    /// Relations must be type-compatible (same heading)
-    /// Result contains tuples in self but not in other
+    /// Computes the set difference of this relation with another.
+    ///
+    /// This is the set difference operator from relational algebra (A - B or
+    /// A MINUS B in SQL). It produces a new relation containing only the tuples
+    /// that appear in this relation but not in the other relation.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - The relation to subtract. Must have the same heading
+    ///   (type) as this relation.
+    ///
+    /// # Returns
+    ///
+    /// A new relation containing tuples that are in `self` but not in `other`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DifferenceError::TypeMismatch`] if the relations have different
+    /// headings (different attribute names or types).
+    ///
+    /// # Behavior
+    ///
+    /// - Both relations must be type-compatible (identical headings)
+    /// - Tuples present in both relations are excluded from the result
+    /// - Order matters: A - B is different from B - A
+    /// - Difference with self returns empty relation
+    /// - Difference with empty relation returns the original relation
+    ///
+    /// # Complexity
+    ///
+    /// O(n * m) where n and m are the cardinalities of the two relations,
+    /// due to tuple membership testing.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("emp_id", ScalarType::Int)
+    ///     .with_attribute("name", ScalarType::String);
+    ///
+    /// let rel_type = RelationType::new(heading);
+    ///
+    /// let mut all = Relation::new(rel_type.clone());
+    /// all.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+    /// all.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+    /// all.insert(tuple! { emp_id: 3i64, name: "Charlie" }).unwrap();
+    ///
+    /// let mut subset = Relation::new(rel_type);
+    /// subset.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+    ///
+    /// let result = all.difference(&subset).unwrap();
+    /// assert_eq!(result.cardinality(), 2);  // Alice and Charlie
+    /// ```
     pub fn difference(&self, other: &Relation) -> Result<Self, DifferenceError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
@@ -31,7 +124,31 @@ impl Relation {
         )
     }
 
-    /// Alias for difference (more SQL-like naming)
+    /// Alias for [`difference`](Self::difference) with SQL-style naming.
+    ///
+    /// This method is identical to `difference()` but uses the SQL-style
+    /// name "minus" which some users may find more intuitive.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let rel_type = RelationType::new(heading);
+    ///
+    /// let mut rel1 = Relation::new(rel_type.clone());
+    /// rel1.insert(tuple! { id: 1i64 }).unwrap();
+    ///
+    /// let rel2 = Relation::new(rel_type);
+    ///
+    /// let result = rel1.minus(&rel2).unwrap();
+    /// assert_eq!(result.cardinality(), 1);
+    /// ```
     pub fn minus(&self, other: &Relation) -> Result<Self, DifferenceError> {
         self.difference(other)
     }

--- a/src/algebra/extend.rs
+++ b/src/algebra/extend.rs
@@ -1,16 +1,87 @@
+//! Extend operator for adding computed attributes.
+//!
+//! The extend operator adds a new computed attribute to each tuple in a relation.
+//! The new attribute's value is computed from the existing attribute values
+//! using a user-provided function.
+//!
+//! # TTM Compliance
+//!
+//! - Result is a valid relation with an extended heading
+//! - New attribute must not conflict with existing attribute names
+//! - Set semantics are maintained
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::{Relation, ScalarValue};
+//! use relvar::algebra::extend::ExtendOps;
+//! use relvar::tuple;
+//!
+//! let heading = TupleType::new()
+//!     .with_attribute("price", ScalarType::Int)
+//!     .with_attribute("quantity", ScalarType::Int);
+//!
+//! let mut relation = Relation::new(RelationType::new(heading));
+//! relation.insert(tuple! { price: 10i64, quantity: 5i64 }).unwrap();
+//!
+//! // Add a computed "total" attribute
+//! let result = relation.extend("total", ScalarType::Int, |t| {
+//!     let price = t.get_typed::<i64>("price").unwrap();
+//!     let quantity = t.get_typed::<i64>("quantity").unwrap();
+//!     ScalarValue::Int(price * quantity)
+//! }).unwrap();
+//!
+//! assert_eq!(result.degree(), 3);  // price, quantity, total
+//! ```
+
 use crate::values::{Relation, ScalarValue, Tuple};
 use thiserror::Error;
 
+/// Errors that can occur during extend operations.
 #[derive(Debug, Error)]
 pub enum ExtendError {
+    /// The new attribute name conflicts with an existing attribute.
+    ///
+    /// Each attribute in a relation must have a unique name. Use rename
+    /// first if you need to replace an existing attribute.
     #[error("Attribute '{0}' already exists in relation")]
     AttributeExists(String),
+
+    /// Failed to create a tuple with the extended attributes.
+    ///
+    /// This can occur if the computed value type doesn't match the
+    /// declared result type.
     #[error("Failed to create extended tuple: {0}")]
     TupleCreation(String),
 }
 
+/// Trait providing the extend operation for relations.
+///
+/// This trait defines the `extend` method which adds computed attributes
+/// to relations. It is implemented for [`Relation`].
 pub trait ExtendOps {
-    /// Extend the relation with a new computed attribute
+    /// Extends the relation with a new computed attribute.
+    ///
+    /// This operator adds a new attribute to each tuple, where the value
+    /// is computed from the tuple's existing attribute values using the
+    /// provided function.
+    ///
+    /// # Arguments
+    ///
+    /// * `attr_name` - The name for the new attribute (must not already exist)
+    /// * `attr_type` - The scalar type of the new attribute
+    /// * `compute` - A function that computes the new attribute value from
+    ///   each tuple
+    ///
+    /// # Returns
+    ///
+    /// A new relation with the additional computed attribute.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtendError::AttributeExists`] if an attribute with the
+    /// given name already exists in the relation.
     fn extend<F>(
         &self,
         attr_name: &str,

--- a/src/algebra/group.rs
+++ b/src/algebra/group.rs
@@ -1,37 +1,131 @@
+//! Group and ungroup operators for relation-valued attributes.
+//!
+//! The group operator creates relation-valued attributes (RVAs) by collecting
+//! related tuples into nested relations. The ungroup operator is the inverse,
+//! flattening RVAs back into regular attributes.
+//!
+//! # TTM Compliance
+//!
+//! - Relation-valued attributes are a key feature of the relational model
+//! - Group and ungroup are inverses: `ungroup(group(R, attrs, name), name) ≡ R`
+//! - Set semantics are maintained at all levels
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::{Relation, ScalarValue};
+//! use relvar::algebra::group::GroupOps;
+//! use relvar::tuple;
+//!
+//! let heading = TupleType::new()
+//!     .with_attribute("dept_id", ScalarType::Int)
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String);
+//!
+//! let mut relation = Relation::new(RelationType::new(heading));
+//! relation.insert(tuple! { dept_id: 10i64, emp_id: 1i64, name: "Alice" }).unwrap();
+//! relation.insert(tuple! { dept_id: 10i64, emp_id: 2i64, name: "Bob" }).unwrap();
+//! relation.insert(tuple! { dept_id: 20i64, emp_id: 3i64, name: "Charlie" }).unwrap();
+//!
+//! // Group employees by department
+//! let grouped = relation.group(&["emp_id", "name"], "employees").unwrap();
+//! assert_eq!(grouped.cardinality(), 2);  // Two departments
+//! assert_eq!(grouped.degree(), 2);  // dept_id and employees RVA
+//! ```
+
 use crate::types::{RelationType, ScalarType, TupleType};
 use crate::values::{Relation, ScalarValue, Tuple};
 use std::collections::{BTreeMap, HashMap};
 use thiserror::Error;
 
+/// Errors that can occur during group operations.
 #[derive(Debug, Error)]
 pub enum GroupError {
+    /// An attribute specified for grouping does not exist in the relation.
     #[error("Grouping attribute '{0}' does not exist in relation")]
     AttributeNotFound(String),
+
+    /// No attributes were specified to group into the RVA.
     #[error("No attributes specified for grouping")]
     NoAttributesSpecified,
+
+    /// Cannot group all attributes - at least one must remain as a grouping key.
     #[error("All attributes cannot be grouped (need at least one non-grouped attribute)")]
     AllAttributesGrouped,
+
+    /// The name for the result RVA conflicts with an existing attribute.
     #[error("Result attribute '{0}' already exists")]
     ResultAttributeExists(String),
+
+    /// Failed to construct a tuple during the grouping process.
     #[error("Failed to create grouped tuple: {0}")]
     TupleCreation(String),
 }
 
+/// Errors that can occur during ungroup operations.
 #[derive(Debug, Error)]
 pub enum UngroupError {
+    /// The specified RVA attribute does not exist in the relation.
     #[error("Attribute '{0}' does not exist in relation")]
     AttributeNotFound(String),
+
+    /// The specified attribute is not a relation-valued attribute.
     #[error("Attribute '{0}' is not a relation-valued attribute")]
     NotRelationValued(String),
+
+    /// Failed to construct a tuple during the ungrouping process.
     #[error("Failed to create ungrouped tuple: {0}")]
     TupleCreation(String),
 }
 
+/// Trait providing group and ungroup operations for relations.
+///
+/// This trait defines methods for creating and flattening relation-valued
+/// attributes (RVAs), which allow nested relations within tuples.
 pub trait GroupOps {
-    /// Group specified attributes into a relation-valued attribute
+    /// Groups specified attributes into a relation-valued attribute.
+    ///
+    /// This operator collects tuples with matching values on the non-grouped
+    /// attributes and creates a nested relation (RVA) containing the grouped
+    /// attribute values.
+    ///
+    /// # Arguments
+    ///
+    /// * `attrs_to_group` - The attribute names to collect into the RVA
+    /// * `rva_name` - The name for the new relation-valued attribute
+    ///
+    /// # Returns
+    ///
+    /// A new relation where the grouped attributes have been replaced by a
+    /// single relation-valued attribute containing nested relations.
+    ///
+    /// # Errors
+    ///
+    /// - [`GroupError::AttributeNotFound`] - A specified attribute doesn't exist
+    /// - [`GroupError::NoAttributesSpecified`] - Empty attributes list
+    /// - [`GroupError::AllAttributesGrouped`] - No grouping key attributes remain
+    /// - [`GroupError::ResultAttributeExists`] - RVA name conflicts
     fn group(&self, attrs_to_group: &[&str], rva_name: &str) -> Result<Relation, GroupError>;
 
-    /// Ungroup a relation-valued attribute back into regular attributes
+    /// Ungroups a relation-valued attribute back into regular attributes.
+    ///
+    /// This is the inverse of [`group`](Self::group). It flattens a nested
+    /// relation by combining each inner tuple with its parent tuple's
+    /// non-RVA attributes.
+    ///
+    /// # Arguments
+    ///
+    /// * `rva_name` - The name of the relation-valued attribute to flatten
+    ///
+    /// # Returns
+    ///
+    /// A new relation with the RVA replaced by its constituent attributes.
+    ///
+    /// # Errors
+    ///
+    /// - [`UngroupError::AttributeNotFound`] - The attribute doesn't exist
+    /// - [`UngroupError::NotRelationValued`] - The attribute is not an RVA
     fn ungroup(&self, rva_name: &str) -> Result<Relation, UngroupError>;
 }
 

--- a/src/algebra/intersect.rs
+++ b/src/algebra/intersect.rs
@@ -1,17 +1,111 @@
+//! Intersect operator for finding common tuples.
+//!
+//! The intersection operator returns only the tuples that appear in both
+//! of two type-compatible relations.
+//!
+//! # TTM Compliance
+//!
+//! - Relations must be type-compatible (identical headings)
+//! - Result contains only tuples present in both relations
+//! - Set semantics are maintained
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::Relation;
+//! use relvar::tuple;
+//!
+//! let heading = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String);
+//!
+//! let rel_type = RelationType::new(heading);
+//!
+//! let mut rel1 = Relation::new(rel_type.clone());
+//! rel1.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+//! rel1.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+//!
+//! let mut rel2 = Relation::new(rel_type);
+//! rel2.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+//! rel2.insert(tuple! { emp_id: 3i64, name: "Charlie" }).unwrap();
+//!
+//! let result = rel1.intersect(&rel2).unwrap();
+//! assert_eq!(result.cardinality(), 1);  // Only Bob is in both
+//! ```
+
 use crate::values::Relation;
 use thiserror::Error;
 
+/// Errors that can occur during intersection operations.
 #[derive(Debug, Error)]
 pub enum IntersectError {
+    /// The two relations have incompatible types (different headings).
+    ///
+    /// Intersection requires both relations to have exactly the same heading
+    /// (attribute names and types).
     #[error("Relations must have the same type (heading) for intersection")]
     TypeMismatch,
 }
 
-/// Intersection operation
 impl Relation {
-    /// Intersection with another relation
-    /// Relations must be type-compatible (same heading)
-    /// Result contains only tuples that appear in both relations
+    /// Computes the intersection of this relation with another.
+    ///
+    /// This is the set intersection operator from relational algebra. It
+    /// produces a new relation containing only the tuples that appear in
+    /// both relations.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - The relation to intersect with. Must have the same heading
+    ///   (type) as this relation.
+    ///
+    /// # Returns
+    ///
+    /// A new relation containing only tuples present in both relations.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IntersectError::TypeMismatch`] if the relations have different
+    /// headings (different attribute names or types).
+    ///
+    /// # Behavior
+    ///
+    /// - Both relations must be type-compatible (identical headings)
+    /// - Only tuples present in both relations are included
+    /// - Intersection with self returns an equivalent relation
+    /// - Intersection with empty relation returns empty relation
+    /// - If no common tuples exist, returns empty relation
+    ///
+    /// # Complexity
+    ///
+    /// O(n * m) where n and m are the cardinalities of the two relations,
+    /// due to tuple membership testing.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("emp_id", ScalarType::Int)
+    ///     .with_attribute("name", ScalarType::String);
+    ///
+    /// let rel_type = RelationType::new(heading);
+    ///
+    /// let mut current_employees = Relation::new(rel_type.clone());
+    /// current_employees.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+    /// current_employees.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+    ///
+    /// let mut managers = Relation::new(rel_type);
+    /// managers.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+    ///
+    /// // Find employees who are also managers
+    /// let managing_employees = current_employees.intersect(&managers).unwrap();
+    /// assert_eq!(managing_employees.cardinality(), 1);  // Bob
+    /// ```
     pub fn intersect(&self, other: &Relation) -> Result<Self, IntersectError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {

--- a/src/algebra/join.rs
+++ b/src/algebra/join.rs
@@ -1,11 +1,104 @@
+//! Join operators for combining relations.
+//!
+//! This module implements the join operators from relational algebra:
+//!
+//! - **Natural Join** - Joins on common attributes, combining matching tuples
+//! - **Theta Join** - Joins with an arbitrary predicate condition
+//!
+//! # TTM Compliance
+//!
+//! - Natural join matches on attribute names and types (not physical identifiers)
+//! - Result heading is the union of both relation headings
+//! - Duplicate tuples are automatically eliminated (set semantics)
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::Relation;
+//! use relvar::tuple;
+//!
+//! // Employees with dept_id
+//! let emp_heading = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String)
+//!     .with_attribute("dept_id", ScalarType::Int);
+//!
+//! let mut employees = Relation::new(RelationType::new(emp_heading));
+//! employees.insert(tuple! { emp_id: 1i64, name: "Alice", dept_id: 10i64 }).unwrap();
+//!
+//! // Departments with dept_id
+//! let dept_heading = TupleType::new()
+//!     .with_attribute("dept_id", ScalarType::Int)
+//!     .with_attribute("dept_name", ScalarType::String);
+//!
+//! let mut departments = Relation::new(RelationType::new(dept_heading));
+//! departments.insert(tuple! { dept_id: 10i64, dept_name: "Engineering" }).unwrap();
+//!
+//! // Natural join on dept_id
+//! let result = employees.join(&departments);
+//! assert_eq!(result.degree(), 4);  // emp_id, name, dept_id, dept_name
+//! ```
+
 use crate::types::{RelationType, TupleType};
 use crate::values::{Relation, Tuple};
 use std::collections::BTreeMap;
 
-/// Join operations
 impl Relation {
-    /// Natural join with another relation
-    /// Joins on common attributes, combining tuples that match on those attributes
+    /// Performs a natural join with another relation.
+    ///
+    /// The natural join combines tuples from two relations based on matching values
+    /// in their common attributes (attributes with the same name and type). The
+    /// result contains combined tuples where all common attributes have equal values.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - The relation to join with
+    ///
+    /// # Returns
+    ///
+    /// A new relation with the union of both headings. Each result tuple is a
+    /// combination of tuples from both relations that match on common attributes.
+    ///
+    /// # Behavior
+    ///
+    /// - If there are no common attributes, produces a Cartesian product
+    /// - Common attributes appear once in the result (not duplicated)
+    /// - Tuples that don't match on common attributes are excluded
+    /// - Result maintains set semantics (no duplicate tuples)
+    ///
+    /// # Complexity
+    ///
+    /// O(n * m) where n and m are the cardinalities of the two relations.
+    /// This is a nested-loop join implementation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// // Employees
+    /// let emp_heading = TupleType::new()
+    ///     .with_attribute("emp_id", ScalarType::Int)
+    ///     .with_attribute("dept_id", ScalarType::Int);
+    ///
+    /// let mut employees = Relation::new(RelationType::new(emp_heading));
+    /// employees.insert(tuple! { emp_id: 1i64, dept_id: 10i64 }).unwrap();
+    /// employees.insert(tuple! { emp_id: 2i64, dept_id: 20i64 }).unwrap();
+    ///
+    /// // Departments
+    /// let dept_heading = TupleType::new()
+    ///     .with_attribute("dept_id", ScalarType::Int)
+    ///     .with_attribute("budget", ScalarType::Int);
+    ///
+    /// let mut departments = Relation::new(RelationType::new(dept_heading));
+    /// departments.insert(tuple! { dept_id: 10i64, budget: 100000i64 }).unwrap();
+    ///
+    /// let result = employees.join(&departments);
+    /// assert_eq!(result.cardinality(), 1);  // Only emp 1 matches (dept 10)
+    /// ```
     pub fn join(&self, other: &Relation) -> Self {
         // Find common attributes
         let common_attrs: Vec<String> = self
@@ -71,8 +164,69 @@ impl Relation {
             .expect("Joined tuples should conform to result relation type")
     }
 
-    /// Theta join with arbitrary predicate
-    /// More general than natural join - allows any join condition
+    /// Performs a theta join with another relation using an arbitrary predicate.
+    ///
+    /// The theta join (θ-join) is a more general form of join that combines
+    /// tuples based on any arbitrary predicate, not just equality on common
+    /// attributes. This allows for comparisons like greater-than, less-than,
+    /// or complex multi-attribute conditions.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - The relation to join with
+    /// * `predicate` - A function that takes references to tuples from both
+    ///   relations and returns `true` if they should be combined
+    ///
+    /// # Returns
+    ///
+    /// A new relation with the union of both headings. Each result tuple is a
+    /// combination of tuples from both relations for which the predicate
+    /// returns `true`.
+    ///
+    /// # Behavior
+    ///
+    /// - All attribute pairs are combined (no automatic deduplication of common names)
+    /// - If relations have common attribute names, the first relation's values
+    ///   take precedence
+    /// - Result maintains set semantics
+    ///
+    /// # Complexity
+    ///
+    /// O(n * m) where n and m are the cardinalities of the two relations.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::{Relation, ScalarValue};
+    /// use relvar::tuple;
+    ///
+    /// // Employees with salaries
+    /// let emp_heading = TupleType::new()
+    ///     .with_attribute("emp_id", ScalarType::Int)
+    ///     .with_attribute("salary", ScalarType::Int);
+    ///
+    /// let mut employees = Relation::new(RelationType::new(emp_heading));
+    /// employees.insert(tuple! { emp_id: 1i64, salary: 50000i64 }).unwrap();
+    /// employees.insert(tuple! { emp_id: 2i64, salary: 75000i64 }).unwrap();
+    ///
+    /// // Departments with minimum salary requirements
+    /// let dept_heading = TupleType::new()
+    ///     .with_attribute("dept_id", ScalarType::Int)
+    ///     .with_attribute("min_salary", ScalarType::Int);
+    ///
+    /// let mut departments = Relation::new(RelationType::new(dept_heading));
+    /// departments.insert(tuple! { dept_id: 10i64, min_salary: 60000i64 }).unwrap();
+    ///
+    /// // Join employees to departments where salary meets minimum
+    /// let result = employees.theta_join(&departments, |emp, dept| {
+    ///     let salary = emp.get_typed::<i64>("salary").unwrap();
+    ///     let min_sal = dept.get_typed::<i64>("min_salary").unwrap();
+    ///     salary >= min_sal
+    /// });
+    /// // Only employee 2 (salary 75000) qualifies for dept 10 (min 60000)
+    /// assert_eq!(result.cardinality(), 1);
+    /// ```
     pub fn theta_join<F>(&self, other: &Relation, predicate: F) -> Self
     where
         F: Fn(&Tuple, &Tuple) -> bool,

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -1,11 +1,107 @@
+//! Relational algebra operators for querying and transforming relations.
+//!
+//! This module implements the complete set of relational algebra operators
+//! as defined in *The Third Manifesto* (RM Prescription 7). All operators
+//! are implemented as methods on the [`Relation`](crate::values::Relation) type.
+//!
+//! # Operators
+//!
+//! ## Set Operators (require type-compatible relations)
+//!
+//! | Operator | Method | Description |
+//! |----------|--------|-------------|
+//! | Union | [`union()`](crate::values::Relation::union) | Combines tuples from both relations |
+//! | Intersect | [`intersect()`](crate::values::Relation::intersect) | Returns tuples in both relations |
+//! | Difference | [`difference()`](crate::values::Relation::difference) | Returns tuples in first but not second |
+//!
+//! ## Projection and Selection
+//!
+//! | Operator | Method | Description |
+//! |----------|--------|-------------|
+//! | Project | [`project()`](crate::values::Relation::project) | Selects a subset of attributes |
+//! | Restrict | [`restrict()`](crate::values::Relation::restrict) | Filters tuples by predicate (σ) |
+//! | Rename | [`rename()`](crate::values::Relation::rename) | Renames attributes |
+//!
+//! ## Join Operators
+//!
+//! | Operator | Method | Description |
+//! |----------|--------|-------------|
+//! | Natural Join | [`join()`](crate::values::Relation::join) | Joins on common attributes |
+//! | Theta Join | [`theta_join()`](crate::values::Relation::theta_join) | Joins with arbitrary predicate |
+//!
+//! ## Extended Operators
+//!
+//! | Operator | Method | Description |
+//! |----------|--------|-------------|
+//! | Extend | [`extend()`](crate::algebra::extend::ExtendOps::extend) | Adds computed attributes |
+//! | Group | [`group()`](crate::algebra::group::GroupOps::group) | Creates relation-valued attributes |
+//! | Ungroup | [`ungroup()`](crate::algebra::group::GroupOps::ungroup) | Flattens relation-valued attributes |
+//! | Summarize | [`summarize()`](crate::algebra::summarize::SummarizeOps::summarize) | Aggregation with grouping |
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::Relation;
+//! use relvar::tuple;
+//!
+//! // Create employee relation
+//! let emp_type = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String)
+//!     .with_attribute("dept_id", ScalarType::Int);
+//!
+//! let mut employees = Relation::new(RelationType::new(emp_type));
+//! employees.insert(tuple! { emp_id: 1i64, name: "Alice", dept_id: 10i64 }).unwrap();
+//! employees.insert(tuple! { emp_id: 2i64, name: "Bob", dept_id: 20i64 }).unwrap();
+//!
+//! // Project to just names
+//! let names = employees.project(&["name"]);
+//! assert_eq!(names.degree(), 1);
+//!
+//! // Restrict to dept 10
+//! let dept10 = employees.restrict(|t| {
+//!     t.get_typed::<i64>("dept_id").unwrap() == 10
+//! });
+//! assert_eq!(dept10.cardinality(), 1);
+//! ```
+//!
+//! # TTM Compliance
+//!
+//! All operators maintain set semantics:
+//! - Duplicate tuples are automatically eliminated
+//! - Tuple ordering is not guaranteed
+//! - Results are always valid relations
+
+/// Set difference operator (A MINUS B).
 pub mod difference;
+
+/// Relational division operator.
 pub mod divide;
+
+/// Extend operator for adding computed attributes.
 pub mod extend;
+
+/// Group and ungroup operators for relation-valued attributes.
 pub mod group;
+
+/// Set intersection operator.
 pub mod intersect;
+
+/// Natural join and theta join operators.
 pub mod join;
+
+/// Project operator for attribute selection (π).
 pub mod project;
+
+/// Rename operator for attribute renaming (ρ).
 pub mod rename;
+
+/// Restrict operator for tuple filtering (σ).
 pub mod restrict;
+
+/// Summarize operator for aggregation with grouping.
 pub mod summarize;
+
+/// Set union operator.
 pub mod union;

--- a/src/algebra/project.rs
+++ b/src/algebra/project.rs
@@ -1,11 +1,77 @@
+//! Project operator for attribute selection.
+//!
+//! The project operator (π in relational algebra) selects a subset of
+//! attributes from a relation, eliminating all other attributes.
+//!
+//! # TTM Compliance
+//!
+//! - Duplicates are automatically eliminated (set semantics)
+//! - Result is a valid relation with the projected heading
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::Relation;
+//! use relvar::tuple;
+//!
+//! let heading = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String)
+//!     .with_attribute("dept_id", ScalarType::Int);
+//!
+//! let mut relation = Relation::new(RelationType::new(heading));
+//! relation.insert(tuple! { emp_id: 1i64, name: "Alice", dept_id: 10i64 }).unwrap();
+//! relation.insert(tuple! { emp_id: 2i64, name: "Bob", dept_id: 10i64 }).unwrap();
+//!
+//! // Project onto just dept_id
+//! let result = relation.project(&["dept_id"]);
+//! assert_eq!(result.degree(), 1);
+//! assert_eq!(result.cardinality(), 1);  // Duplicates eliminated!
+//! ```
+
 use crate::types::{RelationType, TupleType};
 use crate::values::{Relation, Tuple};
 use std::collections::BTreeMap;
 
-/// Project operation (SELECT columns in SQL)
-/// Selects a subset of attributes
 impl Relation {
-    /// Project this relation onto a subset of attributes
+    /// Projects this relation onto a subset of attributes.
+    ///
+    /// This is the relational algebra π (pi) operator. It produces a new
+    /// relation containing only the specified attributes. Duplicate tuples
+    /// that result from the projection are automatically eliminated.
+    ///
+    /// # Arguments
+    ///
+    /// * `attributes` - The attribute names to include in the result
+    ///
+    /// # Returns
+    ///
+    /// A new relation with only the specified attributes.
+    ///
+    /// # Behavior
+    ///
+    /// - Attributes not in the list are removed
+    /// - Attributes that don't exist in the relation are silently ignored
+    /// - Duplicate tuples are automatically eliminated
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("emp_id", ScalarType::Int)
+    ///     .with_attribute("name", ScalarType::String);
+    ///
+    /// let mut relation = Relation::new(RelationType::new(heading));
+    /// relation.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+    ///
+    /// let names_only = relation.project(&["name"]);
+    /// assert_eq!(names_only.degree(), 1);
+    /// ```
     pub fn project(&self, attributes: &[&str]) -> Self {
         // Build new heading with selected attributes
         let mut new_heading = TupleType::new();

--- a/src/algebra/rename.rs
+++ b/src/algebra/rename.rs
@@ -1,12 +1,87 @@
+//! Rename operator for attribute renaming.
+//!
+//! The rename operator (ρ in relational algebra) changes the names of attributes
+//! in a relation while preserving their types and values.
+//!
+//! # TTM Compliance
+//!
+//! - Attribute types are preserved during renaming
+//! - Result is a valid relation with the renamed heading
+//! - Set semantics are maintained
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::Relation;
+//! use relvar::tuple;
+//!
+//! let heading = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String);
+//!
+//! let mut relation = Relation::new(RelationType::new(heading));
+//! relation.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+//!
+//! // Rename emp_id to employee_id
+//! let renamed = relation.rename(&[("emp_id", "employee_id")]);
+//! assert!(renamed.relation_type().heading().has_attribute("employee_id"));
+//! assert!(!renamed.relation_type().heading().has_attribute("emp_id"));
+//! ```
+
 use crate::types::{RelationType, TupleType};
 use crate::values::{Relation, Tuple};
 use std::collections::BTreeMap;
 
-/// Rename operation
-/// Renames attributes while preserving types
 impl Relation {
-    /// Rename attributes according to the provided mapping
-    /// Maps old_name -> new_name
+    /// Renames attributes in this relation according to the provided mapping.
+    ///
+    /// This is the relational algebra ρ (rho) operator. It produces a new relation
+    /// with the same tuples but with some attribute names changed. The attribute
+    /// types and values are preserved.
+    ///
+    /// # Arguments
+    ///
+    /// * `mappings` - A slice of (old_name, new_name) pairs specifying which
+    ///   attributes to rename. Attributes not in the mapping are unchanged.
+    ///
+    /// # Returns
+    ///
+    /// A new relation with the renamed attributes.
+    ///
+    /// # Behavior
+    ///
+    /// - Attributes listed in mappings are renamed to their new names
+    /// - Attributes not in mappings retain their original names
+    /// - Attribute types are preserved
+    /// - Tuple values are preserved (associated with new names)
+    /// - Mappings for non-existent attributes are silently ignored
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("emp_id", ScalarType::Int)
+    ///     .with_attribute("name", ScalarType::String)
+    ///     .with_attribute("dept_id", ScalarType::Int);
+    ///
+    /// let mut relation = Relation::new(RelationType::new(heading));
+    /// relation.insert(tuple! { emp_id: 1i64, name: "Alice", dept_id: 10i64 }).unwrap();
+    ///
+    /// // Rename multiple attributes
+    /// let renamed = relation.rename(&[
+    ///     ("emp_id", "employee_id"),
+    ///     ("dept_id", "department_id"),
+    /// ]);
+    ///
+    /// assert!(renamed.relation_type().heading().has_attribute("employee_id"));
+    /// assert!(renamed.relation_type().heading().has_attribute("department_id"));
+    /// assert!(renamed.relation_type().heading().has_attribute("name"));
+    /// ```
     pub fn rename(&self, mappings: &[(&str, &str)]) -> Self {
         // Build new heading with renamed attributes
         let mut new_heading = TupleType::new();

--- a/src/algebra/restrict.rs
+++ b/src/algebra/restrict.rs
@@ -1,9 +1,84 @@
+//! Restrict operator for tuple selection.
+//!
+//! The restrict operator (σ in relational algebra, commonly called "selection" or "WHERE"
+//! in SQL) filters tuples from a relation based on a predicate function.
+//!
+//! # TTM Compliance
+//!
+//! - Result maintains set semantics (no duplicate tuples)
+//! - Result is a valid relation with the same heading as the input
+//! - Predicate operates on tuple values only, not on physical identifiers
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::{Relation, ScalarValue};
+//! use relvar::tuple;
+//!
+//! let heading = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String)
+//!     .with_attribute("dept_id", ScalarType::Int);
+//!
+//! let mut relation = Relation::new(RelationType::new(heading));
+//! relation.insert(tuple! { emp_id: 1i64, name: "Alice", dept_id: 10i64 }).unwrap();
+//! relation.insert(tuple! { emp_id: 2i64, name: "Bob", dept_id: 20i64 }).unwrap();
+//!
+//! // Restrict to employees in department 10
+//! let dept10 = relation.restrict(|t| {
+//!     t.get_typed::<i64>("dept_id").unwrap() == 10
+//! });
+//! assert_eq!(dept10.cardinality(), 1);
+//! ```
+
 use crate::values::{Relation, Tuple};
 
-/// Restrict operation (WHERE/SELECT in SQL)
-/// Filters tuples based on a predicate
 impl Relation {
-    /// Restrict this relation by a predicate
+    /// Restricts this relation by filtering tuples with a predicate.
+    ///
+    /// This is the relational algebra σ (sigma) operator, commonly known as
+    /// "selection" in relational algebra or "WHERE" in SQL. It produces a new
+    /// relation containing only the tuples that satisfy the given predicate.
+    ///
+    /// # Arguments
+    ///
+    /// * `predicate` - A function that takes a tuple reference and returns `true`
+    ///   if the tuple should be included in the result
+    ///
+    /// # Returns
+    ///
+    /// A new relation with the same heading, containing only tuples for which
+    /// the predicate returns `true`.
+    ///
+    /// # Behavior
+    ///
+    /// - The result has the same heading (type) as the input relation
+    /// - Tuples for which the predicate returns `false` are excluded
+    /// - The predicate is evaluated once per tuple
+    /// - An empty predicate result yields an empty relation
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::{Relation, ScalarValue};
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("emp_id", ScalarType::Int)
+    ///     .with_attribute("salary", ScalarType::Int);
+    ///
+    /// let mut relation = Relation::new(RelationType::new(heading));
+    /// relation.insert(tuple! { emp_id: 1i64, salary: 50000i64 }).unwrap();
+    /// relation.insert(tuple! { emp_id: 2i64, salary: 75000i64 }).unwrap();
+    ///
+    /// // Find employees with salary > 60000
+    /// let high_earners = relation.restrict(|t| {
+    ///     t.get_typed::<i64>("salary").unwrap() > 60000
+    /// });
+    /// assert_eq!(high_earners.cardinality(), 1);
+    /// ```
     pub fn restrict<F>(&self, predicate: F) -> Self
     where
         F: Fn(&Tuple) -> bool,

--- a/src/algebra/summarize.rs
+++ b/src/algebra/summarize.rs
@@ -1,38 +1,155 @@
+//! Summarize operator for aggregation with grouping.
+//!
+//! The summarize operator computes aggregate values (count, sum, average, min, max)
+//! over groups of tuples. It is similar to SQL's GROUP BY with aggregate functions.
+//!
+//! # TTM Compliance
+//!
+//! - Aggregation is performed on tuple values, not physical storage
+//! - Result is a valid relation with the grouped and computed attributes
+//! - Set semantics are maintained
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::Relation;
+//! use relvar::algebra::summarize::{SummarizeOps, Aggregation};
+//! use relvar::tuple;
+//!
+//! let heading = TupleType::new()
+//!     .with_attribute("dept_id", ScalarType::Int)
+//!     .with_attribute("salary", ScalarType::Int);
+//!
+//! let mut relation = Relation::new(RelationType::new(heading));
+//! relation.insert(tuple! { dept_id: 10i64, salary: 50000i64 }).unwrap();
+//! relation.insert(tuple! { dept_id: 10i64, salary: 60000i64 }).unwrap();
+//! relation.insert(tuple! { dept_id: 20i64, salary: 70000i64 }).unwrap();
+//!
+//! // Summarize by department
+//! let result = relation.summarize(
+//!     &["dept_id"],
+//!     &[
+//!         Aggregation::count("emp_count"),
+//!         Aggregation::sum("total_salary", "salary"),
+//!     ],
+//! ).unwrap();
+//!
+//! assert_eq!(result.cardinality(), 2);  // Two departments
+//! ```
+
 use crate::types::{RelationType, ScalarType, TupleType};
 use crate::values::{Relation, ScalarValue, Tuple};
 use std::collections::{BTreeMap, HashMap};
 use thiserror::Error;
 
+/// Errors that can occur during summarize operations.
 #[derive(Debug, Error)]
 pub enum SummarizeError {
+    /// A specified grouping attribute does not exist in the relation.
     #[error("Grouping attribute '{0}' does not exist in relation")]
     GroupingAttributeNotFound(String),
+
+    /// The result attribute name conflicts with an existing attribute.
     #[error("Result attribute '{0}' already exists")]
     ResultAttributeExists(String),
+
+    /// Failed to construct a tuple during the summarization process.
     #[error("Failed to create summarized tuple: {0}")]
     TupleCreation(String),
+
+    /// An error occurred during aggregate computation.
+    ///
+    /// This can happen if the attribute being aggregated doesn't exist
+    /// or has an incompatible type.
     #[error("Aggregation error: {0}")]
     AggregationError(String),
 }
 
-/// Aggregation function type
+/// Specifies the type of aggregation function to apply.
+///
+/// Each variant represents a different aggregate computation that can
+/// be performed over a group of tuples.
 pub enum AggregationFn {
+    /// Counts the number of tuples in the group.
     Count,
-    Sum(String), // attribute name to sum
-    Avg(String), // attribute name to average
-    Min(String), // attribute name for minimum
-    Max(String), // attribute name for maximum
+
+    /// Computes the sum of an integer attribute across the group.
+    ///
+    /// The string parameter specifies the attribute name to sum.
+    Sum(String),
+
+    /// Computes the average of an integer attribute across the group.
+    ///
+    /// The string parameter specifies the attribute name to average.
+    /// Result is a floating-point value.
+    Avg(String),
+
+    /// Finds the minimum value of an attribute in the group.
+    ///
+    /// The string parameter specifies the attribute name.
+    Min(String),
+
+    /// Finds the maximum value of an attribute in the group.
+    ///
+    /// The string parameter specifies the attribute name.
+    Max(String),
+
+    /// A custom aggregation function.
+    ///
+    /// Takes a slice of tuple references and returns a computed scalar value.
     #[allow(clippy::type_complexity)]
     Custom(Box<dyn Fn(&[&Tuple]) -> ScalarValue>),
 }
 
+/// Defines a single aggregation to compute in a summarize operation.
+///
+/// An aggregation specifies what to compute (the function), what to call
+/// the result (the name), and what type the result will be.
+///
+/// # Example
+///
+/// ```
+/// use relvar::types::ScalarType;
+/// use relvar::algebra::summarize::Aggregation;
+///
+/// // Count all tuples, store in "total" as Int
+/// let count_agg = Aggregation::count("total");
+///
+/// // Sum the "salary" attribute, store in "total_pay" as Int
+/// let sum_agg = Aggregation::sum("total_pay", "salary");
+///
+/// // Average the "age" attribute, store in "avg_age" as Float
+/// let avg_agg = Aggregation::avg("avg_age", "age");
+/// ```
 pub struct Aggregation {
+    /// The name for the computed result attribute.
     pub result_name: String,
+
+    /// The scalar type of the result value.
     pub result_type: ScalarType,
+
+    /// The aggregation function to apply.
     pub function: AggregationFn,
 }
 
 impl Aggregation {
+    /// Creates a COUNT aggregation.
+    ///
+    /// Counts the number of tuples in each group. The result type is always
+    /// [`ScalarType::Int`].
+    ///
+    /// # Arguments
+    ///
+    /// * `result_name` - The name for the count result attribute
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::algebra::summarize::Aggregation;
+    ///
+    /// let agg = Aggregation::count("num_employees");
+    /// ```
     pub fn count(result_name: &str) -> Self {
         Self {
             result_name: result_name.to_string(),
@@ -41,6 +158,23 @@ impl Aggregation {
         }
     }
 
+    /// Creates a SUM aggregation.
+    ///
+    /// Computes the sum of an integer attribute across all tuples in each group.
+    /// The result type is [`ScalarType::Int`].
+    ///
+    /// # Arguments
+    ///
+    /// * `result_name` - The name for the sum result attribute
+    /// * `attr_name` - The attribute to sum (must be Int type)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::algebra::summarize::Aggregation;
+    ///
+    /// let agg = Aggregation::sum("total_salary", "salary");
+    /// ```
     pub fn sum(result_name: &str, attr_name: &str) -> Self {
         Self {
             result_name: result_name.to_string(),
@@ -49,6 +183,23 @@ impl Aggregation {
         }
     }
 
+    /// Creates an AVG (average) aggregation.
+    ///
+    /// Computes the arithmetic mean of an integer attribute across all tuples
+    /// in each group. The result type is [`ScalarType::Float`].
+    ///
+    /// # Arguments
+    ///
+    /// * `result_name` - The name for the average result attribute
+    /// * `attr_name` - The attribute to average (must be Int type)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::algebra::summarize::Aggregation;
+    ///
+    /// let agg = Aggregation::avg("avg_salary", "salary");
+    /// ```
     pub fn avg(result_name: &str, attr_name: &str) -> Self {
         Self {
             result_name: result_name.to_string(),
@@ -57,6 +208,25 @@ impl Aggregation {
         }
     }
 
+    /// Creates a MIN aggregation.
+    ///
+    /// Finds the minimum value of an attribute across all tuples in each group.
+    /// The result type must be specified and should match the attribute type.
+    ///
+    /// # Arguments
+    ///
+    /// * `result_name` - The name for the minimum result attribute
+    /// * `attr_name` - The attribute to find the minimum of
+    /// * `result_type` - The type of the result (should match the attribute type)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::ScalarType;
+    /// use relvar::algebra::summarize::Aggregation;
+    ///
+    /// let agg = Aggregation::min("lowest_salary", "salary", ScalarType::Int);
+    /// ```
     pub fn min(result_name: &str, attr_name: &str, result_type: ScalarType) -> Self {
         Self {
             result_name: result_name.to_string(),
@@ -65,6 +235,25 @@ impl Aggregation {
         }
     }
 
+    /// Creates a MAX aggregation.
+    ///
+    /// Finds the maximum value of an attribute across all tuples in each group.
+    /// The result type must be specified and should match the attribute type.
+    ///
+    /// # Arguments
+    ///
+    /// * `result_name` - The name for the maximum result attribute
+    /// * `attr_name` - The attribute to find the maximum of
+    /// * `result_type` - The type of the result (should match the attribute type)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::ScalarType;
+    /// use relvar::algebra::summarize::Aggregation;
+    ///
+    /// let agg = Aggregation::max("highest_salary", "salary", ScalarType::Int);
+    /// ```
     pub fn max(result_name: &str, attr_name: &str, result_type: ScalarType) -> Self {
         Self {
             result_name: result_name.to_string(),
@@ -159,8 +348,66 @@ impl Aggregation {
     }
 }
 
+/// Trait providing the summarize operation for relations.
+///
+/// This trait defines the `summarize` method which computes aggregate
+/// values over groups of tuples. It is implemented for [`Relation`].
 pub trait SummarizeOps {
-    /// Summarize the relation with aggregations, optionally grouped by attributes
+    /// Summarizes the relation by computing aggregations over groups.
+    ///
+    /// This operator groups tuples by the specified attributes and computes
+    /// aggregate values (count, sum, avg, min, max, or custom) for each group.
+    /// It is similar to SQL's `GROUP BY` clause with aggregate functions.
+    ///
+    /// # Arguments
+    ///
+    /// * `group_by` - Attribute names to group by. If empty, all tuples are
+    ///   treated as a single group.
+    /// * `aggregations` - The aggregation functions to compute for each group
+    ///
+    /// # Returns
+    ///
+    /// A new relation with the grouping attributes plus the computed aggregate
+    /// attributes. There is one tuple per distinct combination of grouping
+    /// attribute values.
+    ///
+    /// # Errors
+    ///
+    /// - [`SummarizeError::GroupingAttributeNotFound`] - A grouping attribute
+    ///   doesn't exist
+    /// - [`SummarizeError::ResultAttributeExists`] - An aggregation result name
+    ///   conflicts with a grouping attribute
+    /// - [`SummarizeError::AggregationError`] - An aggregation failed (e.g.,
+    ///   MIN/MAX on empty set)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::algebra::summarize::{SummarizeOps, Aggregation};
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("dept_id", ScalarType::Int)
+    ///     .with_attribute("salary", ScalarType::Int);
+    ///
+    /// let mut relation = Relation::new(RelationType::new(heading));
+    /// relation.insert(tuple! { dept_id: 10i64, salary: 50000i64 }).unwrap();
+    /// relation.insert(tuple! { dept_id: 10i64, salary: 60000i64 }).unwrap();
+    /// relation.insert(tuple! { dept_id: 20i64, salary: 70000i64 }).unwrap();
+    ///
+    /// // Compute aggregates per department
+    /// let result = relation.summarize(
+    ///     &["dept_id"],
+    ///     &[
+    ///         Aggregation::count("emp_count"),
+    ///         Aggregation::avg("avg_salary", "salary"),
+    ///     ],
+    /// ).unwrap();
+    ///
+    /// assert_eq!(result.cardinality(), 2);  // One row per department
+    /// ```
     fn summarize(
         &self,
         group_by: &[&str],

--- a/src/algebra/union.rs
+++ b/src/algebra/union.rs
@@ -1,17 +1,105 @@
+//! Union operator for combining relations.
+//!
+//! The union operator combines all tuples from two type-compatible relations
+//! into a single relation. As required by set semantics, duplicate tuples
+//! are automatically eliminated.
+//!
+//! # TTM Compliance
+//!
+//! - Relations must be type-compatible (identical headings)
+//! - Duplicates are automatically eliminated (set semantics)
+//! - Result is a valid relation
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::Relation;
+//! use relvar::tuple;
+//!
+//! let heading = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String);
+//!
+//! let rel_type = RelationType::new(heading);
+//!
+//! let mut rel1 = Relation::new(rel_type.clone());
+//! rel1.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+//!
+//! let mut rel2 = Relation::new(rel_type);
+//! rel2.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+//!
+//! let result = rel1.union(&rel2).unwrap();
+//! assert_eq!(result.cardinality(), 2);  // Alice and Bob
+//! ```
+
 use crate::values::Relation;
 use thiserror::Error;
 
+/// Errors that can occur during union operations.
 #[derive(Debug, Error)]
 pub enum UnionError {
+    /// The two relations have incompatible types (different headings).
+    ///
+    /// Union requires both relations to have exactly the same heading
+    /// (attribute names and types).
     #[error("Relations must have the same type (heading) for union")]
     TypeMismatch,
 }
 
-/// Union operation
 impl Relation {
-    /// Union with another relation
-    /// Relations must be type-compatible (same heading)
-    /// Result contains all tuples from both relations, with duplicates removed
+    /// Computes the union of this relation with another.
+    ///
+    /// This is the set union operator from relational algebra. It produces a
+    /// new relation containing all tuples that appear in either relation.
+    /// Duplicate tuples are automatically eliminated per set semantics.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - The relation to union with. Must have the same heading
+    ///   (type) as this relation.
+    ///
+    /// # Returns
+    ///
+    /// A new relation containing all tuples from both relations, with
+    /// duplicates removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UnionError::TypeMismatch`] if the relations have different
+    /// headings (different attribute names or types).
+    ///
+    /// # Behavior
+    ///
+    /// - Both relations must be type-compatible (identical headings)
+    /// - Duplicate tuples across relations are eliminated
+    /// - Union with self returns an equivalent relation
+    /// - Union with empty relation returns the non-empty relation
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("emp_id", ScalarType::Int)
+    ///     .with_attribute("name", ScalarType::String);
+    ///
+    /// let rel_type = RelationType::new(heading);
+    ///
+    /// let mut rel1 = Relation::new(rel_type.clone());
+    /// rel1.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+    /// rel1.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+    ///
+    /// let mut rel2 = Relation::new(rel_type);
+    /// rel2.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();  // Duplicate
+    /// rel2.insert(tuple! { emp_id: 3i64, name: "Charlie" }).unwrap();
+    ///
+    /// let result = rel1.union(&rel2).unwrap();
+    /// assert_eq!(result.cardinality(), 3);  // Alice, Bob (once), Charlie
+    /// ```
     pub fn union(&self, other: &Relation) -> Result<Self, UnionError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {

--- a/src/constraints/foreign_key.rs
+++ b/src/constraints/foreign_key.rs
@@ -1,29 +1,129 @@
+//! Foreign key constraints for referential integrity.
+//!
+//! Foreign keys ensure that values in one relation (the referencing relation)
+//! correspond to existing values in another relation (the referenced relation).
+//! This maintains referential integrity across related relations.
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::constraints::{ForeignKey, ForeignKeyConstraints};
+//!
+//! // Employees.dept_id must reference an existing Departments.dept_id
+//! let fk = ForeignKey::new(
+//!     vec!["dept_id".to_string()],       // Foreign key attribute(s)
+//!     "DEPARTMENTS".to_string(),          // Referenced relation name
+//!     vec!["dept_id".to_string()],       // Referenced attribute(s)
+//! ).unwrap();
+//!
+//! // Composite foreign key (multiple attributes)
+//! let composite_fk = ForeignKey::new(
+//!     vec!["project_id".to_string(), "task_id".to_string()],
+//!     "TASKS".to_string(),
+//!     vec!["proj_id".to_string(), "task_num".to_string()],
+//! ).unwrap();
+//! ```
+//!
+//! # Detecting Foreign Key Violations
+//!
+//! Foreign key constraints can detect when an insert would reference
+//! a non-existent tuple (dangling reference):
+//!
+//! ```
+//! use relvar::constraints::ForeignKey;
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::Relation;
+//! use relvar::tuple;
+//!
+//! // Create departments relation (the referenced relation)
+//! let dept_heading = TupleType::new()
+//!     .with_attribute("dept_id", ScalarType::Int)
+//!     .with_attribute("dept_name", ScalarType::String);
+//!
+//! let mut departments = Relation::new(RelationType::new(dept_heading));
+//! departments.insert(tuple! { dept_id: 10i64, dept_name: "Engineering" }).unwrap();
+//! departments.insert(tuple! { dept_id: 20i64, dept_name: "Sales" }).unwrap();
+//!
+//! // Define foreign key: employees.dept_id -> departments.dept_id
+//! let fk = ForeignKey::new(
+//!     vec!["dept_id".to_string()],
+//!     "DEPARTMENTS".to_string(),
+//!     vec!["dept_id".to_string()],
+//! ).unwrap();
+//!
+//! // Valid insert - dept_id 10 exists in departments
+//! let valid_employee = tuple! { emp_id: 1i64, name: "Alice", dept_id: 10i64 };
+//! assert!(!fk.would_violate_on_insert(&valid_employee, &departments).unwrap());
+//!
+//! // Invalid insert - dept_id 99 does NOT exist in departments!
+//! let invalid_employee = tuple! { emp_id: 2i64, name: "Bob", dept_id: 99i64 };
+//! assert!(fk.would_violate_on_insert(&invalid_employee, &departments).unwrap());
+//! ```
+
 use crate::values::{Relation, Tuple};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+/// Errors that can occur with foreign key constraints.
 #[derive(Debug, Error)]
 pub enum ForeignKeyError {
+    /// A foreign key value doesn't correspond to any tuple in the referenced relation.
     #[error("Foreign key constraint violation: referenced tuple not found")]
     ReferencedTupleNotFound,
+
+    /// The foreign key references attributes that don't exist in the referencing relation.
     #[error("Foreign key attributes {0:?} do not exist in referencing relation")]
     InvalidForeignKeyAttributes(Vec<String>),
+
+    /// The referenced attributes don't exist in the referenced relation.
     #[error("Referenced attributes {0:?} do not exist in referenced relation")]
     InvalidReferencedAttributes(Vec<String>),
+
+    /// The number of foreign key attributes must match the number of referenced attributes.
     #[error("Foreign key and referenced attributes must have same count")]
     AttributeCountMismatch,
+
+    /// A foreign key must have at least one attribute.
     #[error("Foreign key cannot be empty")]
     EmptyForeignKey,
 }
 
-/// A foreign key constraint ensures referential integrity between relations
+/// A foreign key constraint ensuring referential integrity between relations.
+///
+/// A foreign key links attributes in one relation (referencing) to attributes
+/// in another relation (referenced). Every combination of foreign key values
+/// must exist as a corresponding combination in the referenced relation.
+///
+/// # Referential Integrity Rules
+///
+/// - **Insert**: Cannot insert a tuple with foreign key values that don't exist
+///   in the referenced relation
+/// - **Delete**: Cannot delete a tuple from the referenced relation if it's
+///   referenced by tuples in the referencing relation
+/// - **Update**: Updates must maintain the integrity of references
+///
+/// # Example
+///
+/// ```
+/// use relvar::constraints::ForeignKey;
+///
+/// // Simple foreign key: employees.dept_id -> departments.dept_id
+/// let fk = ForeignKey::new(
+///     vec!["dept_id".to_string()],
+///     "DEPARTMENTS".to_string(),
+///     vec!["dept_id".to_string()],
+/// ).unwrap();
+///
+/// assert_eq!(fk.foreign_key_attributes(), &["dept_id"]);
+/// assert_eq!(fk.referenced_relation_name(), "DEPARTMENTS");
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ForeignKey {
-    /// Attributes in the referencing relation
+    /// Attributes in the referencing relation.
     foreign_key_attributes: Vec<String>,
-    /// Name of the referenced relation
+    /// Name of the referenced relation.
     referenced_relation_name: String,
-    /// Attributes in the referenced relation
+    /// Attributes in the referenced relation.
     referenced_attributes: Vec<String>,
 }
 

--- a/src/constraints/key.rs
+++ b/src/constraints/key.rs
@@ -1,21 +1,115 @@
+//! Key constraints for ensuring tuple uniqueness.
+//!
+//! Key constraints define which attributes (or combinations of attributes)
+//! must have unique values across all tuples in a relation.
+//!
+//! # TTM Compliance
+//!
+//! Per **Proscription 2** (No duplicate tuples), relations are true sets.
+//! Key constraints enforce this at the schema level by defining which
+//! attributes must be unique across all tuples.
+//!
+//! # Key Types
+//!
+//! - **Candidate Key** - Any minimal set of attributes that uniquely identifies tuples
+//! - **Primary Key** - A designated candidate key chosen as the main identifier
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::constraints::{PrimaryKey, CandidateKey, KeyConstraints};
+//!
+//! // Single-attribute primary key
+//! let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+//!
+//! // Composite candidate key (email must also be unique)
+//! let ck = CandidateKey::new(vec!["email".to_string()]).unwrap();
+//!
+//! // Create key constraints
+//! let constraints = KeyConstraints::new()
+//!     .with_primary_key(pk)
+//!     .with_candidate_key(ck);
+//! ```
+//!
+//! # Detecting Key Violations
+//!
+//! Key constraints can detect when an insert would create duplicates:
+//!
+//! ```
+//! use relvar::constraints::{PrimaryKey, KeyConstraints};
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::Relation;
+//! use relvar::tuple;
+//!
+//! // Create a relation with employee data
+//! let heading = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String);
+//!
+//! let mut relation = Relation::new(RelationType::new(heading));
+//! relation.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+//! relation.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+//!
+//! // Define primary key on emp_id
+//! let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+//! let constraints = KeyConstraints::new().with_primary_key(pk);
+//!
+//! // Check if current data satisfies the key constraint
+//! assert!(constraints.are_satisfied_by(&relation).unwrap());
+//!
+//! // Check if inserting a duplicate would violate the constraint
+//! let duplicate = tuple! { emp_id: 1i64, name: "Charlie" };  // emp_id=1 already exists!
+//! let violation = constraints.would_violate_on_insert(&relation, &duplicate).unwrap();
+//!
+//! // Violation detected - returns the violated key attributes
+//! assert!(violation.is_some());
+//! assert_eq!(violation.unwrap(), vec!["emp_id"]);
+//! ```
+
 use crate::values::{Relation, Tuple};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use thiserror::Error;
 
+/// Errors that can occur with key constraints.
 #[derive(Debug, Error)]
 pub enum KeyConstraintError {
+    /// A tuple would create a duplicate key value.
     #[error("Key constraint violation: duplicate key value for attributes {0:?}")]
     DuplicateKey(Vec<String>),
+
+    /// The key references attributes that don't exist in the relation.
     #[error("Key attributes {0:?} do not exist in relation")]
     InvalidKeyAttributes(Vec<String>),
+
+    /// A key must have at least one attribute.
     #[error("Key cannot be empty")]
     EmptyKey,
 }
 
-/// A candidate key is a minimal set of attributes that uniquely identifies tuples
+/// A candidate key - a minimal set of attributes that uniquely identifies tuples.
+///
+/// A candidate key has two properties:
+/// 1. **Uniqueness** - No two tuples can have the same values for all key attributes
+/// 2. **Minimality** - No proper subset of the attributes has the uniqueness property
+///
+/// # Example
+///
+/// ```
+/// use relvar::constraints::CandidateKey;
+///
+/// // Single-attribute key
+/// let emp_key = CandidateKey::new(vec!["emp_id".to_string()]).unwrap();
+///
+/// // Composite key (multiple attributes together form the key)
+/// let composite_key = CandidateKey::new(vec![
+///     "dept_id".to_string(),
+///     "emp_num".to_string(),
+/// ]).unwrap();
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CandidateKey {
+    /// The attribute names that compose this key.
     attributes: Vec<String>,
 }
 

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -1,3 +1,39 @@
+//! Database constraints for maintaining data integrity.
+//!
+//! This module implements the constraint system for enforcing data integrity
+//! rules on relations. Constraints ensure that the database maintains
+//! consistency as data is inserted, updated, or deleted.
+//!
+//! # Constraint Types
+//!
+//! - **Key Constraints** - Ensure tuple uniqueness
+//!   - `PrimaryKey` - The designated unique identifier for tuples
+//!   - `CandidateKey` - Additional unique identifiers
+//! - **Referential Integrity** - Ensure relationship validity
+//!   - `ForeignKey` - References must point to existing tuples
+//! - **Type Constraints** - Ensure value validity
+//!   - `TypeConstraint` - Value domain restrictions (range, enum, etc.)
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::constraints::{PrimaryKey, KeyConstraints, ForeignKey};
+//!
+//! // Define a primary key on emp_id
+//! let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+//!
+//! // Create key constraints with the primary key
+//! let key_constraints = KeyConstraints::new()
+//!     .with_primary_key(pk);
+//!
+//! // Define a foreign key from employees.dept_id to departments.dept_id
+//! let fk = ForeignKey::new(
+//!     vec!["dept_id".to_string()],
+//!     "DEPARTMENTS".to_string(),
+//!     vec!["dept_id".to_string()],
+//! ).unwrap();
+//! ```
+
 pub mod foreign_key;
 pub mod key;
 pub mod type_constraint;

--- a/src/constraints/type_constraint.rs
+++ b/src/constraints/type_constraint.rs
@@ -1,35 +1,127 @@
+//! Type constraints for value domain restrictions.
+//!
+//! Type constraints define additional rules beyond basic type checking that
+//! values must satisfy. These include range limits, enumerated values,
+//! string length requirements, and custom validation functions.
+//!
+//! # Constraint Types
+//!
+//! - [`TypeConstraint::Range`] - Value must be within min/max bounds
+//! - [`TypeConstraint::Enum`] - Value must be one of specified options
+//! - [`TypeConstraint::StringLength`] - String length must be within bounds
+//! - [`TypeConstraint::PositiveInt`] - Integer must be > 0
+//! - [`TypeConstraint::NonNegativeInt`] - Integer must be >= 0
+//! - [`TypeConstraint::Custom`] - User-defined validation function
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::constraints::{TypeConstraint, AttributeConstraints};
+//! use relvar::types::ScalarType;
+//! use relvar::values::ScalarValue;
+//!
+//! // Age must be between 0 and 150
+//! let age_constraint = TypeConstraint::Range {
+//!     min: ScalarValue::Int(0),
+//!     max: ScalarValue::Int(150),
+//! };
+//!
+//! assert!(age_constraint.is_satisfied_by(&ScalarValue::Int(25)).unwrap());
+//! assert!(!age_constraint.is_satisfied_by(&ScalarValue::Int(200)).unwrap());
+//! ```
+
 use crate::types::ScalarType;
 use crate::values::ScalarValue;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+/// Errors that can occur with type constraints.
 #[derive(Debug, Error)]
 pub enum TypeConstraintError {
+    /// A value violates a constraint.
     #[error("Type constraint violation: value {0:?} does not satisfy constraint")]
     ConstraintViolation(ScalarValue),
+
+    /// A value's type doesn't match what the constraint expects.
     #[error("Type mismatch: expected {expected}, got {actual}")]
-    TypeMismatch { expected: String, actual: String },
+    TypeMismatch {
+        /// The expected type name.
+        expected: String,
+        /// The actual type name of the value.
+        actual: String,
+    },
 }
 
-/// A constraint on a scalar type
+/// A constraint that restricts the valid values for a scalar type.
+///
+/// Type constraints add domain restrictions beyond the basic type system.
+/// They can enforce ranges, enumerated values, string lengths, or custom
+/// validation logic.
+///
+/// # Example
+///
+/// ```
+/// use relvar::constraints::TypeConstraint;
+/// use relvar::values::ScalarValue;
+///
+/// // Range constraint for percentages
+/// let percentage = TypeConstraint::Range {
+///     min: ScalarValue::Int(0),
+///     max: ScalarValue::Int(100),
+/// };
+///
+/// // Enum constraint for status values
+/// let status = TypeConstraint::Enum {
+///     allowed_values: vec![
+///         ScalarValue::String("active".to_string()),
+///         ScalarValue::String("inactive".to_string()),
+///         ScalarValue::String("pending".to_string()),
+///     ],
+/// };
+/// ```
 #[derive(Serialize, Deserialize)]
 pub enum TypeConstraint {
-    /// Value must be within a range (inclusive)
-    Range { min: ScalarValue, max: ScalarValue },
-    /// Value must be one of the specified values
-    Enum { allowed_values: Vec<ScalarValue> },
-    /// String must match a pattern (simplified - just length for now)
-    StringLength { min: usize, max: usize },
-    /// Integer must be positive
+    /// Value must be within an inclusive range.
+    ///
+    /// Both `min` and `max` bounds are included in the valid range.
+    Range {
+        /// The minimum allowed value (inclusive).
+        min: ScalarValue,
+        /// The maximum allowed value (inclusive).
+        max: ScalarValue,
+    },
+
+    /// Value must be one of the specified allowed values.
+    Enum {
+        /// The list of valid values.
+        allowed_values: Vec<ScalarValue>,
+    },
+
+    /// String length must be within the specified bounds.
+    StringLength {
+        /// Minimum string length (inclusive).
+        min: usize,
+        /// Maximum string length (inclusive).
+        max: usize,
+    },
+
+    /// Integer must be strictly positive (> 0).
     PositiveInt,
-    /// Integer must be non-negative
+
+    /// Integer must be non-negative (>= 0).
     NonNegativeInt,
-    /// Custom validation function (not serializable, for in-memory use only)
+
+    /// Custom validation function.
+    ///
+    /// The validator function is not serializable. After deserialization,
+    /// the validator will be `None` and validation will pass by default.
     #[serde(skip)]
     Custom {
+        /// The validation function (optional for deserialization support).
         #[serde(skip)]
         #[allow(clippy::type_complexity)]
         validator: Option<Box<dyn Fn(&ScalarValue) -> bool + Send + Sync>>,
+        /// Human-readable description of the constraint.
         description: String,
     },
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,3 +1,54 @@
+//! Core database instance and operations.
+//!
+//! This module provides the [`Database`] struct, which is the main entry point
+//! for all database operations including:
+//!
+//! - Creating and dropping relations (base relvars)
+//! - Inserting, updating, and deleting tuples
+//! - Querying relations with relational algebra
+//! - Managing transactions
+//! - Setting up constraints (primary keys, foreign keys, type constraints)
+//!
+//! # TTM Compliance
+//!
+//! The database enforces The Third Manifesto principles:
+//!
+//! - **No NULL values**: All tuple attributes must have values
+//! - **No duplicates**: Relations are true sets
+//! - **Constraint enforcement**: Keys and foreign keys are validated on mutation
+//! - **Type safety**: Tuples must conform to their relation's heading
+//!
+//! # Example
+//!
+//! ```no_run
+//! use relvar::Database;
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::constraints::{PrimaryKey, KeyConstraints};
+//! use relvar::tuple;
+//!
+//! // Open or create a database
+//! let mut db = Database::open("my_database")?;
+//!
+//! // Define and create a relation
+//! let emp_type = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String);
+//!
+//! db.create_relvar("EMP", RelationType::new(emp_type))?;
+//!
+//! // Set primary key constraint
+//! let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+//! db.set_key_constraints("EMP", KeyConstraints::new().with_primary_key(pk))?;
+//!
+//! // Insert data
+//! db.insert("EMP", tuple! { emp_id: 1i64, name: "Alice" })?;
+//!
+//! // Query with relational algebra
+//! let result = db.query("EMP")?.project(&["name"]);
+//!
+//! # Ok::<(), relvar::DatabaseError>(())
+//! ```
+
 use crate::constraints::{AttributeConstraints, ForeignKey, ForeignKeyConstraints, KeyConstraints};
 use crate::storage::{BTreeIndex, Catalog, CatalogError, HeapError, HeapFile};
 use crate::types::RelationType;
@@ -7,62 +58,190 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
+/// Errors that can occur during database operations.
+///
+/// This enum covers all error conditions including I/O errors, constraint
+/// violations, and transaction errors.
 #[derive(Debug, Error)]
 pub enum DatabaseError {
+    /// An I/O error occurred during file operations.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// An error occurred in the system catalog.
     #[error("Catalog error: {0}")]
     Catalog(#[from] CatalogError),
+
+    /// An error occurred in the heap file storage.
     #[error("Heap file error: {0}")]
     HeapFile(#[from] HeapError),
+
+    /// An error occurred with a relation value.
     #[error("Relation error: {0}")]
     Relation(#[from] RelationError),
+
+    /// Attempted to create a relation that already exists.
     #[error("Relation {0} already exists")]
     RelationAlreadyExists(String),
+
+    /// The specified relation does not exist.
     #[error("Relation {0} not found")]
     RelationNotFound(String),
+
+    /// The tuple's type does not match the relation's heading.
+    ///
+    /// This occurs when inserting or updating a tuple that doesn't
+    /// conform to the relation's declared type.
     #[error("Tuple type does not match relation type")]
     TupleMismatch,
+
+    /// Inserting a tuple would violate the primary key constraint.
+    ///
+    /// Primary key values must be unique across all tuples in a relation.
     #[error("Primary key constraint violation")]
     PrimaryKeyViolation,
+
+    /// Inserting a tuple would violate a candidate key constraint.
+    ///
+    /// Candidate key values must be unique across all tuples in a relation.
     #[error("Candidate key constraint violation")]
     CandidateKeyViolation,
+
+    /// A foreign key constraint was violated.
+    ///
+    /// This occurs when:
+    /// - Inserting a tuple with a foreign key value that doesn't exist in the referenced relation
+    /// - Deleting a tuple that is referenced by another relation
     #[error("Foreign key constraint violation: {0}")]
     ForeignKeyViolation(String),
+
+    /// A type constraint was violated.
+    ///
+    /// This occurs when a value doesn't satisfy the defined type constraints
+    /// (e.g., range, enum, string length).
     #[error("Type constraint violation: {0}")]
     TypeConstraintViolation(String),
+
+    /// The specified attribute does not exist in the relation.
     #[error("Attribute {0} not found")]
     AttributeNotFound(String),
+
+    /// A transaction-related error occurred.
+    ///
+    /// This includes attempting to commit/rollback without an active transaction,
+    /// or beginning a transaction when one is already in progress.
     #[error("Transaction error: {0}")]
     TransactionError(String),
 }
 
-/// A database instance managing relations, storage, and constraints
+/// A database instance managing relations, storage, and constraints.
+///
+/// `Database` is the main entry point for all database operations. It manages:
+///
+/// - **Relations (Relvars)**: Create, drop, and query base relations
+/// - **Data Manipulation**: Insert, update, and delete tuples
+/// - **Constraints**: Primary keys, foreign keys, and type constraints
+/// - **Transactions**: Begin, commit, and rollback operations
+/// - **Storage**: Heap files and indexes for persistent storage
+///
+/// # Architecture
+///
+/// ```text
+/// Database
+/// ├── Catalog (metadata about all relations)
+/// ├── HeapFiles (tuple storage, keyed by relation name)
+/// ├── Indexes (B-tree indexes for efficient lookups)
+/// └── Constraints
+///     ├── KeyConstraints (primary and candidate keys)
+///     ├── ForeignKeyConstraints (referential integrity)
+///     └── TypeConstraints (value domain restrictions)
+/// ```
+///
+/// # Example
+///
+/// ```no_run
+/// use relvar::Database;
+/// use relvar::types::{TupleType, RelationType, ScalarType};
+/// use relvar::tuple;
+///
+/// // Create or open a database
+/// let mut db = Database::open("my_db")?;
+///
+/// // Create a relation
+/// let heading = TupleType::new()
+///     .with_attribute("id", ScalarType::Int)
+///     .with_attribute("name", ScalarType::String);
+/// db.create_relvar("USERS", RelationType::new(heading))?;
+///
+/// // Insert tuples
+/// db.insert("USERS", tuple! { id: 1i64, name: "Alice" })?;
+///
+/// // Query with relational algebra
+/// let users = db.query("USERS")?;
+/// let names = users.project(&["name"]);
+///
+/// // Use transactions for atomic operations
+/// db.begin()?;
+/// db.insert("USERS", tuple! { id: 2i64, name: "Bob" })?;
+/// db.commit()?;  // or db.rollback()?
+///
+/// # Ok::<(), relvar::DatabaseError>(())
+/// ```
 pub struct Database {
-    /// Base directory for database files
+    /// Base directory for database files.
     db_path: PathBuf,
-    /// Path to catalog file
+    /// Path to the catalog file.
     catalog_path: PathBuf,
-    /// System catalog
+    /// System catalog containing relation metadata.
     catalog: Catalog,
-    /// Open heap files (relation_name -> heap_file)
+    /// Open heap files, keyed by relation name.
     heap_files: HashMap<String, HeapFile>,
-    /// Indexes (relation_name.attribute -> index)
+    /// B-tree indexes, keyed by "relation_name.attribute".
     indexes: HashMap<String, BTreeIndex>,
-    /// Key constraints per relation
+    /// Key constraints (primary and candidate) per relation.
     key_constraints: HashMap<String, KeyConstraints>,
-    /// Foreign key constraints per relation
+    /// Foreign key constraints per relation.
     foreign_key_constraints: HashMap<String, ForeignKeyConstraints>,
-    /// Type constraints per relation per attribute
+    /// Type constraints per relation, per attribute.
     type_constraints: HashMap<String, HashMap<String, AttributeConstraints>>,
-    /// Transaction state
+    /// Whether a transaction is currently in progress.
     in_transaction: bool,
-    /// Savepoint for rollback (simplified - just store full relations)
+    /// Savepoint data for transaction rollback.
+    ///
+    /// This is a simplified implementation that stores full relation snapshots.
+    /// A production system would use write-ahead logging (WAL).
     savepoint: Option<HashMap<String, Relation>>,
 }
 
 impl Database {
-    /// Open or create a database at the specified path
+    /// Opens or creates a database at the specified path.
+    ///
+    /// If the database directory does not exist, it will be created along with
+    /// an empty catalog. If the database already exists, the catalog is loaded
+    /// from disk.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The directory path where the database files will be stored
+    ///
+    /// # Returns
+    ///
+    /// A `Database` instance ready for use.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The directory cannot be created
+    /// - The catalog file cannot be read or created
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use relvar::Database;
+    ///
+    /// let db = Database::open("my_database")?;
+    /// # Ok::<(), relvar::DatabaseError>(())
+    /// ```
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, DatabaseError> {
         let db_path = path.as_ref().to_path_buf();
         std::fs::create_dir_all(&db_path)?;
@@ -90,7 +269,36 @@ impl Database {
         })
     }
 
-    /// Create a new relation (base relvar)
+    /// Creates a new relation (base relvar) in the database.
+    ///
+    /// A relation is defined by its [`RelationType`], which specifies the
+    /// heading (attribute names and types). The relation is initially empty.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the relation (case-sensitive)
+    /// * `relation_type` - The type definition for the relation
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseError::RelationAlreadyExists`] if a relation with
+    /// the given name already exists.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use relvar::Database;
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    ///
+    /// let mut db = Database::open("test_db")?;
+    ///
+    /// let emp_type = TupleType::new()
+    ///     .with_attribute("emp_id", ScalarType::Int)
+    ///     .with_attribute("name", ScalarType::String);
+    ///
+    /// db.create_relvar("EMPLOYEES", RelationType::new(emp_type))?;
+    /// # Ok::<(), relvar::DatabaseError>(())
+    /// ```
     pub fn create_relvar(
         &mut self,
         name: &str,
@@ -118,7 +326,23 @@ impl Database {
         Ok(())
     }
 
-    /// Drop a relation
+    /// Drops (deletes) a relation from the database.
+    ///
+    /// This removes the relation and all its data, including associated
+    /// constraints and indexes.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the relation to drop
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseError::RelationNotFound`] if the relation does not exist.
+    ///
+    /// # Warning
+    ///
+    /// This operation is irreversible outside of a transaction. All data in
+    /// the relation will be permanently deleted.
     pub fn drop_relvar(&mut self, name: &str) -> Result<(), DatabaseError> {
         if self.catalog.get_relation(name).is_err() {
             return Err(DatabaseError::RelationNotFound(name.to_string()));
@@ -145,7 +369,37 @@ impl Database {
         Ok(())
     }
 
-    /// Set key constraints for a relation
+    /// Sets key constraints (primary and candidate keys) for a relation.
+    ///
+    /// Key constraints ensure uniqueness of specified attribute combinations.
+    /// A primary key is a designated candidate key that uniquely identifies tuples.
+    ///
+    /// # Arguments
+    ///
+    /// * `relation_name` - The name of the relation
+    /// * `constraints` - The key constraints to apply
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseError::RelationNotFound`] if the relation does not exist.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use relvar::Database;
+    /// use relvar::constraints::{PrimaryKey, CandidateKey, KeyConstraints};
+    ///
+    /// # let mut db = Database::open("test")?;
+    /// let pk = PrimaryKey::new(vec!["emp_id".to_string()])?;
+    /// let ck = CandidateKey::new(vec!["email".to_string()])?;
+    ///
+    /// let constraints = KeyConstraints::new()
+    ///     .with_primary_key(pk)
+    ///     .with_candidate_key(ck);
+    ///
+    /// db.set_key_constraints("EMPLOYEES", constraints)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn set_key_constraints(
         &mut self,
         relation_name: &str,
@@ -160,7 +414,37 @@ impl Database {
         Ok(())
     }
 
-    /// Add a foreign key constraint
+    /// Adds a foreign key constraint to a relation.
+    ///
+    /// Foreign keys enforce referential integrity by requiring that values in
+    /// specified attributes exist in another relation's corresponding attributes.
+    ///
+    /// # Arguments
+    ///
+    /// * `relation_name` - The name of the referencing relation
+    /// * `foreign_key` - The foreign key constraint to add
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseError::RelationNotFound`] if the relation does not exist.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use relvar::Database;
+    /// use relvar::constraints::ForeignKey;
+    ///
+    /// # let mut db = Database::open("test")?;
+    /// // EMP.dept_id references DEPT.dept_id
+    /// let fk = ForeignKey::new(
+    ///     vec!["dept_id".to_string()],
+    ///     "DEPT".to_string(),
+    ///     vec!["dept_id".to_string()],
+    /// )?;
+    ///
+    /// db.add_foreign_key("EMP", fk)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub fn add_foreign_key(
         &mut self,
         relation_name: &str,
@@ -182,7 +466,37 @@ impl Database {
         Ok(())
     }
 
-    /// Set type constraints for an attribute
+    /// Sets type constraints for an attribute in a relation.
+    ///
+    /// Type constraints restrict the allowed values for an attribute beyond
+    /// its base type. Supported constraints include ranges, enumerations,
+    /// string length limits, and custom validators.
+    ///
+    /// # Arguments
+    ///
+    /// * `relation_name` - The name of the relation
+    /// * `attribute` - The name of the attribute to constrain
+    /// * `constraints` - The constraints to apply
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseError::RelationNotFound`] if the relation does not exist.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use relvar::Database;
+    /// use relvar::types::ScalarType;
+    /// use relvar::constraints::{AttributeConstraints, TypeConstraint};
+    ///
+    /// # let mut db = Database::open("test")?;
+    /// // Age must be positive
+    /// let age_constraint = AttributeConstraints::new("age".to_string(), ScalarType::Int)
+    ///     .with_constraint(TypeConstraint::PositiveInt);
+    ///
+    /// db.set_type_constraints("EMPLOYEES", "age", age_constraint)?;
+    /// # Ok::<(), relvar::DatabaseError>(())
+    /// ```
     pub fn set_type_constraints(
         &mut self,
         relation_name: &str,
@@ -201,7 +515,45 @@ impl Database {
         Ok(())
     }
 
-    /// Insert a tuple into a relation
+    /// Inserts a tuple into a relation.
+    ///
+    /// The tuple must conform to the relation's type (heading). All constraints
+    /// are validated before insertion:
+    ///
+    /// 1. **Type matching**: Tuple type must match relation type
+    /// 2. **Type constraints**: Values must satisfy attribute constraints
+    /// 3. **Primary key**: No duplicate key values
+    /// 4. **Candidate keys**: No duplicate key values
+    /// 5. **Foreign keys**: Referenced values must exist
+    ///
+    /// # Arguments
+    ///
+    /// * `relation_name` - The name of the relation
+    /// * `tuple` - The tuple to insert
+    ///
+    /// # Errors
+    ///
+    /// - [`DatabaseError::RelationNotFound`] - Relation does not exist
+    /// - [`DatabaseError::TupleMismatch`] - Tuple type doesn't match relation type
+    /// - [`DatabaseError::TypeConstraintViolation`] - Value violates type constraint
+    /// - [`DatabaseError::PrimaryKeyViolation`] - Duplicate primary key
+    /// - [`DatabaseError::CandidateKeyViolation`] - Duplicate candidate key
+    /// - [`DatabaseError::ForeignKeyViolation`] - Referenced value doesn't exist
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use relvar::Database;
+    /// use relvar::tuple;
+    ///
+    /// # let mut db = Database::open("test")?;
+    /// db.insert("EMPLOYEES", tuple! {
+    ///     emp_id: 1i64,
+    ///     name: "Alice",
+    ///     dept_id: 10i64
+    /// })?;
+    /// # Ok::<(), relvar::DatabaseError>(())
+    /// ```
     pub fn insert(&mut self, relation_name: &str, tuple: Tuple) -> Result<(), DatabaseError> {
         // Get relation metadata
         let metadata = self
@@ -280,7 +632,38 @@ impl Database {
         Ok(())
     }
 
-    /// Query a relation (returns the full relation for algebra operations)
+    /// Queries a relation, returning all tuples as a [`Relation`] value.
+    ///
+    /// The returned relation can be transformed using relational algebra
+    /// operators such as `project`, `restrict`, `join`, `union`, etc.
+    ///
+    /// # Arguments
+    ///
+    /// * `relation_name` - The name of the relation to query
+    ///
+    /// # Returns
+    ///
+    /// A [`Relation`] containing all tuples from the stored relation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseError::RelationNotFound`] if the relation does not exist.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use relvar::Database;
+    ///
+    /// # let mut db = Database::open("test")?;
+    /// // Get all employees
+    /// let employees = db.query("EMPLOYEES")?;
+    ///
+    /// // Use relational algebra
+    /// let senior_employees = employees
+    ///     .restrict(|t| t.get_typed::<i64>("salary").unwrap() > 100000)
+    ///     .project(&["name", "salary"]);
+    /// # Ok::<(), relvar::DatabaseError>(())
+    /// ```
     pub fn query(&mut self, relation_name: &str) -> Result<Relation, DatabaseError> {
         // Get relation metadata (clone to avoid borrow issues)
         let relation_type = self
@@ -304,7 +687,38 @@ impl Database {
         Ok(relation)
     }
 
-    /// Delete tuples matching a predicate
+    /// Deletes tuples matching a predicate from a relation.
+    ///
+    /// All tuples for which the predicate returns `true` are removed. Foreign
+    /// key constraints are checked before deletion to prevent orphaned references.
+    ///
+    /// # Arguments
+    ///
+    /// * `relation_name` - The name of the relation
+    /// * `predicate` - A function that returns `true` for tuples to delete
+    ///
+    /// # Returns
+    ///
+    /// The number of tuples deleted.
+    ///
+    /// # Errors
+    ///
+    /// - [`DatabaseError::RelationNotFound`] - Relation does not exist
+    /// - [`DatabaseError::ForeignKeyViolation`] - Deletion would orphan references
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use relvar::Database;
+    ///
+    /// # let mut db = Database::open("test")?;
+    /// // Delete employee with emp_id = 42
+    /// let deleted = db.delete("EMPLOYEES", |t| {
+    ///     t.get_typed::<i64>("emp_id").unwrap() == 42
+    /// })?;
+    /// println!("Deleted {} tuples", deleted);
+    /// # Ok::<(), relvar::DatabaseError>(())
+    /// ```
     pub fn delete<F>(&mut self, relation_name: &str, predicate: F) -> Result<usize, DatabaseError>
     where
         F: Fn(&Tuple) -> bool,
@@ -377,7 +791,45 @@ impl Database {
         Ok(deleted_count)
     }
 
-    /// Update tuples matching a predicate
+    /// Updates tuples matching a predicate.
+    ///
+    /// All tuples for which the predicate returns `true` are modified by
+    /// the updater function. After modification, type conformance is verified.
+    ///
+    /// # Arguments
+    ///
+    /// * `relation_name` - The name of the relation
+    /// * `predicate` - A function that returns `true` for tuples to update
+    /// * `updater` - A function that modifies the tuple in place
+    ///
+    /// # Returns
+    ///
+    /// The number of tuples updated.
+    ///
+    /// # Errors
+    ///
+    /// - [`DatabaseError::RelationNotFound`] - Relation does not exist
+    /// - [`DatabaseError::TupleMismatch`] - Updated tuple doesn't conform to type
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use relvar::Database;
+    /// use relvar::values::ScalarValue;
+    ///
+    /// # let mut db = Database::open("test")?;
+    /// // Give all employees in dept 10 a 10% raise
+    /// let updated = db.update(
+    ///     "EMPLOYEES",
+    ///     |t| t.get_typed::<i64>("dept_id").unwrap() == 10,
+    ///     |t| {
+    ///         let old_salary = t.get_typed::<i64>("salary").unwrap();
+    ///         t.set("salary".to_string(), ScalarValue::Int(old_salary * 11 / 10)).unwrap();
+    ///     },
+    /// )?;
+    /// println!("Updated {} tuples", updated);
+    /// # Ok::<(), relvar::DatabaseError>(())
+    /// ```
     pub fn update<F, U>(
         &mut self,
         relation_name: &str,
@@ -431,7 +883,33 @@ impl Database {
         Ok(updated_count)
     }
 
-    /// Begin a transaction
+    /// Begins a new transaction.
+    ///
+    /// A transaction provides atomicity - all changes within the transaction
+    /// are either committed together or rolled back together.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseError::TransactionError`] if a transaction is already
+    /// in progress.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use relvar::Database;
+    /// use relvar::tuple;
+    ///
+    /// # let mut db = Database::open("test")?;
+    /// db.begin()?;
+    ///
+    /// // Multiple operations
+    /// db.insert("EMPLOYEES", tuple! { emp_id: 1i64, name: "Alice" })?;
+    /// db.insert("EMPLOYEES", tuple! { emp_id: 2i64, name: "Bob" })?;
+    ///
+    /// // Commit all changes atomically
+    /// db.commit()?;
+    /// # Ok::<(), relvar::DatabaseError>(())
+    /// ```
     pub fn begin(&mut self) -> Result<(), DatabaseError> {
         if self.in_transaction {
             return Err(DatabaseError::TransactionError(
@@ -452,7 +930,14 @@ impl Database {
         Ok(())
     }
 
-    /// Commit a transaction
+    /// Commits the current transaction.
+    ///
+    /// All changes made since [`begin()`](Self::begin) are made permanent.
+    /// The transaction is ended after commit.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseError::TransactionError`] if no transaction is in progress.
     pub fn commit(&mut self) -> Result<(), DatabaseError> {
         if !self.in_transaction {
             return Err(DatabaseError::TransactionError(
@@ -467,7 +952,31 @@ impl Database {
         Ok(())
     }
 
-    /// Rollback a transaction
+    /// Rolls back the current transaction.
+    ///
+    /// All changes made since [`begin()`](Self::begin) are discarded and
+    /// the database is restored to its pre-transaction state.
+    /// The transaction is ended after rollback.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseError::TransactionError`] if no transaction is in progress.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use relvar::Database;
+    /// use relvar::tuple;
+    ///
+    /// # let mut db = Database::open("test")?;
+    /// db.begin()?;
+    /// db.insert("EMPLOYEES", tuple! { emp_id: 999i64, name: "Test" })?;
+    ///
+    /// // Oops, changed our mind - rollback
+    /// db.rollback()?;
+    /// // The insert never happened
+    /// # Ok::<(), relvar::DatabaseError>(())
+    /// ```
     pub fn rollback(&mut self) -> Result<(), DatabaseError> {
         if !self.in_transaction {
             return Err(DatabaseError::TransactionError(
@@ -501,7 +1010,9 @@ impl Database {
         Ok(())
     }
 
-    /// Helper to get or open a heap file
+    /// Gets or opens a heap file for a relation.
+    ///
+    /// This is an internal helper that lazily opens heap files as needed.
     fn get_or_open_heap_file(
         &mut self,
         relation_name: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@
 //! | TTM Term | SQL Equivalent | Description |
 //! |----------|----------------|-------------|
 //! | Relation | Table | A set of tuples with a common heading |
-//! | Tuple | Row | An ordered set of attribute-value pairs |
+//! | Tuple | Row | A set of attribute-value pairs |
 //! | Attribute | Column | A named component of a tuple |
 //! | Heading | Schema | The set of attributes defining a relation's structure |
 //! | Relvar | Table variable | A variable whose value is a relation |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,189 @@
+//! # Relvar - A Pure Relational Database Management System
+//!
+//! Relvar is a Rust implementation of a relational database management system (RDBMS)
+//! that strictly adheres to the principles outlined in *The Third Manifesto* by
+//! C.J. Date and Hugh Darwen.
+//!
+//! ## Core Principles
+//!
+//! This library implements the relational model with strict adherence to TTM:
+//!
+//! - **No NULL values** (Proscription 1) - All attributes must have values
+//! - **No duplicate tuples** (Proscription 2) - Relations are true sets
+//! - **No tuple ordering** (Proscription 3) - Tuples have no inherent order
+//! - **No attribute ordering** (Proscription 4) - Attributes are identified by name
+//! - **No tuple-level IDs** (Proscription 6) - Physical storage details are never exposed
+//!   ```
+//!   use relvar::types::{TupleType, RelationType, ScalarType};
+//!   use relvar::values::Relation;
+//!   use relvar::tuple;
+//!
+//!   let heading = TupleType::new()
+//!       .with_attribute("id", ScalarType::Int)
+//!       .with_attribute("name", ScalarType::String);
+//!
+//!   let mut employees = Relation::new(RelationType::new(heading));
+//!
+//!   // Insert returns bool (was it new?), not a row ID - tuples are values
+//!   let was_new: bool = employees.insert(tuple! { id: 1i64, name: "Alice" }).unwrap();
+//!   assert!(was_new);  // No physical address returned
+//!
+//!   // Query returns tuple values, not physical references
+//!   for tuple in employees.tuples() {
+//!       // Tuples are accessed by attribute name, never by physical address
+//!       let _name = tuple.get("name");
+//!   }
+//!   ```
+//! - **Complete relational algebra** (Prescription 7) - All standard operators implemented
+//! - **User-defined types** (Prescription 1) - POSSREP pattern support
+//!
+//! ## Quick Start
+//!
+//! ```no_run
+//! use relvar::{Database, DatabaseError, ScalarType};
+//! use relvar::types::{TupleType, RelationType};
+//! use relvar::tuple;
+//!
+//! // Open or create a database
+//! let mut db = Database::open("my_database")?;
+//!
+//! // Define a relation type (heading)
+//! let employee_type = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String)
+//!     .with_attribute("dept_id", ScalarType::Int);
+//!
+//! // Create a relation (base relvar)
+//! db.create_relvar("EMPLOYEES", RelationType::new(employee_type))?;
+//!
+//! // Insert tuples
+//! db.insert("EMPLOYEES", tuple! { emp_id: 1i64, name: "Alice", dept_id: 10i64 })?;
+//! db.insert("EMPLOYEES", tuple! { emp_id: 2i64, name: "Bob", dept_id: 20i64 })?;
+//!
+//! // Query with relational algebra
+//! let result = db.query("EMPLOYEES")?
+//!     .restrict(|t| t.get_typed::<i64>("dept_id").unwrap() == 10)
+//!     .project(&["emp_id", "name"]);
+//!
+//! # Ok::<(), DatabaseError>(())
+//! ```
+//!
+//! ## Modules
+//!
+//! - [`algebra`] - Relational algebra operators (project, restrict, join, union, etc.)
+//! - [`constraints`] - Database constraints (primary keys, foreign keys, type constraints)
+//! - [`database`] - Core database instance and transaction management
+//! - [`storage`] - Persistent storage layer (heap files, B-tree indexes, catalog)
+//! - [`types`] - Type system (scalar types, tuple types, relation types)
+//! - [`values`] - Runtime values (scalar values, tuples, relations)
+//!
+//! ## TTM Terminology
+//!
+//! This library uses terminology from The Third Manifesto:
+//!
+//! | TTM Term | SQL Equivalent | Description |
+//! |----------|----------------|-------------|
+//! | Relation | Table | A set of tuples with a common heading |
+//! | Tuple | Row | An ordered set of attribute-value pairs |
+//! | Attribute | Column | A named component of a tuple |
+//! | Heading | Schema | The set of attributes defining a relation's structure |
+//! | Relvar | Table variable | A variable whose value is a relation |
+//! | Cardinality | Row count | Number of tuples in a relation |
+//! | Degree | Column count | Number of attributes in a relation |
+//!
+//! ## Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────┐
+//! │                    Database API                      │
+//! │        (create_relvar, insert, query, etc.)         │
+//! ├─────────────────────────────────────────────────────┤
+//! │                 Relational Algebra                   │
+//! │    (project, restrict, join, union, summarize)      │
+//! ├─────────────────────────────────────────────────────┤
+//! │                   Type System                        │
+//! │      (ScalarType, TupleType, RelationType)          │
+//! ├─────────────────────────────────────────────────────┤
+//! │                  Constraints                         │
+//! │    (PrimaryKey, ForeignKey, TypeConstraint)         │
+//! ├─────────────────────────────────────────────────────┤
+//! │                 Storage Layer                        │
+//! │      (HeapFile, BTreeIndex, Catalog, Page)          │
+//! └─────────────────────────────────────────────────────┘
+//! ```
+
+/// Relational algebra operators for querying and transforming relations.
+///
+/// This module provides the complete set of relational algebra operators
+/// as defined in The Third Manifesto (RM Prescription 7):
+///
+/// - **Project** (`project`) - Select a subset of attributes
+/// - **Restrict** (`restrict`) - Filter tuples by a predicate (σ)
+/// - **Rename** (`rename`) - Rename attributes
+/// - **Join** (`join`, `theta_join`) - Combine relations
+/// - **Union** (`union`) - Set union of type-compatible relations
+/// - **Intersect** (`intersect`) - Set intersection
+/// - **Difference** (`difference`) - Set difference
+/// - **Extend** (`extend`) - Add computed attributes
+/// - **Group** (`group`) - Create relation-valued attributes
+/// - **Summarize** (`summarize`) - Aggregate with grouping
 pub mod algebra;
+
+/// Database constraints for maintaining data integrity.
+///
+/// This module implements the constraint system per TTM principles:
+///
+/// - [`KeyConstraints`](constraints::KeyConstraints) - Primary and candidate keys
+/// - [`ForeignKey`](constraints::ForeignKey) - Referential integrity
+/// - [`TypeConstraint`](constraints::TypeConstraint) - Value domain restrictions
 pub mod constraints;
+
+/// Core database instance and operations.
+///
+/// The [`Database`] struct is the main entry point for:
+///
+/// - Creating and dropping relations (base relvars)
+/// - Inserting, updating, and deleting tuples
+/// - Querying relations with relational algebra
+/// - Managing transactions (begin, commit, rollback)
+/// - Setting up constraints
 pub mod database;
+
+/// Persistent storage layer.
+///
+/// This module provides the physical storage implementation:
+///
+/// - [`HeapFile`](storage::HeapFile) - Unordered tuple storage
+/// - [`BTreeIndex`](storage::BTreeIndex) - Efficient key lookups
+/// - [`Catalog`](storage::Catalog) - Relation metadata storage
+/// - [`Page`](storage::Page) - Fixed-size disk blocks
+///
+/// **TTM Compliance:** Physical storage details (e.g., TupleId) are never
+/// exposed in public APIs per Proscription 6.
 pub mod storage;
+
+/// Type system for relations, tuples, and scalar values.
+///
+/// This module defines the type hierarchy:
+///
+/// - [`ScalarType`] - Primitive and user-defined types
+/// - [`TupleType`](types::TupleType) - Heading (set of attributes with types)
+/// - [`RelationType`](types::RelationType) - Type of a relation
+///
+/// **TTM Compliance:** User-defined types are supported via the POSSREP
+/// (possible representation) pattern per Prescription 1.
 pub mod types;
+
+/// Runtime values for relations, tuples, and scalars.
+///
+/// This module provides the value types:
+///
+/// - [`ScalarValue`] - Runtime scalar value
+/// - [`Tuple`](values::Tuple) - A tuple value conforming to a tuple type
+/// - [`Relation`](values::Relation) - A relation value (heading + body)
+///
+/// **TTM Compliance:** Relations are true sets (no duplicates, no ordering).
+/// All values carry their types. No NULL values are permitted.
 pub mod values;
 
 pub use database::{Database, DatabaseError};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
+//! Relvar database command-line interface.
+//!
+//! This binary provides a command-line interface to the Relvar database.
+//! Currently a placeholder for future CLI functionality.
+
 fn main() {
     println!("Hello, world!");
 }

--- a/src/storage/btree.rs
+++ b/src/storage/btree.rs
@@ -1,3 +1,47 @@
+//! B-tree index for efficient key-based tuple lookup.
+//!
+//! This module provides a B-tree index that maps scalar key values to tuples.
+//! It supports point lookups, range scans, and persistence to disk.
+//!
+//! # TTM Compliance
+//!
+//! This index stores full tuples rather than TupleId references, complying
+//! with TTM Proscription 6: "The database must not generate or expose
+//! tuple-level identifiers."
+//!
+//! From the relational perspective, tuples are identified by their attribute
+//! values (keys), not by physical storage locations.
+//!
+//! # Implementation Note
+//!
+//! This is a simplified implementation using Rust's `BTreeMap`. Production
+//! systems would implement a proper on-disk B-tree with:
+//! - Page-based storage
+//! - Split and merge operations
+//! - Write-ahead logging
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::storage::BTreeIndex;
+//! use relvar::values::ScalarValue;
+//! use relvar::tuple;
+//!
+//! let mut index = BTreeIndex::new();
+//!
+//! // Insert key-tuple pairs
+//! index.insert(ScalarValue::Int(1), tuple! { id: 1i64, name: "Alice" });
+//! index.insert(ScalarValue::Int(2), tuple! { id: 2i64, name: "Bob" });
+//!
+//! // Point lookup
+//! let results = index.search(&ScalarValue::Int(1)).unwrap();
+//! assert_eq!(results.len(), 1);
+//!
+//! // Range scan
+//! let range = index.range_scan(&ScalarValue::Int(1), &ScalarValue::Int(2));
+//! assert_eq!(range.len(), 2);
+//! ```
+
 use crate::values::{ScalarValue, Tuple};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -6,23 +50,37 @@ use std::io::{Read, Write};
 use std::path::Path;
 use thiserror::Error;
 
+/// Errors that can occur during B-tree index operations.
 #[derive(Debug, Error)]
 pub enum BTreeIndexError {
+    /// An I/O error occurred while reading or writing the index.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// Serialization or deserialization of the index failed.
     #[error("Serialization error: {0}")]
     Serialization(String),
+
+    /// The requested key was not found in the index.
     #[error("Key not found")]
     KeyNotFound,
 }
 
-/// A B-tree index mapping scalar values to tuples.
+/// A B-tree index mapping scalar key values to tuples.
 ///
-/// **TTM Compliance Note:**
-/// This redesigned index stores full tuple values instead of TupleId references
-/// to comply with TTM Proscription 6 (no tuple-level identifiers).
+/// This index provides O(log n) lookup, insertion, and deletion. Multiple
+/// tuples can share the same key value (non-unique index). The index
+/// maintains keys in sorted order, enabling efficient range scans.
 ///
-/// **Design Tradeoffs:**
+/// # TTM Compliance
+///
+/// This index stores full tuple values instead of TupleId references,
+/// complying with TTM Proscription 6 (no tuple-level identifiers).
+/// From the relational perspective, tuples are identified by their
+/// attribute values, not by physical storage locations.
+///
+/// # Design Tradeoffs
+///
 /// - **Memory overhead:** Tuples are duplicated in both heap and indexes
 /// - **Consistency:** Indexes must be updated when heap tuples change (not yet implemented)
 /// - **Benefit:** No exposure of physical storage identifiers; pure value-based indexing
@@ -38,30 +96,101 @@ pub enum BTreeIndexError {
 ///
 /// **Implementation:** Simplified in-memory BTreeMap. Production systems would
 /// implement proper on-disk B-tree with more sophisticated storage strategies.
+///
+/// # Example
+///
+/// ```
+/// use relvar::storage::BTreeIndex;
+/// use relvar::values::ScalarValue;
+/// use relvar::tuple;
+///
+/// let mut index = BTreeIndex::new();
+///
+/// // Index supports duplicate keys
+/// index.insert(ScalarValue::String("Sales".to_string()),
+///              tuple! { id: 1i64, dept: "Sales" });
+/// index.insert(ScalarValue::String("Sales".to_string()),
+///              tuple! { id: 2i64, dept: "Sales" });
+///
+/// // Search returns all matching tuples
+/// let results = index.search(&ScalarValue::String("Sales".to_string())).unwrap();
+/// assert_eq!(results.len(), 2);
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BTreeIndex {
-    /// Map from key value to list of tuples
+    /// Map from key value to list of tuples with that key.
     index: BTreeMap<ScalarValue, Vec<Tuple>>,
 }
 
 impl BTreeIndex {
+    /// Creates a new empty B-tree index.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::storage::BTreeIndex;
+    ///
+    /// let index = BTreeIndex::new();
+    /// assert!(index.is_empty());
+    /// ```
     pub fn new() -> Self {
         Self {
             index: BTreeMap::new(),
         }
     }
 
-    /// Insert a key-tuple pair
+    /// Inserts a key-tuple pair into the index.
+    ///
+    /// Multiple tuples can be associated with the same key. This is useful
+    /// for non-unique indexes (e.g., indexing by department name).
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key value to index by
+    /// * `tuple` - The tuple to associate with this key
     pub fn insert(&mut self, key: ScalarValue, tuple: Tuple) {
         self.index.entry(key).or_default().push(tuple);
     }
 
-    /// Search for a key and return all matching tuples
+    /// Searches for all tuples with the given key.
+    ///
+    /// Returns `None` if no tuples match the key, or `Some(&[Tuple])`
+    /// containing all matching tuples.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key value to search for
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::storage::BTreeIndex;
+    /// use relvar::values::ScalarValue;
+    /// use relvar::tuple;
+    ///
+    /// let mut index = BTreeIndex::new();
+    /// index.insert(ScalarValue::Int(42), tuple! { id: 42i64, name: "Answer" });
+    ///
+    /// assert!(index.search(&ScalarValue::Int(42)).is_some());
+    /// assert!(index.search(&ScalarValue::Int(0)).is_none());
+    /// ```
     pub fn search(&self, key: &ScalarValue) -> Option<&[Tuple]> {
         self.index.get(key).map(|v| v.as_slice())
     }
 
-    /// Remove a specific tuple for a key
+    /// Removes a specific tuple for a key.
+    ///
+    /// If the key has multiple tuples, only the matching tuple is removed.
+    /// If this was the last tuple for the key, the key is also removed.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to look up
+    /// * `tuple` - The specific tuple to remove
+    ///
+    /// # Returns
+    ///
+    /// `true` if the tuple was found and removed, `false` otherwise.
     pub fn remove(&mut self, key: &ScalarValue, tuple: &Tuple) -> bool {
         if let Some(tuples) = self.index.get_mut(key)
             && let Some(pos) = tuples.iter().position(|t| t == tuple)
@@ -75,12 +204,46 @@ impl BTreeIndex {
         false
     }
 
-    /// Delete all entries for a key
+    /// Deletes all entries for a key.
+    ///
+    /// Removes the key and all associated tuples from the index.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to delete
+    ///
+    /// # Returns
+    ///
+    /// `true` if the key existed and was deleted, `false` otherwise.
     pub fn delete(&mut self, key: &ScalarValue) -> bool {
         self.index.remove(key).is_some()
     }
 
-    /// Range scan: find all keys in [start, end]
+    /// Performs a range scan for keys in the inclusive range `[start, end]`.
+    ///
+    /// Returns all (key, tuple) pairs where `start <= key <= end`, in
+    /// sorted order by key.
+    ///
+    /// # Arguments
+    ///
+    /// * `start` - The lower bound of the range (inclusive)
+    /// * `end` - The upper bound of the range (inclusive)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::storage::BTreeIndex;
+    /// use relvar::values::ScalarValue;
+    /// use relvar::tuple;
+    ///
+    /// let mut index = BTreeIndex::new();
+    /// index.insert(ScalarValue::Int(10), tuple! { id: 10i64 });
+    /// index.insert(ScalarValue::Int(20), tuple! { id: 20i64 });
+    /// index.insert(ScalarValue::Int(30), tuple! { id: 30i64 });
+    ///
+    /// let results = index.range_scan(&ScalarValue::Int(15), &ScalarValue::Int(25));
+    /// assert_eq!(results.len(), 1); // Only key 20 is in range
+    /// ```
     pub fn range_scan(&self, start: &ScalarValue, end: &ScalarValue) -> Vec<(ScalarValue, Tuple)> {
         let mut results = Vec::new();
         for (key, tuples) in self.index.range(start.clone()..=end.clone()) {
@@ -96,18 +259,31 @@ impl BTreeIndex {
         results
     }
 
+    /// Returns the number of unique keys in the index.
     pub fn key_count(&self) -> usize {
         self.index.len()
     }
 
+    /// Returns the total number of tuple entries in the index.
+    ///
+    /// This may be larger than `key_count()` if keys have multiple tuples.
     pub fn entry_count(&self) -> usize {
         self.index.values().map(|v| v.len()).sum()
     }
 
+    /// Returns `true` if the index contains no entries.
     pub fn is_empty(&self) -> bool {
         self.index.is_empty()
     }
 
+    /// Saves the index to a file.
+    ///
+    /// The index is serialized using bincode and written to the specified path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BTreeIndexError::Io`] if the file cannot be written.
+    /// Returns [`BTreeIndexError::Serialization`] if serialization fails.
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), BTreeIndexError> {
         let contents =
             bincode::serialize(self).map_err(|e| BTreeIndexError::Serialization(e.to_string()))?;
@@ -124,6 +300,14 @@ impl BTreeIndex {
         Ok(())
     }
 
+    /// Loads an index from a file.
+    ///
+    /// If the file is empty, returns an empty index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BTreeIndexError::Io`] if the file cannot be read.
+    /// Returns [`BTreeIndexError::Serialization`] if deserialization fails.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, BTreeIndexError> {
         let mut file = File::open(path)?;
         let mut contents = Vec::new();

--- a/src/storage/catalog.rs
+++ b/src/storage/catalog.rs
@@ -1,3 +1,43 @@
+//! System catalog for database metadata management.
+//!
+//! The catalog stores metadata about all relations in the database, including
+//! their names, types (headings), and storage locations. It serves as the
+//! single source of truth for database schema information.
+//!
+//! # Metadata Storage
+//!
+//! For each relation, the catalog stores:
+//! - **Name** - The unique identifier for the relation
+//! - **RelationType** - The heading (attribute names and types)
+//! - **Heap file path** - Location of the data file on disk
+//!
+//! # Example
+//!
+//! ```no_run
+//! use relvar::storage::Catalog;
+//! use relvar::types::{RelationType, TupleType, ScalarType};
+//! use std::path::PathBuf;
+//!
+//! let mut catalog = Catalog::new();
+//!
+//! // Define relation type
+//! let heading = TupleType::new()
+//!     .with_attribute("id".to_string(), ScalarType::Int)
+//!     .with_attribute("name".to_string(), ScalarType::String);
+//! let rel_type = RelationType::new(heading);
+//!
+//! // Register relation in catalog
+//! catalog.create_relation(
+//!     "employees".to_string(),
+//!     rel_type,
+//!     PathBuf::from("employees.heap"),
+//! ).unwrap();
+//!
+//! // Look up relation metadata
+//! let metadata = catalog.get_relation("employees").unwrap();
+//! assert_eq!(metadata.name, "employees");
+//! ```
+
 use crate::types::RelationType;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -6,41 +46,116 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
+/// Errors that can occur during catalog operations.
 #[derive(Debug, Error)]
 pub enum CatalogError {
+    /// An I/O error occurred while reading or writing the catalog.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// Serialization or deserialization of the catalog failed.
     #[error("Serialization error: {0}")]
     Serialization(String),
+
+    /// The requested relation was not found in the catalog.
     #[error("Relation '{0}' not found")]
     RelationNotFound(String),
+
+    /// A relation with this name already exists.
     #[error("Relation '{0}' already exists")]
     RelationExists(String),
 }
 
-/// Metadata for a stored relation
+/// Metadata for a stored relation (relvar).
+///
+/// Contains all the information needed to locate and interpret a relation's
+/// data on disk.
+///
+/// # Fields
+///
+/// - `name` - The unique name identifying this relation
+/// - `relation_type` - The type (heading) defining attribute names and types
+/// - `heap_file_path` - Path to the heap file containing the relation's tuples
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelationMetadata {
+    /// The unique name of the relation.
     pub name: String,
+    /// The relation's type (heading).
     pub relation_type: RelationType,
+    /// Path to the heap file storing the relation's data.
     pub heap_file_path: PathBuf,
 }
 
-/// System catalog stores metadata about all relations in the database
+/// The system catalog storing metadata for all relations in the database.
+///
+/// The catalog is the central registry for relation metadata. It maintains
+/// a mapping from relation names to their metadata (type and storage location).
+///
+/// # Persistence
+///
+/// The catalog can be saved to and loaded from a JSON file for persistence
+/// across database restarts.
+///
+/// # Example
+///
+/// ```no_run
+/// use relvar::storage::Catalog;
+/// use relvar::types::{RelationType, TupleType, ScalarType};
+/// use std::path::PathBuf;
+///
+/// // Create and populate catalog
+/// let mut catalog = Catalog::new();
+///
+/// let emp_type = RelationType::new(
+///     TupleType::new()
+///         .with_attribute("id".to_string(), ScalarType::Int)
+///         .with_attribute("name".to_string(), ScalarType::String)
+/// );
+///
+/// catalog.create_relation(
+///     "employees".to_string(),
+///     emp_type,
+///     PathBuf::from("data/employees.heap"),
+/// ).unwrap();
+///
+/// // Save to disk
+/// catalog.save("catalog.json").unwrap();
+///
+/// // Later: load from disk
+/// let loaded = Catalog::load("catalog.json").unwrap();
+/// assert!(loaded.relation_exists("employees"));
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Catalog {
+    /// Map from relation name to metadata.
     relations: HashMap<String, RelationMetadata>,
 }
 
 impl Catalog {
-    /// Create a new empty catalog
+    /// Creates a new empty catalog.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::storage::Catalog;
+    ///
+    /// let catalog = Catalog::new();
+    /// assert_eq!(catalog.relation_count(), 0);
+    /// ```
     pub fn new() -> Self {
         Self {
             relations: HashMap::new(),
         }
     }
 
-    /// Load catalog from a file
+    /// Loads a catalog from a JSON file.
+    ///
+    /// If the file is empty, returns an empty catalog.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::Io`] if the file cannot be read.
+    /// Returns [`CatalogError::Serialization`] if the JSON is invalid.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, CatalogError> {
         let mut file = File::open(path)?;
         let mut contents = String::new();
@@ -53,7 +168,14 @@ impl Catalog {
         serde_json::from_str(&contents).map_err(|e| CatalogError::Serialization(e.to_string()))
     }
 
-    /// Save catalog to a file
+    /// Saves the catalog to a JSON file.
+    ///
+    /// The file is written in pretty-printed JSON format for readability.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::Io`] if the file cannot be written.
+    /// Returns [`CatalogError::Serialization`] if serialization fails.
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), CatalogError> {
         let contents = serde_json::to_string_pretty(self)
             .map_err(|e| CatalogError::Serialization(e.to_string()))?;
@@ -70,7 +192,18 @@ impl Catalog {
         Ok(())
     }
 
-    /// Register a new relation
+    /// Registers a new relation in the catalog.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Unique name for the relation
+    /// * `relation_type` - The relation's type (heading)
+    /// * `heap_file_path` - Path where the relation's data will be stored
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::RelationExists`] if a relation with this
+    /// name already exists.
     pub fn create_relation(
         &mut self,
         name: String,
@@ -91,31 +224,50 @@ impl Catalog {
         Ok(())
     }
 
-    /// Get metadata for a relation
+    /// Retrieves metadata for a relation by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::RelationNotFound`] if no relation with
+    /// this name exists.
     pub fn get_relation(&self, name: &str) -> Result<&RelationMetadata, CatalogError> {
         self.relations
             .get(name)
             .ok_or_else(|| CatalogError::RelationNotFound(name.to_string()))
     }
 
-    /// Check if a relation exists
+    /// Checks if a relation with the given name exists.
     pub fn relation_exists(&self, name: &str) -> bool {
         self.relations.contains_key(name)
     }
 
-    /// Drop a relation
+    /// Removes a relation from the catalog.
+    ///
+    /// This only removes the catalog entry; it does not delete the data file.
+    ///
+    /// # Returns
+    ///
+    /// The removed relation's metadata, so the caller can clean up the
+    /// data file if desired.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::RelationNotFound`] if no relation with
+    /// this name exists.
     pub fn drop_relation(&mut self, name: &str) -> Result<RelationMetadata, CatalogError> {
         self.relations
             .remove(name)
             .ok_or_else(|| CatalogError::RelationNotFound(name.to_string()))
     }
 
-    /// List all relation names
+    /// Returns a list of all relation names in the catalog.
+    ///
+    /// The order of names is not guaranteed (hash map iteration order).
     pub fn list_relations(&self) -> Vec<String> {
         self.relations.keys().cloned().collect()
     }
 
-    /// Get the number of relations
+    /// Returns the number of relations in the catalog.
     pub fn relation_count(&self) -> usize {
         self.relations.len()
     }

--- a/src/storage/heap.rs
+++ b/src/storage/heap.rs
@@ -35,22 +35,76 @@ pub(crate) struct TupleId {
     pub(crate) slot: u32,
 }
 
+/// Errors that can occur during heap file operations.
 #[derive(Debug, Error)]
 pub enum HeapError {
+    /// An error occurred at the page layer.
     #[error("Page error: {0}")]
     Page(#[from] PageError),
+
+    /// Tuple serialization or deserialization failed.
     #[error("Serialization error: {0}")]
     Serialization(String),
+
+    /// The requested tuple was not found.
+    /// Physical details (page_id, slot) hidden per TTM Proscription 6.
     #[error("Tuple not found")]
-    TupleNotFound, // Physical details (page_id, slot) hidden per TTM Proscription 6
+    TupleNotFound,
+
+    /// The page has insufficient space for the tuple.
     #[error("Page full")]
     PageFull,
 }
 
-/// Heap file stores tuples in an unordered collection of pages.
-/// Each page contains a slot directory and tuple data.
+/// Stores tuples in an unordered collection of slotted pages.
+///
+/// A heap file is the primary storage structure for relation tuples. Tuples
+/// are stored in pages without any particular ordering. Each page uses a
+/// slotted page format with a slot directory at the beginning and tuple
+/// data growing from the end.
+///
+/// # Page Layout
+///
+/// ```text
+/// ┌─────────────────────────────────────────────────────────────┐
+/// │ slot_count │ slot[0] │ slot[1] │ ... │ free space │ tuples  │
+/// └─────────────────────────────────────────────────────────────┘
+/// ```
+///
+/// # TTM Compliance
+///
+/// This struct carefully maintains TTM Proscription 6 compliance:
+/// - `insert_tuple()` returns `Result<(), HeapError>` (no TupleId)
+/// - `scan()` returns `Vec<Tuple>` (no TupleId)
+/// - `read_tuple(TupleId)` is `pub(crate)` (internal only)
+///
+/// # Example
+///
+/// ```no_run
+/// use relvar::storage::HeapFile;
+/// use relvar::types::{RelationType, TupleType, ScalarType};
+/// use relvar::tuple;
+///
+/// // Create heap file
+/// let heading = TupleType::new()
+///     .with_attribute("id".to_string(), ScalarType::Int)
+///     .with_attribute("name".to_string(), ScalarType::String);
+/// let rel_type = RelationType::new(heading);
+///
+/// let mut heap = HeapFile::create("employees.heap", rel_type).unwrap();
+///
+/// // Insert tuples
+/// heap.insert_tuple(&tuple! { id: 1i64, name: "Alice" }).unwrap();
+/// heap.insert_tuple(&tuple! { id: 2i64, name: "Bob" }).unwrap();
+///
+/// // Scan all tuples
+/// let tuples = heap.scan().unwrap();
+/// assert_eq!(tuples.len(), 2);
+/// ```
 pub struct HeapFile {
+    /// The underlying page file for storage.
     page_file: PageFile,
+    /// The type of tuples stored in this heap file.
     relation_type: RelationType,
 }
 
@@ -69,7 +123,16 @@ struct SlottedPage {
 }
 
 impl HeapFile {
-    /// Create a new heap file
+    /// Creates a new heap file, truncating any existing file.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path where the heap file will be created
+    /// * `relation_type` - The type of tuples that will be stored
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HeapError::Page`] if the file cannot be created.
     pub fn create<P: AsRef<Path>>(path: P, relation_type: RelationType) -> Result<Self, HeapError> {
         let page_file = PageFile::create(path)?;
         Ok(Self {
@@ -78,7 +141,18 @@ impl HeapFile {
         })
     }
 
-    /// Open an existing heap file
+    /// Opens an existing heap file, or creates one if it doesn't exist.
+    ///
+    /// Unlike [`create`](Self::create), this preserves existing data.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the heap file
+    /// * `relation_type` - The type of tuples stored in this heap file
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HeapError::Page`] if the file cannot be opened.
     pub fn open<P: AsRef<Path>>(path: P, relation_type: RelationType) -> Result<Self, HeapError> {
         let page_file = PageFile::open(path)?;
         Ok(Self {
@@ -87,7 +161,24 @@ impl HeapFile {
         })
     }
 
-    /// Insert a tuple into the heap file
+    /// Inserts a tuple into the heap file.
+    ///
+    /// The tuple is serialized and stored in the first page with sufficient
+    /// space. If no existing page has room, a new page is allocated.
+    ///
+    /// # TTM Compliance
+    ///
+    /// Returns `Result<(), HeapError>` rather than a TupleId, per TTM
+    /// Proscription 6.
+    ///
+    /// # Arguments
+    ///
+    /// * `tuple` - The tuple to insert
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HeapError::Serialization`] if the tuple cannot be serialized.
+    /// Returns [`HeapError::Page`] if a page I/O error occurs.
     pub fn insert_tuple(&mut self, tuple: &Tuple) -> Result<(), HeapError> {
         // Serialize the tuple
         let tuple_data =
@@ -256,7 +347,25 @@ impl HeapFile {
         Ok(tuple)
     }
 
-    /// Scan all tuples in the heap file
+    /// Scans all tuples in the heap file.
+    ///
+    /// Iterates through all pages and returns every valid tuple. The order
+    /// of tuples is not guaranteed (heap files are unordered).
+    ///
+    /// # TTM Compliance
+    ///
+    /// Returns `Vec<Tuple>` without TupleId, per TTM Proscription 6.
+    ///
+    /// # Performance
+    ///
+    /// This is a full table scan with O(n) complexity where n is the number
+    /// of pages. For large relations, consider using indexes for selective
+    /// queries.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HeapError::Page`] if a page read fails.
+    /// Returns [`HeapError::Serialization`] if tuple deserialization fails.
     pub fn scan(&mut self) -> Result<Vec<Tuple>, HeapError> {
         let mut results = Vec::new();
         let mut page_id = 0;
@@ -308,7 +417,15 @@ impl HeapFile {
         Ok(results)
     }
 
-    /// Load all tuples into a Relation
+    /// Loads all tuples from the heap file into a `Relation`.
+    ///
+    /// This is a convenience method that scans all tuples and constructs
+    /// a [`Relation`] value with the heap file's relation type.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HeapError::Serialization`] if tuples cannot be deserialized
+    /// or if the relation cannot be constructed.
     pub fn load_relation(&mut self) -> Result<Relation, HeapError> {
         let tuples = self.scan()?; // Already returns Vec<Tuple>
 
@@ -316,7 +433,23 @@ impl HeapFile {
             .map_err(|e| HeapError::Serialization(e.to_string()))
     }
 
-    /// Store a relation's tuples into the heap file
+    /// Stores all tuples from a relation into the heap file.
+    ///
+    /// Iterates through the relation's tuples and inserts each one.
+    ///
+    /// # TTM Compliance
+    ///
+    /// Returns `Result<(), HeapError>` (no TupleId vector), per TTM
+    /// Proscription 6.
+    ///
+    /// # Arguments
+    ///
+    /// * `relation` - The relation whose tuples should be stored
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HeapError::Serialization`] if a tuple cannot be serialized.
+    /// Returns [`HeapError::Page`] if a page I/O error occurs.
     pub fn store_relation(&mut self, relation: &Relation) -> Result<(), HeapError> {
         for tuple in relation.tuples() {
             self.insert_tuple(tuple)?;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,3 +1,67 @@
+//! Physical storage layer for persistent data management.
+//!
+//! This module implements the storage subsystem that persists relations to disk.
+//! It provides page-based I/O, heap file storage, B-tree indexing, and a
+//! system catalog for metadata management.
+//!
+//! # Architecture
+//!
+//! The storage layer is organized in three tiers:
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────┐
+//! │                    Catalog                          │
+//! │         (relation metadata & schema)                │
+//! ├─────────────────────┬───────────────────────────────┤
+//! │     HeapFile        │        BTreeIndex             │
+//! │  (tuple storage)    │     (key-value lookup)        │
+//! ├─────────────────────┴───────────────────────────────┤
+//! │                    PageFile                         │
+//! │              (fixed-size page I/O)                  │
+//! └─────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Components
+//!
+//! - `Page` / `PageFile` - Fixed-size page abstraction for disk I/O
+//! - `HeapFile` - Unordered tuple storage with slotted pages
+//! - `BTreeIndex` - Ordered index for efficient key lookups
+//! - `Catalog` - System catalog storing relation metadata
+//!
+//! # TTM Compliance
+//!
+//! This module carefully maintains TTM compliance, particularly Proscription 6:
+//! "The database must not generate or expose tuple-level identifiers."
+//!
+//! - `TupleId` is `pub(crate)` - only visible within the storage layer
+//! - Public APIs return `Tuple` values, not physical addresses
+//! - Callers work with tuples as values, never as storage references
+//!
+//! # Example
+//!
+//! ```no_run
+//! use relvar::storage::{HeapFile, Catalog};
+//! use relvar::types::{RelationType, TupleType, ScalarType};
+//! use relvar::tuple;
+//! use std::path::PathBuf;
+//!
+//! // Define relation type
+//! let heading = TupleType::new()
+//!     .with_attribute("id".to_string(), ScalarType::Int)
+//!     .with_attribute("name".to_string(), ScalarType::String);
+//! let rel_type = RelationType::new(heading);
+//!
+//! // Create heap file for storage
+//! let mut heap = HeapFile::create("employees.heap", rel_type.clone()).unwrap();
+//!
+//! // Insert tuples (no TupleId returned - TTM compliant)
+//! heap.insert_tuple(&tuple! { id: 1i64, name: "Alice" }).unwrap();
+//! heap.insert_tuple(&tuple! { id: 2i64, name: "Bob" }).unwrap();
+//!
+//! // Scan returns tuples without physical identifiers
+//! let tuples = heap.scan().unwrap();
+//! ```
+
 pub mod btree;
 pub mod catalog;
 pub mod heap;

--- a/src/storage/page.rs
+++ b/src/storage/page.rs
@@ -1,37 +1,118 @@
+//! Page-based I/O for fixed-size disk blocks.
+//!
+//! This module provides the lowest-level storage abstraction: fixed-size pages
+//! that serve as the unit of I/O between disk and memory. All higher-level
+//! storage structures (heap files, indexes) are built on top of pages.
+//!
+//! # Page Layout
+//!
+//! Each page on disk has the following format:
+//!
+//! ```text
+//! ┌────────────────────────────────────────────────────┐
+//! │ data_length (8 bytes, little-endian u64)           │
+//! ├────────────────────────────────────────────────────┤
+//! │ actual_data (variable, up to PAGE_SIZE - 8 bytes)  │
+//! ├────────────────────────────────────────────────────┤
+//! │ padding (zeros to fill PAGE_SIZE)                  │
+//! └────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Example
+//!
+//! ```no_run
+//! use relvar::storage::{Page, PageFile, PAGE_SIZE};
+//!
+//! // Create a page file
+//! let mut pf = PageFile::create("data.pages").unwrap();
+//!
+//! // Create and write a page
+//! let page = Page::from_data(0, vec![1, 2, 3, 4, 5]).unwrap();
+//! pf.write_page(&page).unwrap();
+//!
+//! // Read it back
+//! let loaded = pf.read_page(0).unwrap();
+//! assert_eq!(loaded.data(), &[1, 2, 3, 4, 5]);
+//! ```
+
 use serde::{Deserialize, Serialize};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use thiserror::Error;
 
-/// Page size in bytes (4KB is a common choice)
+/// Page size in bytes (4KB).
+///
+/// This is a common page size that balances I/O efficiency with memory usage.
+/// Larger pages reduce I/O overhead but may waste space for small tuples.
 pub const PAGE_SIZE: usize = 4096;
 
-/// Page ID type
+/// Unique identifier for a page within a page file.
+///
+/// Pages are numbered sequentially starting from 0. The page ID determines
+/// the byte offset in the file: `offset = page_id * PAGE_SIZE`.
 pub type PageId = u64;
 
+/// Errors that can occur during page operations.
 #[derive(Debug, Error)]
 pub enum PageError {
+    /// An I/O error occurred while reading or writing.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// Serialization or deserialization failed.
     #[error("Serialization error: {0}")]
     Serialization(String),
+
+    /// The page data exceeds the maximum allowed size.
     #[error("Page data exceeds maximum size")]
     PageTooLarge,
 }
 
-/// A page is a fixed-size block of data stored on disk.
-/// Pages are the unit of I/O between disk and memory.
+/// A fixed-size block of data stored on disk.
+///
+/// Pages are the fundamental unit of I/O between disk and memory. Each page
+/// has a unique ID and can hold up to [`PAGE_SIZE`] bytes of data. The actual
+/// data is stored along with its length to handle variable-size content.
+///
+/// # Example
+///
+/// ```
+/// use relvar::storage::{Page, PAGE_SIZE};
+///
+/// // Create an empty page
+/// let mut page = Page::new(0);
+/// assert!(page.is_empty());
+/// assert_eq!(page.available_space(), PAGE_SIZE);
+///
+/// // Create a page with data
+/// let page = Page::from_data(1, vec![1, 2, 3, 4, 5]).unwrap();
+/// assert_eq!(page.data().len(), 5);
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Page {
-    /// Page identifier
+    /// Page identifier.
     id: PageId,
-    /// Raw page data (up to PAGE_SIZE bytes)
+    /// Raw page data (up to PAGE_SIZE bytes).
     data: Vec<u8>,
 }
 
 impl Page {
-    /// Create a new empty page
+    /// Creates a new empty page with the given ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The unique identifier for this page
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::storage::Page;
+    ///
+    /// let page = Page::new(0);
+    /// assert_eq!(page.id(), 0);
+    /// assert!(page.is_empty());
+    /// ```
     pub fn new(id: PageId) -> Self {
         Self {
             id,
@@ -39,7 +120,26 @@ impl Page {
         }
     }
 
-    /// Create a page from data
+    /// Creates a page with the given ID and data.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The unique identifier for this page
+    /// * `data` - The data to store in the page
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PageError::PageTooLarge`] if `data.len() > PAGE_SIZE`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::storage::Page;
+    ///
+    /// let page = Page::from_data(42, vec![1, 2, 3]).unwrap();
+    /// assert_eq!(page.id(), 42);
+    /// assert_eq!(page.data(), &[1, 2, 3]);
+    /// ```
     pub fn from_data(id: PageId, data: Vec<u8>) -> Result<Self, PageError> {
         if data.len() > PAGE_SIZE {
             return Err(PageError::PageTooLarge);
@@ -47,17 +147,21 @@ impl Page {
         Ok(Self { id, data })
     }
 
-    /// Get page ID
+    /// Returns the page's unique identifier.
     pub fn id(&self) -> PageId {
         self.id
     }
 
-    /// Get page data
+    /// Returns a reference to the page's data.
     pub fn data(&self) -> &[u8] {
         &self.data
     }
 
-    /// Set page data
+    /// Replaces the page's data.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PageError::PageTooLarge`] if `data.len() > PAGE_SIZE`.
     pub fn set_data(&mut self, data: Vec<u8>) -> Result<(), PageError> {
         if data.len() > PAGE_SIZE {
             return Err(PageError::PageTooLarge);
@@ -66,24 +170,67 @@ impl Page {
         Ok(())
     }
 
-    /// Get available space in the page
+    /// Returns the number of bytes available in this page.
+    ///
+    /// This is `PAGE_SIZE - data.len()`.
     pub fn available_space(&self) -> usize {
         PAGE_SIZE - self.data.len()
     }
 
-    /// Check if the page is empty
+    /// Returns `true` if the page contains no data.
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
 }
 
-/// Page file manages pages on disk
+/// Manages fixed-size pages stored in a file on disk.
+///
+/// `PageFile` provides random access to pages by their ID. Pages are stored
+/// at fixed offsets (`page_id * PAGE_SIZE`), allowing efficient seek-based
+/// access without scanning the entire file.
+///
+/// # File Format
+///
+/// The file consists of consecutive PAGE_SIZE blocks:
+///
+/// ```text
+/// Offset 0:                 Page 0
+/// Offset PAGE_SIZE:         Page 1
+/// Offset 2*PAGE_SIZE:       Page 2
+/// ...
+/// ```
+///
+/// # Example
+///
+/// ```no_run
+/// use relvar::storage::{Page, PageFile};
+///
+/// // Create a new page file
+/// let mut pf = PageFile::create("data.pages").unwrap();
+///
+/// // Write pages (can write in any order)
+/// pf.write_page(&Page::from_data(0, vec![1, 2, 3]).unwrap()).unwrap();
+/// pf.write_page(&Page::from_data(5, vec![4, 5, 6]).unwrap()).unwrap();
+///
+/// // Read pages back
+/// let page0 = pf.read_page(0).unwrap();
+/// let page5 = pf.read_page(5).unwrap();
+/// ```
 pub struct PageFile {
+    /// The underlying file handle.
     file: File,
 }
 
 impl PageFile {
-    /// Create a new page file
+    /// Creates a new page file, truncating any existing file.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path where the page file will be created
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PageError::Io`] if the file cannot be created.
     pub fn create<P: AsRef<Path>>(path: P) -> Result<Self, PageError> {
         let file = OpenOptions::new()
             .read(true)
@@ -94,7 +241,17 @@ impl PageFile {
         Ok(Self { file })
     }
 
-    /// Open an existing page file
+    /// Opens an existing page file, or creates one if it doesn't exist.
+    ///
+    /// Unlike [`create`](Self::create), this preserves existing content.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the page file
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PageError::Io`] if the file cannot be opened.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, PageError> {
         let file = OpenOptions::new()
             .read(true)
@@ -105,7 +262,18 @@ impl PageFile {
         Ok(Self { file })
     }
 
-    /// Read a page from disk
+    /// Reads a page from disk.
+    ///
+    /// Seeks to the page's offset (`page_id * PAGE_SIZE`) and reads the data.
+    /// If the page doesn't exist or is unreadable, returns an empty page.
+    ///
+    /// # Arguments
+    ///
+    /// * `page_id` - The ID of the page to read
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PageError::Io`] if the read fails.
     pub fn read_page(&mut self, page_id: PageId) -> Result<Page, PageError> {
         // Seek to the page offset
         let offset = page_id * PAGE_SIZE as u64;
@@ -132,7 +300,18 @@ impl PageFile {
         Ok(Page::new(page_id))
     }
 
-    /// Write a page to disk
+    /// Writes a page to disk.
+    ///
+    /// The page is written at offset `page.id() * PAGE_SIZE`. The data is
+    /// prefixed with its length and padded to fill exactly PAGE_SIZE bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `page` - The page to write
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PageError::Io`] if the write fails.
     pub fn write_page(&mut self, page: &Page) -> Result<(), PageError> {
         // Seek to the page offset
         let offset = page.id() * PAGE_SIZE as u64;
@@ -160,7 +339,13 @@ impl PageFile {
         Ok(())
     }
 
-    /// Flush all changes to disk
+    /// Flushes all pending writes to disk.
+    ///
+    /// Ensures durability by calling `fsync` on the underlying file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PageError::Io`] if the sync fails.
     pub fn sync(&mut self) -> Result<(), PageError> {
         self.file.sync_all()?;
         Ok(())

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,47 @@
+//! Type system for the relational model.
+//!
+//! This module defines the type hierarchy used throughout Relvar:
+//!
+//! - `ScalarType` - Primitive and user-defined scalar types
+//! - `TupleType` - A heading (set of attribute name-type pairs)
+//! - `RelationType` - The type of a relation (defined by its heading)
+//!
+//! # Type Hierarchy
+//!
+//! ```text
+//! ScalarType          -- Primitive types (Int, Float, String, Bool, Bytes)
+//!    │                   or user-defined types (POSSREP pattern)
+//!    │                   or relation-valued attributes
+//!    v
+//! TupleType           -- A set of (attribute_name, ScalarType) pairs
+//!    │                   This is the "heading" in relational terminology
+//!    v
+//! RelationType        -- Wraps a TupleType as the type of a relation
+//! ```
+//!
+//! # TTM Compliance
+//!
+//! - **Prescription 1**: User-defined scalar types via POSSREP pattern
+//! - **Proscription 4**: No attribute ordering (attributes identified by name)
+//! - Type equality is structural, not physical
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{ScalarType, TupleType, RelationType};
+//!
+//! // Define a tuple type (heading)
+//! let employee_heading = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String)
+//!     .with_attribute("salary", ScalarType::Float);
+//!
+//! // Create a relation type from the heading
+//! let employee_type = RelationType::new(employee_heading);
+//!
+//! assert_eq!(employee_type.degree(), 3);
+//! ```
+
 pub mod relation_type;
 pub mod scalar;
 pub mod tuple_type;

--- a/src/types/relation_type.rs
+++ b/src/types/relation_type.rs
@@ -1,35 +1,171 @@
+//! Relation types for the relational model.
+//!
+//! A relation type defines the structure of a relation. It consists of a
+//! heading (tuple type) that specifies the attributes all tuples in the
+//! relation must have.
+//!
+//! # TTM Compliance
+//!
+//! - A relation is a set of tuples all of the same type
+//! - The relation type is determined solely by its heading
+//! - Type compatibility for set operations requires identical headings
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{RelationType, TupleType, ScalarType};
+//!
+//! let employee_heading = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String);
+//!
+//! let employee_type = RelationType::new(employee_heading);
+//!
+//! assert_eq!(employee_type.degree(), 2);
+//! assert!(employee_type.has_attribute("emp_id"));
+//! ```
+
 use crate::types::TupleType;
 use serde::{Deserialize, Serialize};
 
-/// Relation type is defined by its heading, which is a tuple type.
-/// Per Date's relational model, a relation is a set of tuples all of the same type.
+/// Defines the type of a relation.
+///
+/// A `RelationType` specifies what attributes a relation contains and their
+/// types. All tuples in a relation must conform to the relation's type.
+///
+/// The relation type is defined entirely by its "heading" - the tuple type
+/// that describes the structure of its tuples.
+///
+/// # Type Compatibility
+///
+/// Two relations are type-compatible if and only if they have the same
+/// relation type (identical headings). This is required for set operations
+/// like union, intersection, and difference.
+///
+/// # Example
+///
+/// ```
+/// use relvar::types::{RelationType, TupleType, ScalarType};
+///
+/// // Define a relation type for employees
+/// let heading = TupleType::new()
+///     .with_attribute("emp_id", ScalarType::Int)
+///     .with_attribute("name", ScalarType::String)
+///     .with_attribute("dept_id", ScalarType::Int);
+///
+/// let employee_type = RelationType::new(heading);
+///
+/// // Query the type
+/// assert_eq!(employee_type.degree(), 3);
+/// assert!(employee_type.has_attribute("emp_id"));
+/// assert!(!employee_type.has_attribute("salary"));
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct RelationType {
+    /// The heading (tuple type) that defines this relation type.
     heading: TupleType,
 }
 
 impl RelationType {
-    /// Create a new relation type from a tuple type (heading)
+    /// Creates a new relation type from a tuple type (heading).
+    ///
+    /// The heading specifies the attributes that all tuples in relations
+    /// of this type must have.
+    ///
+    /// # Arguments
+    ///
+    /// * `heading` - The tuple type defining the relation's structure
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{RelationType, TupleType, ScalarType};
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let rel_type = RelationType::new(heading);
+    /// ```
     pub fn new(heading: TupleType) -> Self {
         Self { heading }
     }
 
-    /// Get the heading (tuple type) of this relation
+    /// Returns the heading (tuple type) of this relation type.
+    ///
+    /// The heading defines what attributes tuples in this relation must have.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{RelationType, TupleType, ScalarType};
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let rel_type = RelationType::new(heading.clone());
+    /// assert_eq!(rel_type.heading(), &heading);
+    /// ```
     pub fn heading(&self) -> &TupleType {
         &self.heading
     }
 
-    /// Get the degree (number of attributes)
+    /// Returns the degree (number of attributes) of this relation type.
+    ///
+    /// This is equivalent to `self.heading().degree()`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{RelationType, TupleType, ScalarType};
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("a", ScalarType::Int)
+    ///     .with_attribute("b", ScalarType::Int);
+    ///
+    /// let rel_type = RelationType::new(heading);
+    /// assert_eq!(rel_type.degree(), 2);
+    /// ```
     pub fn degree(&self) -> usize {
         self.heading.degree()
     }
 
-    /// Get the tuple type (heading)
+    /// Returns the tuple type (heading) of this relation type.
+    ///
+    /// This is an alias for [`heading()`](Self::heading).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{RelationType, TupleType, ScalarType};
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let rel_type = RelationType::new(heading.clone());
+    /// assert_eq!(rel_type.tuple_type(), &heading);
+    /// ```
     pub fn tuple_type(&self) -> &TupleType {
         &self.heading
     }
 
-    /// Check if an attribute exists in the heading
+    /// Checks whether an attribute with the given name exists in the heading.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The attribute name to check
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{RelationType, TupleType, ScalarType};
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let rel_type = RelationType::new(heading);
+    /// assert!(rel_type.has_attribute("id"));
+    /// assert!(!rel_type.has_attribute("name"));
+    /// ```
     pub fn has_attribute(&self, name: &str) -> bool {
         self.heading.has_attribute(name)
     }

--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -1,37 +1,148 @@
+//! Scalar types for the relational model.
+//!
+//! This module defines [`ScalarType`], which represents the atomic types that
+//! can appear as attribute values in tuples. It includes built-in types
+//! (Int, Float, String, Bool, Bytes) and user-defined types.
+//!
+//! # TTM Compliance
+//!
+//! - **Prescription 1**: User-defined scalar types are supported via the POSSREP
+//!   (possible representation) pattern
+//! - Type identity is determined by name, not representation
+//! - Built-in types provide the foundation for user-defined types
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::ScalarType;
+//!
+//! // Built-in types
+//! let int_type = ScalarType::Int;
+//! let string_type = ScalarType::String;
+//!
+//! // User-defined types with distinct identity
+//! let widget_id = ScalarType::user_defined("WidgetId", ScalarType::Int);
+//! let supplier_id = ScalarType::user_defined("SupplierId", ScalarType::Int);
+//!
+//! // Same representation, but different types!
+//! assert_ne!(widget_id, supplier_id);
+//! ```
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// Errors related to user-defined type operations
+/// Errors that can occur during scalar type operations.
 #[derive(Debug, Error)]
 pub enum ScalarTypeError {
+    /// A value's type doesn't match the expected type.
+    ///
+    /// This typically occurs when using a selector with a value of the
+    /// wrong representation type.
     #[error("Type mismatch: expected {expected}, got {actual}")]
-    TypeMismatch { expected: String, actual: String },
+    TypeMismatch {
+        /// The expected type name.
+        expected: String,
+        /// The actual type name of the provided value.
+        actual: String,
+    },
 }
 
-/// Scalar type representation per Date's relational model.
-/// Types are identified by name and support equality comparison.
+/// Represents a scalar (atomic) type in the relational model.
 ///
-/// TTM Prescription 1: The system must allow users to define their own scalar types.
-/// This is implemented via the UserDefined variant which supports the POSSREP pattern.
+/// Scalar types are the building blocks of the type system. Each attribute
+/// in a tuple has a scalar type that defines what values it can hold.
+///
+/// # Built-in Types
+///
+/// - [`Int`](ScalarType::Int) - 64-bit signed integer
+/// - [`Float`](ScalarType::Float) - 64-bit floating point
+/// - [`String`](ScalarType::String) - UTF-8 string
+/// - [`Bool`](ScalarType::Bool) - Boolean (true/false)
+/// - [`Bytes`](ScalarType::Bytes) - Arbitrary byte sequence
+///
+/// # Advanced Types
+///
+/// - [`Relation`](ScalarType::Relation) - Nested relation (relation-valued attribute)
+/// - [`UserDefined`](ScalarType::UserDefined) - Custom type with POSSREP pattern
+///
+/// # TTM Prescription 1
+///
+/// Users can define their own scalar types using the POSSREP (possible
+/// representation) pattern. A user-defined type has:
+///
+/// - A **name** that provides type identity
+/// - A **representation** type for storage
+///
+/// Two user-defined types with the same representation but different names
+/// are considered distinct types.
+///
+/// # Example
+///
+/// ```
+/// use relvar::types::ScalarType;
+///
+/// // Built-in types
+/// let age_type = ScalarType::Int;
+/// let name_type = ScalarType::String;
+///
+/// // User-defined type for type safety
+/// let employee_id = ScalarType::user_defined("EmployeeId", ScalarType::Int);
+/// let department_id = ScalarType::user_defined("DepartmentId", ScalarType::Int);
+///
+/// // These are different types despite same representation
+/// assert_ne!(employee_id, department_id);
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum ScalarType {
-    /// 64-bit signed integer
+    /// 64-bit signed integer.
+    ///
+    /// Corresponds to Rust's `i64` type.
     Int,
-    /// 64-bit floating point
+
+    /// 64-bit floating point number.
+    ///
+    /// Corresponds to Rust's `f64` type.
     Float,
-    /// UTF-8 string
+
+    /// UTF-8 encoded string.
+    ///
+    /// Corresponds to Rust's `String` type.
     String,
-    /// Boolean value
+
+    /// Boolean value (true or false).
+    ///
+    /// Corresponds to Rust's `bool` type.
     Bool,
-    /// Arbitrary bytes
+
+    /// Arbitrary byte sequence.
+    ///
+    /// Corresponds to Rust's `Vec<u8>` type.
     Bytes,
-    /// Relation-valued attribute type
+
+    /// Relation-valued attribute (RVA) type.
+    ///
+    /// Contains a nested relation, enabling hierarchical data modeling.
+    /// The boxed `RelationType` specifies the heading of the nested relation.
     Relation(Box<crate::types::RelationType>),
-    /// User-defined type with a name and base representation type.
-    /// TTM: This implements POSSREP (possible representation) pattern.
-    /// The name provides type identity, the representation provides storage.
+
+    /// User-defined scalar type.
+    ///
+    /// Implements the POSSREP (possible representation) pattern from TTM.
+    /// The type has a unique name (providing type identity) and a base
+    /// representation type (defining storage and valid values).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::ScalarType;
+    ///
+    /// let currency = ScalarType::user_defined("Currency", ScalarType::Float);
+    /// assert_eq!(currency.name(), "Currency");
+    /// ```
     UserDefined {
+        /// The unique name identifying this type.
         name: String,
+        /// The underlying representation type.
         representation: Box<ScalarType>,
     },
 }

--- a/src/types/tuple_type.rs
+++ b/src/types/tuple_type.rs
@@ -1,51 +1,224 @@
+//! Tuple types (headings) for the relational model.
+//!
+//! A tuple type, also called a "heading" in relational terminology, defines
+//! the structure of tuples in a relation. It is a set of attribute definitions,
+//! where each attribute has a name and a scalar type.
+//!
+//! # TTM Compliance
+//!
+//! - **Proscription 4**: Attributes have no ordering (identified by name only)
+//! - Attribute names must be unique within a tuple type
+//! - Type equality is structural (same attributes = same type)
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, ScalarType};
+//!
+//! let employee_type = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String)
+//!     .with_attribute("salary", ScalarType::Float);
+//!
+//! assert_eq!(employee_type.degree(), 3);
+//! assert!(employee_type.has_attribute("emp_id"));
+//! ```
+
 use crate::types::ScalarType;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-/// Tuple type is defined by a set of (attribute_name, type) pairs.
-/// Per Date's relational model, attributes have no ordering.
-/// We use BTreeMap for deterministic iteration.
+/// Defines the structure (heading) of tuples.
+///
+/// A `TupleType` represents the set of attributes that tuples of this type
+/// must have. Each attribute has a unique name and a scalar type. This is
+/// called a "heading" in relational terminology.
+///
+/// # Attribute Ordering
+///
+/// Per TTM Proscription 4, attributes have no inherent ordering. They are
+/// identified solely by name. The implementation uses `BTreeMap` internally
+/// for deterministic iteration, but this ordering should not be relied upon
+/// for semantic purposes.
+///
+/// # Type Equality
+///
+/// Two tuple types are equal if and only if they have the same set of
+/// attributes (same names with same types). The order in which attributes
+/// were added does not affect equality.
+///
+/// # Example
+///
+/// ```
+/// use relvar::types::{TupleType, ScalarType};
+///
+/// // Create a tuple type with the builder pattern
+/// let person_type = TupleType::new()
+///     .with_attribute("id", ScalarType::Int)
+///     .with_attribute("name", ScalarType::String)
+///     .with_attribute("active", ScalarType::Bool);
+///
+/// // Query the type
+/// assert_eq!(person_type.degree(), 3);
+/// assert_eq!(person_type.get_attribute_type("id"), Some(&ScalarType::Int));
+/// assert!(!person_type.has_attribute("nonexistent"));
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct TupleType {
-    /// Attributes of this tuple type, mapping attribute names to their types
+    /// The attributes of this tuple type, mapping names to scalar types.
     attributes: BTreeMap<String, ScalarType>,
 }
 
 impl TupleType {
-    /// Create a new empty tuple type
+    /// Creates a new empty tuple type.
+    ///
+    /// An empty tuple type (degree 0) is valid and represents the type of
+    /// tuples with no attributes. Such tuples are called "0-tuples" or
+    /// "nullary tuples".
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::TupleType;
+    ///
+    /// let empty_type = TupleType::new();
+    /// assert_eq!(empty_type.degree(), 0);
+    /// ```
     pub fn new() -> Self {
         Self {
             attributes: BTreeMap::new(),
         }
     }
 
-    /// Add an attribute to the tuple type
+    /// Adds an attribute to this tuple type.
+    ///
+    /// This is a builder-style method that returns `self` for chaining.
+    /// If an attribute with the same name already exists, it will be
+    /// overwritten with the new type.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The attribute name (must be unique within the tuple type)
+    /// * `ty` - The scalar type of the attribute
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, ScalarType};
+    ///
+    /// let person_type = TupleType::new()
+    ///     .with_attribute("name", ScalarType::String)
+    ///     .with_attribute("age", ScalarType::Int);
+    ///
+    /// assert_eq!(person_type.degree(), 2);
+    /// ```
     pub fn with_attribute(mut self, name: impl Into<String>, ty: ScalarType) -> Self {
         self.attributes.insert(name.into(), ty);
         self
     }
 
-    /// Get the type of an attribute by name
+    /// Gets the type of an attribute by name.
+    ///
+    /// Returns `None` if no attribute with the given name exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The attribute name to look up
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, ScalarType};
+    ///
+    /// let tuple_type = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// assert_eq!(tuple_type.get_attribute_type("id"), Some(&ScalarType::Int));
+    /// assert_eq!(tuple_type.get_attribute_type("nonexistent"), None);
+    /// ```
     pub fn get_attribute_type(&self, name: &str) -> Option<&ScalarType> {
         self.attributes.get(name)
     }
 
-    /// Check if an attribute exists
+    /// Checks whether an attribute with the given name exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The attribute name to check
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, ScalarType};
+    ///
+    /// let tuple_type = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// assert!(tuple_type.has_attribute("id"));
+    /// assert!(!tuple_type.has_attribute("other"));
+    /// ```
     pub fn has_attribute(&self, name: &str) -> bool {
         self.attributes.contains_key(name)
     }
 
-    /// Get all attribute names
+    /// Returns an iterator over all attribute names.
+    ///
+    /// The order of iteration is deterministic (sorted by name) but should
+    /// not be relied upon for semantic purposes per TTM Proscription 4.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, ScalarType};
+    ///
+    /// let tuple_type = TupleType::new()
+    ///     .with_attribute("b", ScalarType::Int)
+    ///     .with_attribute("a", ScalarType::Int);
+    ///
+    /// let names: Vec<_> = tuple_type.attribute_names().collect();
+    /// assert_eq!(names.len(), 2);
+    /// ```
     pub fn attribute_names(&self) -> impl Iterator<Item = &String> {
         self.attributes.keys()
     }
 
-    /// Get the number of attributes (degree)
+    /// Returns the degree (number of attributes) of this tuple type.
+    ///
+    /// The degree is the count of distinct attributes in the heading.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, ScalarType};
+    ///
+    /// let tuple_type = TupleType::new()
+    ///     .with_attribute("a", ScalarType::Int)
+    ///     .with_attribute("b", ScalarType::Int)
+    ///     .with_attribute("c", ScalarType::Int);
+    ///
+    /// assert_eq!(tuple_type.degree(), 3);
+    /// ```
     pub fn degree(&self) -> usize {
         self.attributes.len()
     }
 
-    /// Get all attributes
+    /// Returns a reference to the underlying attribute map.
+    ///
+    /// This provides access to all attribute definitions as a map from
+    /// names to types.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, ScalarType};
+    ///
+    /// let tuple_type = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// for (name, scalar_type) in tuple_type.attributes() {
+    ///     println!("{}: {:?}", name, scalar_type);
+    /// }
+    /// ```
     pub fn attributes(&self) -> &BTreeMap<String, ScalarType> {
         &self.attributes
     }

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -1,3 +1,61 @@
+//! Runtime values for the relational model.
+//!
+//! This module defines the value types used at runtime:
+//!
+//! - `ScalarValue` - An atomic value (Int, Float, String, Bool, Bytes, or user-defined)
+//! - `Tuple` - A set of attribute-value pairs conforming to a tuple type
+//! - `Relation` - A set of tuples conforming to a relation type
+//!
+//! # Value Hierarchy
+//!
+//! ```text
+//! ScalarValue          -- Atomic values with their types
+//!    │
+//!    v
+//! Tuple               -- Set of (attribute_name, ScalarValue) pairs
+//!    │                   Each tuple conforms to a TupleType
+//!    v
+//! Relation            -- Set of Tuples (no duplicates)
+//!                        All tuples conform to the same RelationType
+//! ```
+//!
+//! # TTM Compliance
+//!
+//! - **Proscription 1**: No NULL values (all attributes must have values)
+//! - **Proscription 2**: No duplicate tuples (relations are true sets)
+//! - **Proscription 3**: No tuple ordering (tuples are unordered in relations)
+//! - **Prescription 1**: User-defined types supported via POSSREP pattern
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::{ScalarValue, Tuple, Relation};
+//! use relvar::tuple;
+//!
+//! // Create scalar values
+//! let id = ScalarValue::Int(42);
+//! let name = ScalarValue::String("Alice".to_string());
+//!
+//! // Create a tuple using the macro
+//! let employee = tuple! {
+//!     emp_id: 1i64,
+//!     name: "Alice",
+//!     active: true,
+//! };
+//!
+//! // Create a relation
+//! let heading = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String);
+//!
+//! let mut employees = Relation::new(RelationType::new(heading));
+//! employees.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+//! employees.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+//!
+//! assert_eq!(employees.cardinality(), 2);
+//! ```
+
 pub mod relation;
 pub mod scalar;
 pub mod tuple;

--- a/src/values/relation.rs
+++ b/src/values/relation.rs
@@ -1,25 +1,117 @@
+//! Relation values for the relational model.
+//!
+//! A relation is a set of tuples that all conform to the same relation type.
+//! This is the fundamental data structure in the relational model.
+//!
+//! # TTM Compliance
+//!
+//! - **Proscription 2**: No duplicate tuples (relations are true sets)
+//! - **Proscription 3**: No tuple ordering (tuples are unordered)
+//! - All tuples conform to the relation's heading
+//! - Relation equality is based on heading and body content
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::Relation;
+//! use relvar::tuple;
+//!
+//! let heading = TupleType::new()
+//!     .with_attribute("emp_id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String);
+//!
+//! let mut employees = Relation::new(RelationType::new(heading));
+//!
+//! // Insert tuples
+//! employees.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+//! employees.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+//!
+//! // Duplicates are silently ignored (set semantics)
+//! employees.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+//!
+//! assert_eq!(employees.cardinality(), 2);  // Still 2, not 3
+//! ```
+
 use crate::types::RelationType;
 use crate::values::Tuple;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use thiserror::Error;
 
+/// Errors that can occur when working with relations.
 #[derive(Debug, Error)]
 pub enum RelationError {
+    /// A tuple doesn't conform to the relation's type (heading).
+    ///
+    /// This occurs when attempting to insert a tuple with a different
+    /// structure than what the relation expects.
     #[error("Tuple does not conform to relation type")]
     TypeMismatch,
+
+    /// A duplicate tuple was detected.
+    ///
+    /// Note: This error is not typically returned during insert operations
+    /// since duplicates are silently ignored per set semantics.
     #[error("Duplicate tuple")]
     DuplicateTuple,
 }
 
-/// A relation value: a heading (relation type) and a body (set of tuples).
-/// Per Date's relational model:
-/// - The body is a true set (no duplicates)
-/// - All tuples conform to the heading
-/// - Relations are equal iff they have the same heading and same body
+/// A relation value consisting of a heading and a body.
+///
+/// A relation has two components:
+///
+/// 1. **Heading** (relation type) - Defines the structure (attributes and types)
+/// 2. **Body** - A set of tuples that conform to the heading
+///
+/// # Set Semantics
+///
+/// Per TTM Proscription 2, the body is a true mathematical set:
+///
+/// - No duplicate tuples are permitted
+/// - Inserting a duplicate has no effect
+/// - There is no inherent ordering of tuples
+///
+/// # Type Safety
+///
+/// All tuples in a relation must conform to the relation's heading. Attempting
+/// to insert a tuple with a different structure results in an error.
+///
+/// # Example
+///
+/// ```
+/// use relvar::types::{TupleType, RelationType, ScalarType};
+/// use relvar::values::Relation;
+/// use relvar::tuple;
+///
+/// // Define the relation type
+/// let heading = TupleType::new()
+///     .with_attribute("id", ScalarType::Int)
+///     .with_attribute("name", ScalarType::String);
+///
+/// let rel_type = RelationType::new(heading);
+///
+/// // Create an empty relation
+/// let mut relation = Relation::new(rel_type);
+/// assert!(relation.is_empty());
+///
+/// // Insert tuples
+/// relation.insert(tuple! { id: 1i64, name: "Alice" }).unwrap();
+/// relation.insert(tuple! { id: 2i64, name: "Bob" }).unwrap();
+///
+/// // Query the relation
+/// assert_eq!(relation.cardinality(), 2);
+/// assert_eq!(relation.degree(), 2);
+///
+/// // Check for tuple membership
+/// let alice = tuple! { id: 1i64, name: "Alice" };
+/// assert!(relation.contains(&alice));
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Relation {
+    /// The relation type (heading) that defines the structure.
     relation_type: RelationType,
+    /// The body: a set of tuples conforming to the heading.
     body: HashSet<Tuple>,
 }
 
@@ -47,7 +139,28 @@ impl std::hash::Hash for Relation {
 }
 
 impl Relation {
-    /// Create a new empty relation with the given type
+    /// Creates a new empty relation with the given type.
+    ///
+    /// The relation starts with zero tuples but has a defined structure
+    /// (heading) that all future tuples must conform to.
+    ///
+    /// # Arguments
+    ///
+    /// * `relation_type` - The type defining the relation's structure
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let relation = Relation::new(RelationType::new(heading));
+    /// assert!(relation.is_empty());
+    /// assert_eq!(relation.degree(), 1);
+    /// ```
     pub fn new(relation_type: RelationType) -> Self {
         Self {
             relation_type,
@@ -55,7 +168,40 @@ impl Relation {
         }
     }
 
-    /// Create a relation from a type and a set of tuples
+    /// Creates a relation from a type and an iterable of tuples.
+    ///
+    /// This is useful for creating a pre-populated relation. Duplicate
+    /// tuples in the input are automatically removed per set semantics.
+    ///
+    /// # Arguments
+    ///
+    /// * `relation_type` - The type defining the relation's structure
+    /// * `tuples` - An iterable of tuples to populate the relation
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RelationError::TypeMismatch`] if any tuple doesn't conform
+    /// to the relation type.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let tuples = vec![
+    ///     tuple! { id: 1i64 },
+    ///     tuple! { id: 2i64 },
+    ///     tuple! { id: 1i64 },  // Duplicate - will be removed
+    /// ];
+    ///
+    /// let relation = Relation::from_tuples(RelationType::new(heading), tuples).unwrap();
+    /// assert_eq!(relation.cardinality(), 2);  // Only 2 unique tuples
+    /// ```
     pub fn from_tuples(
         relation_type: RelationType,
         tuples: impl IntoIterator<Item = Tuple>,
@@ -76,23 +222,99 @@ impl Relation {
         })
     }
 
-    /// Get the relation type
+    /// Returns the relation type (heading) of this relation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let rel_type = RelationType::new(heading.clone());
+    /// let relation = Relation::new(rel_type);
+    ///
+    /// assert_eq!(relation.relation_type().heading(), &heading);
+    /// ```
     pub fn relation_type(&self) -> &RelationType {
         &self.relation_type
     }
 
-    /// Get the cardinality (number of tuples)
+    /// Returns the cardinality (number of tuples) of this relation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let mut relation = Relation::new(RelationType::new(heading));
+    /// assert_eq!(relation.cardinality(), 0);
+    ///
+    /// relation.insert(tuple! { id: 1i64 }).unwrap();
+    /// assert_eq!(relation.cardinality(), 1);
+    /// ```
     pub fn cardinality(&self) -> usize {
         self.body.len()
     }
 
-    /// Get the degree (number of attributes)
+    /// Returns the degree (number of attributes) of this relation.
+    ///
+    /// This is determined by the relation type's heading.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int)
+    ///     .with_attribute("name", ScalarType::String);
+    ///
+    /// let relation = Relation::new(RelationType::new(heading));
+    /// assert_eq!(relation.degree(), 2);
+    /// ```
     pub fn degree(&self) -> usize {
         self.relation_type.degree()
     }
 
-    /// Insert a tuple into the relation
-    /// Returns Ok(true) if inserted, Ok(false) if duplicate
+    /// Inserts a tuple into the relation.
+    ///
+    /// Returns `Ok(true)` if the tuple was inserted, or `Ok(false)` if the
+    /// tuple was already present (duplicates are silently ignored per set
+    /// semantics).
+    ///
+    /// # Arguments
+    ///
+    /// * `tuple` - The tuple to insert (must conform to the relation type)
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RelationError::TypeMismatch`] if the tuple doesn't conform
+    /// to the relation's type.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let mut relation = Relation::new(RelationType::new(heading));
+    ///
+    /// assert!(relation.insert(tuple! { id: 1i64 }).unwrap());  // true: inserted
+    /// assert!(!relation.insert(tuple! { id: 1i64 }).unwrap()); // false: duplicate
+    /// ```
     pub fn insert(&mut self, tuple: Tuple) -> Result<bool, RelationError> {
         // Verify tuple conforms to the relation type
         if tuple.tuple_type() != self.relation_type.heading() {
@@ -102,17 +324,77 @@ impl Relation {
         Ok(self.body.insert(tuple))
     }
 
-    /// Check if the relation contains a tuple
+    /// Checks if the relation contains a specific tuple.
+    ///
+    /// # Arguments
+    ///
+    /// * `tuple` - The tuple to search for
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let mut relation = Relation::new(RelationType::new(heading));
+    /// relation.insert(tuple! { id: 1i64 }).unwrap();
+    ///
+    /// assert!(relation.contains(&tuple! { id: 1i64 }));
+    /// assert!(!relation.contains(&tuple! { id: 2i64 }));
+    /// ```
     pub fn contains(&self, tuple: &Tuple) -> bool {
         self.body.contains(tuple)
     }
 
-    /// Get an iterator over the tuples
+    /// Returns an iterator over the tuples in this relation.
+    ///
+    /// Per TTM Proscription 3, tuples have no inherent ordering. The
+    /// iteration order is not guaranteed to be consistent.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let mut relation = Relation::new(RelationType::new(heading));
+    /// relation.insert(tuple! { id: 1i64 }).unwrap();
+    /// relation.insert(tuple! { id: 2i64 }).unwrap();
+    ///
+    /// for tuple in relation.tuples() {
+    ///     println!("{:?}", tuple);
+    /// }
+    /// ```
     pub fn tuples(&self) -> impl Iterator<Item = &Tuple> {
         self.body.iter()
     }
 
-    /// Check if the relation is empty
+    /// Checks if the relation has no tuples.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, RelationType, ScalarType};
+    /// use relvar::values::Relation;
+    /// use relvar::tuple;
+    ///
+    /// let heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int);
+    ///
+    /// let mut relation = Relation::new(RelationType::new(heading));
+    /// assert!(relation.is_empty());
+    ///
+    /// relation.insert(tuple! { id: 1i64 }).unwrap();
+    /// assert!(!relation.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.body.is_empty()
     }

--- a/src/values/scalar.rs
+++ b/src/values/scalar.rs
@@ -1,37 +1,138 @@
+//! Scalar values for the relational model.
+//!
+//! This module defines [`ScalarValue`], which represents atomic runtime values
+//! that can be stored as attribute values in tuples.
+//!
+//! # TTM Compliance
+//!
+//! - All values carry their type (introspection is possible)
+//! - No NULL values are permitted
+//! - User-defined values via POSSREP pattern (Prescription 1)
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::values::ScalarValue;
+//! use relvar::types::ScalarType;
+//!
+//! // Built-in values
+//! let age = ScalarValue::Int(42);
+//! let name = ScalarValue::String("Alice".to_string());
+//! let pi = ScalarValue::Float(3.14159);
+//! let active = ScalarValue::Bool(true);
+//!
+//! // Check types
+//! assert!(age.is_type(&ScalarType::Int));
+//! assert!(name.is_type(&ScalarType::String));
+//! ```
+
 use crate::types::ScalarType;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// Errors related to scalar value operations
+/// Errors that can occur during scalar value operations.
 #[derive(Debug, Error)]
 pub enum ScalarValueError {
+    /// Attempted to use an observer on a built-in type.
+    ///
+    /// The observer operation is only valid for user-defined types.
     #[error("Cannot extract observer from built-in type")]
     NotUserDefined,
 }
 
-/// A scalar value with its type.
-/// Per Date's relational model, all values carry their type.
+/// Represents an atomic (scalar) value at runtime.
 ///
-/// TTM Prescription 1: Support for user-defined types via POSSREP pattern.
+/// Each `ScalarValue` holds data of a specific type and can report its type
+/// via the [`scalar_type()`](Self::scalar_type) method. This implements the
+/// TTM principle that all values carry their type.
+///
+/// # Built-in Value Types
+///
+/// - [`Int`](ScalarValue::Int) - 64-bit signed integer (`i64`)
+/// - [`Float`](ScalarValue::Float) - 64-bit floating point (`f64`)
+/// - [`String`](ScalarValue::String) - UTF-8 string
+/// - [`Bool`](ScalarValue::Bool) - Boolean
+/// - [`Bytes`](ScalarValue::Bytes) - Byte sequence
+///
+/// # Advanced Values
+///
+/// - [`Relation`](ScalarValue::Relation) - Nested relation (for RVAs)
+/// - [`UserDefined`](ScalarValue::UserDefined) - Custom type value
+///
+/// # Equality and Hashing
+///
+/// `ScalarValue` implements `Eq` and `Hash` to support use in sets and as
+/// hash map keys. Notably, floating-point values use bit equality, which
+/// means `NaN == NaN` (required for database set semantics).
+///
+/// # Example
+///
+/// ```
+/// use relvar::values::ScalarValue;
+/// use relvar::types::ScalarType;
+///
+/// let value = ScalarValue::Int(100);
+///
+/// // Introspect the type
+/// assert_eq!(value.scalar_type(), ScalarType::Int);
+/// assert!(value.is_type(&ScalarType::Int));
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ScalarValue {
+    /// 64-bit signed integer value.
     Int(i64),
+
+    /// 64-bit floating point value.
+    ///
+    /// Uses bit equality for comparison, so `NaN == NaN` for set semantics.
     Float(f64),
+
+    /// UTF-8 string value.
     String(String),
+
+    /// Boolean value.
     Bool(bool),
+
+    /// Arbitrary byte sequence.
     Bytes(Vec<u8>),
+
+    /// Relation value (for relation-valued attributes).
+    ///
+    /// Enables nested relations within tuples.
     Relation(crate::values::Relation),
-    /// User-defined value wrapping its type definition and underlying representation.
-    /// TTM: Implements POSSREP - the value carries both its type identity
-    /// and its representation value.
+
+    /// User-defined type value.
+    ///
+    /// Implements the POSSREP pattern: the value carries both its type
+    /// identity (via `type_def`) and its representation value (via `value`).
+    ///
+    /// Use [`ScalarType::selector()`] to create user-defined values.
     UserDefined {
+        /// The type definition for this user-defined value.
         type_def: ScalarType,
+        /// The underlying representation value.
         value: Box<ScalarValue>,
     },
 }
 
 impl ScalarValue {
-    /// Returns the type of this value
+    /// Returns the scalar type of this value.
+    ///
+    /// Every value in the relational model carries its type. This method
+    /// allows introspection of the value's type at runtime.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::values::ScalarValue;
+    /// use relvar::types::ScalarType;
+    ///
+    /// let value = ScalarValue::Int(42);
+    /// assert_eq!(value.scalar_type(), ScalarType::Int);
+    ///
+    /// let value = ScalarValue::String("hello".to_string());
+    /// assert_eq!(value.scalar_type(), ScalarType::String);
+    /// ```
     pub fn scalar_type(&self) -> ScalarType {
         match self {
             ScalarValue::Int(_) => ScalarType::Int,

--- a/src/values/tuple.rs
+++ b/src/values/tuple.rs
@@ -1,32 +1,136 @@
+//! Tuple values for the relational model.
+//!
+//! A tuple is a set of attribute-value pairs that conforms to a tuple type.
+//! This module provides the [`Tuple`] struct and the `tuple!` macro for
+//! convenient tuple creation.
+//!
+//! # TTM Compliance
+//!
+//! - **Proscription 1**: No NULL values - all attributes must have values
+//! - **Proscription 4**: No attribute ordering - attributes identified by name
+//! - Tuple equality is based on attribute values, not physical identity
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::tuple;
+//! use relvar::values::ScalarValue;
+//!
+//! // Create a tuple using the macro
+//! let employee = tuple! {
+//!     emp_id: 1i64,
+//!     name: "Alice",
+//!     active: true,
+//! };
+//!
+//! assert_eq!(employee.degree(), 3);
+//! assert_eq!(employee.get("name"), Some(&ScalarValue::String("Alice".to_string())));
+//! ```
+
 use crate::types::TupleType;
 use crate::values::ScalarValue;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use thiserror::Error;
 
+/// Errors that can occur when creating or modifying tuples.
 #[derive(Debug, Error)]
 pub enum TupleError {
+    /// An attribute name was provided that doesn't exist in the tuple type.
     #[error("Attribute '{0}' not found in tuple type")]
     AttributeNotFound(String),
+
+    /// A value's type doesn't match the expected type for its attribute.
     #[error("Type mismatch for attribute '{0}': expected {1:?}, got {2:?}")]
     TypeMismatch(String, String, String),
+
+    /// An attribute defined in the tuple type has no corresponding value.
+    ///
+    /// This enforces TTM Proscription 1 (no NULL values).
     #[error("Missing value for attribute '{0}'")]
     MissingValue(String),
 }
 
-/// A tuple value conforming to a tuple type.
-/// Per Date's relational model:
-/// - All attributes must have values (no nulls)
-/// - Tuples are equal iff all attribute values are equal
-/// - No ordering of attributes
+/// A tuple value that conforms to a tuple type.
+///
+/// A tuple is an unordered set of attribute-value pairs. Each attribute
+/// has a name and a scalar value. The tuple must conform to its tuple type,
+/// meaning all attributes defined in the type must be present with values
+/// of the correct types.
+///
+/// # No NULL Values
+///
+/// Per TTM Proscription 1, every attribute must have a value. Attempting to
+/// create a tuple with missing attributes will result in an error.
+///
+/// # Equality
+///
+/// Two tuples are equal if and only if they have the same tuple type and
+/// all their attribute values are equal. The order of insertion does not
+/// affect equality.
+///
+/// # Example
+///
+/// ```
+/// use relvar::tuple;
+/// use relvar::values::ScalarValue;
+///
+/// let person = tuple! {
+///     id: 1i64,
+///     name: "Alice",
+///     age: 30i64,
+/// };
+///
+/// // Access values by attribute name
+/// assert_eq!(person.get("id"), Some(&ScalarValue::Int(1)));
+///
+/// // Use typed access
+/// let age: i64 = person.get_typed("age").unwrap();
+/// assert_eq!(age, 30);
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Tuple {
+    /// The tuple type (heading) that this tuple conforms to.
     tuple_type: TupleType,
+    /// The attribute values, keyed by attribute name.
     values: BTreeMap<String, ScalarValue>,
 }
 
 impl Tuple {
-    /// Create a new tuple from a type and values
+    /// Creates a new tuple from a type and values.
+    ///
+    /// Validates that all attributes defined in the tuple type have
+    /// corresponding values and that all values match their expected types.
+    ///
+    /// # Arguments
+    ///
+    /// * `tuple_type` - The tuple type (heading) this tuple must conform to
+    /// * `values` - A map of attribute names to scalar values
+    ///
+    /// # Errors
+    ///
+    /// - [`TupleError::MissingValue`] - An attribute has no value (violates Proscription 1)
+    /// - [`TupleError::AttributeNotFound`] - A value is provided for an undefined attribute
+    /// - [`TupleError::TypeMismatch`] - A value's type doesn't match the attribute type
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar::types::{TupleType, ScalarType};
+    /// use relvar::values::{Tuple, ScalarValue};
+    /// use std::collections::BTreeMap;
+    ///
+    /// let tuple_type = TupleType::new()
+    ///     .with_attribute("id", ScalarType::Int)
+    ///     .with_attribute("name", ScalarType::String);
+    ///
+    /// let mut values = BTreeMap::new();
+    /// values.insert("id".to_string(), ScalarValue::Int(1));
+    /// values.insert("name".to_string(), ScalarValue::String("Alice".to_string()));
+    ///
+    /// let tuple = Tuple::new(tuple_type, values).unwrap();
+    /// assert_eq!(tuple.degree(), 2);
+    /// ```
     pub fn new(
         tuple_type: TupleType,
         values: BTreeMap<String, ScalarValue>,


### PR DESCRIPTION
## Summary

- Add extensive rustdoc documentation across all modules for `cargo doc` generation
- Add TTM invariant doctests for Proscription 6 (no TupleId), key constraint violations, and foreign key violations
- Document all relational algebra operators, constraints, storage layer, types, and values modules
- Fix broken intra-doc links and ensure clean `cargo doc --no-deps` build

## Changes by Module

**lib.rs**
- Crate-level docs with architecture diagram, TTM principles table, and terminology glossary
- Proscription 6 doctest demonstrating no physical IDs exposed

**algebra/**
- Document all operators: project, restrict, join, union, intersect, difference, extend, group, summarize, rename
- Each operator has module docs, struct docs, and working examples

**constraints/**
- Document key, foreign key, and type constraints
- Add violation detection doctests showing how constraints catch invalid data

**storage/**
- Document page, heap, btree, and catalog modules
- Architecture diagrams showing storage layer organization
- TTM Proscription 6 compliance notes

**types/** and **values/**
- Document scalar types, tuple types, relation types
- Document scalar values, tuples, relations with set semantics examples

## Test plan

- [x] `cargo fmt` - no changes needed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - zero warnings
- [x] `cargo test --all-features` - 189 unit tests pass
- [x] `cargo test --doc` - 105 doctests pass
- [x] `cargo doc --no-deps` - builds cleanly with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)