### PR TITLE
feat: implement views (virtual relvars) per TTM RM Prescription 10

### DIFF
--- a/benches/database.rs
+++ b/benches/database.rs
@@ -447,18 +447,25 @@ fn bench_virtual_relvar_query(c: &mut Criterion) {
             BenchmarkId::new("restrict_virtual_relvar", count),
             count,
             |b, &count| {
-                let (_temp_dir, mut db) = create_populated_database(count);
-                db.create_virtual_relvar("HIGH_EARNERS", |db| {
-                    Ok(db
-                        .query("EMP")?
-                        .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 60000.0))
-                })
-                .unwrap();
-
-                b.iter(|| {
-                    let result = db.query("HIGH_EARNERS").unwrap();
-                    black_box(result);
-                });
+                b.iter_batched(
+                    || {
+                        // Setup: create database with data and virtual relvar
+                        let (_temp_dir, mut db) = create_populated_database(count);
+                        db.create_virtual_relvar("HIGH_EARNERS", |db| {
+                            Ok(db
+                                .query("EMP")?
+                                .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 60000.0))
+                        })
+                        .unwrap();
+                        (_temp_dir, db)
+                    },
+                    |(_temp_dir, mut db)| {
+                        // Measured: just the virtual relvar query
+                        let result = db.query("HIGH_EARNERS").unwrap();
+                        black_box(result);
+                    },
+                    BatchSize::SmallInput,
+                );
             },
         );
     }

--- a/benches/database.rs
+++ b/benches/database.rs
@@ -395,6 +395,77 @@ fn bench_realistic_workload(c: &mut Criterion) {
     group.finish();
 }
 
+// =============================================================================
+// View Benchmarks (TTM RM Prescription 10)
+// =============================================================================
+
+/// Helper to create a database with an EMP relvar pre-populated with data
+fn create_populated_database(count: usize) -> (TempDir, Database) {
+    let (_temp_dir, mut db) = create_database_with_relvar();
+    for i in 0..count {
+        let tuple = tuple! {
+            emp_id: i as i64,
+            name: format!("Employee_{}", i),
+            dept_id: (i % 10) as i64,
+            salary: 50000.0 + (i as f64 * 1000.0)
+        };
+        db.insert("EMP", tuple).unwrap();
+    }
+    (_temp_dir, db)
+}
+
+/// Benchmark view creation
+fn bench_view_creation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("view_creation");
+
+    group.bench_function("create_simple_view", |b| {
+        b.iter_batched(
+            || create_populated_database(100),
+            |(_temp_dir, mut db)| {
+                db.create_view("HIGH_EARNERS", |db| {
+                    Ok(db
+                        .query("EMP")?
+                        .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 60000.0))
+                })
+                .unwrap();
+                black_box(db);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+/// Benchmark view query (re-evaluation)
+fn bench_view_query(c: &mut Criterion) {
+    let mut group = c.benchmark_group("view_query");
+
+    for count in [100, 500, 1000].iter() {
+        group.throughput(Throughput::Elements(*count as u64));
+        group.bench_with_input(
+            BenchmarkId::new("restrict_view", count),
+            count,
+            |b, &count| {
+                let (_temp_dir, mut db) = create_populated_database(count);
+                db.create_view("HIGH_EARNERS", |db| {
+                    Ok(db
+                        .query("EMP")?
+                        .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 60000.0))
+                })
+                .unwrap();
+
+                b.iter(|| {
+                    let result = db.query("HIGH_EARNERS").unwrap();
+                    black_box(result);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_database_open,
@@ -406,6 +477,9 @@ criterion_group!(
     bench_delete,
     bench_update,
     bench_transaction,
-    bench_realistic_workload
+    bench_realistic_workload,
+    // View benchmarks (TTM RM Prescription 10)
+    bench_view_creation,
+    bench_view_query
 );
 criterion_main!(benches);

--- a/benches/database.rs
+++ b/benches/database.rs
@@ -396,7 +396,7 @@ fn bench_realistic_workload(c: &mut Criterion) {
 }
 
 // =============================================================================
-// View Benchmarks (TTM RM Prescription 10)
+// Virtual Relvar Benchmarks (TTM RM Prescription 10)
 // =============================================================================
 
 /// Helper to create a database with an EMP relvar pre-populated with data
@@ -414,15 +414,15 @@ fn create_populated_database(count: usize) -> (TempDir, Database) {
     (_temp_dir, db)
 }
 
-/// Benchmark view creation
-fn bench_view_creation(c: &mut Criterion) {
-    let mut group = c.benchmark_group("view_creation");
+/// Benchmark virtual relvar creation
+fn bench_virtual_relvar_creation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("virtual_relvar_creation");
 
-    group.bench_function("create_simple_view", |b| {
+    group.bench_function("create_simple_virtual_relvar", |b| {
         b.iter_batched(
             || create_populated_database(100),
             |(_temp_dir, mut db)| {
-                db.create_view("HIGH_EARNERS", |db| {
+                db.create_virtual_relvar("HIGH_EARNERS", |db| {
                     Ok(db
                         .query("EMP")?
                         .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 60000.0))
@@ -437,18 +437,18 @@ fn bench_view_creation(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmark view query (re-evaluation)
-fn bench_view_query(c: &mut Criterion) {
-    let mut group = c.benchmark_group("view_query");
+/// Benchmark virtual relvar query (re-evaluation)
+fn bench_virtual_relvar_query(c: &mut Criterion) {
+    let mut group = c.benchmark_group("virtual_relvar_query");
 
     for count in [100, 500, 1000].iter() {
         group.throughput(Throughput::Elements(*count as u64));
         group.bench_with_input(
-            BenchmarkId::new("restrict_view", count),
+            BenchmarkId::new("restrict_virtual_relvar", count),
             count,
             |b, &count| {
                 let (_temp_dir, mut db) = create_populated_database(count);
-                db.create_view("HIGH_EARNERS", |db| {
+                db.create_virtual_relvar("HIGH_EARNERS", |db| {
                     Ok(db
                         .query("EMP")?
                         .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 60000.0))
@@ -478,8 +478,8 @@ criterion_group!(
     bench_update,
     bench_transaction,
     bench_realistic_workload,
-    // View benchmarks (TTM RM Prescription 10)
-    bench_view_creation,
-    bench_view_query
+    // Virtual relvar benchmarks (TTM RM Prescription 10)
+    bench_virtual_relvar_creation,
+    bench_virtual_relvar_query
 );
 criterion_main!(benches);

--- a/src/database.rs
+++ b/src/database.rs
@@ -1927,4 +1927,66 @@ mod tests {
         assert_eq!(result.cardinality(), 2);
         assert_eq!(result.degree(), 4);
     }
+
+    #[test]
+    fn test_virtual_relvar_evaluation_error_preserves_definition() {
+        // Verifies that if a virtual relvar's definition returns an error,
+        // the virtual relvar is still preserved and can be queried again.
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        // Create a virtual relvar that queries a non-existent base relvar
+        db.create_virtual_relvar("BAD_VIRTUAL", |db| db.query("NONEXISTENT"))
+            .unwrap();
+
+        // First query fails (NONEXISTENT doesn't exist)
+        let result = db.query("BAD_VIRTUAL");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DatabaseError::RelationNotFound(_)
+        ));
+
+        // Virtual relvar should still exist after the error
+        assert!(db.virtual_relvar_exists("BAD_VIRTUAL"));
+
+        // Can query it again (still fails, but proves definition wasn't lost)
+        let result2 = db.query("BAD_VIRTUAL");
+        assert!(result2.is_err());
+    }
+
+    #[test]
+    fn test_drop_relvar_breaks_dependent_virtual_relvar() {
+        // Verifies behavior when a base relvar is dropped while a virtual relvar depends on it.
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let tuple_type = TupleType::new().with_attribute("id".to_string(), ScalarType::Int);
+        db.create_relvar("EMP", RelationType::new(tuple_type))
+            .unwrap();
+
+        db.insert("EMP", tuple! { id: 1i64 }).unwrap();
+
+        // Create a virtual relvar that depends on EMP
+        db.create_virtual_relvar("EMP_VIRTUAL", |db| db.query("EMP"))
+            .unwrap();
+
+        // Virtual relvar works initially
+        let result = db.query("EMP_VIRTUAL").unwrap();
+        assert_eq!(result.cardinality(), 1);
+
+        // Drop the base relvar
+        db.drop_relvar("EMP").unwrap();
+
+        // Virtual relvar still exists
+        assert!(db.virtual_relvar_exists("EMP_VIRTUAL"));
+
+        // But querying it now fails because EMP no longer exists
+        let result = db.query("EMP_VIRTUAL");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DatabaseError::RelationNotFound(_)
+        ));
+    }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -132,13 +132,51 @@ pub enum DatabaseError {
     /// or beginning a transaction when one is already in progress.
     #[error("Transaction error: {0}")]
     TransactionError(String),
+
+    /// A view with the given name already exists.
+    ///
+    /// TTM: RM Prescription 10 - View names must be unique within the database.
+    #[error("View {0} already exists")]
+    ViewAlreadyExists(String),
+
+    /// No view with the given name was found.
+    ///
+    /// TTM: RM Prescription 10 - Views must exist to be queried or dropped.
+    #[error("View {0} not found")]
+    ViewNotFound(String),
+
+    /// Cannot modify a view because views are read-only.
+    ///
+    /// TTM: RM Prescription 10 - Views are virtual relvars and cannot be
+    /// directly modified. Modifications must be made to the underlying
+    /// base relvars.
+    #[error("Cannot modify view {0}: views are read-only")]
+    CannotModifyView(String),
 }
+
+/// Type alias for view definition functions.
+///
+/// A view definition is a closure that takes a mutable reference to the database
+/// and returns a [`Relation`] value. The closure is re-evaluated each time the
+/// view is queried, ensuring the view always reflects the current state of the
+/// underlying base relvars.
+///
+/// TTM: RM Prescription 10 - Views are virtual relation variables defined by
+/// relational expressions. They are not stored, but computed on demand.
+///
+/// # Thread Safety
+///
+/// View definitions must be `Send + Sync` to allow the database to be used
+/// across threads safely.
+pub type ViewDefinition =
+    Box<dyn Fn(&mut Database) -> Result<Relation, DatabaseError> + Send + Sync>;
 
 /// A database instance managing relations, storage, and constraints.
 ///
 /// `Database` is the main entry point for all database operations. It manages:
 ///
 /// - **Relations (Relvars)**: Create, drop, and query base relations
+/// - **Views**: Virtual relvars defined by expressions (TTM RM Prescription 10)
 /// - **Data Manipulation**: Insert, update, and delete tuples
 /// - **Constraints**: Primary keys, foreign keys, and type constraints
 /// - **Transactions**: Begin, commit, and rollback operations
@@ -211,6 +249,11 @@ pub struct Database {
     /// This is a simplified implementation that stores full relation snapshots.
     /// A production system would use write-ahead logging (WAL).
     savepoint: Option<HashMap<String, Relation>>,
+    /// Views (virtual relvars) defined by expressions.
+    ///
+    /// TTM: RM Prescription 10 - Views are virtual relation variables that
+    /// re-evaluate their defining expression on each query.
+    views: HashMap<String, ViewDefinition>,
 }
 
 impl Database {
@@ -266,6 +309,7 @@ impl Database {
             type_constraints: HashMap::new(),
             in_transaction: false,
             savepoint: None,
+            views: HashMap::new(),
         })
     }
 
@@ -307,6 +351,11 @@ impl Database {
         // Check if relation already exists
         if self.catalog.get_relation(name).is_ok() {
             return Err(DatabaseError::RelationAlreadyExists(name.to_string()));
+        }
+
+        // Check if a view with this name exists
+        if self.views.contains_key(name) {
+            return Err(DatabaseError::ViewAlreadyExists(name.to_string()));
         }
 
         // Create heap file
@@ -367,6 +416,108 @@ impl Database {
         self.type_constraints.remove(name);
 
         Ok(())
+    }
+
+    /// Creates a new view (virtual relvar).
+    ///
+    /// TTM: RM Prescription 10 - The system must support views (virtual relation
+    /// variables defined by expressions).
+    ///
+    /// Views are read-only and re-evaluate their defining expression on each query.
+    /// The view definition is a closure that takes a mutable reference to the database
+    /// and returns a relation value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar::Database;
+    /// use relvar::types::{RelationType, ScalarType, TupleType};
+    /// use relvar::tuple;
+    ///
+    /// let temp_dir = tempfile::TempDir::new().unwrap();
+    /// let mut db = Database::open(temp_dir.path()).unwrap();
+    ///
+    /// // Create a base relvar
+    /// let emp_type = TupleType::new()
+    ///     .with_attribute("id".to_string(), ScalarType::Int)
+    ///     .with_attribute("salary".to_string(), ScalarType::Float);
+    /// db.create_relvar("EMP", RelationType::new(emp_type)).unwrap();
+    ///
+    /// // Insert some data
+    /// db.insert("EMP", tuple! { id: 1i64, salary: 150000.0 }).unwrap();
+    /// db.insert("EMP", tuple! { id: 2i64, salary: 50000.0 }).unwrap();
+    ///
+    /// // Create a view for high earners (salary > 100000)
+    /// db.create_view("HIGH_EARNERS", |db| {
+    ///     Ok(db.query("EMP")?
+    ///         .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 100000.0))
+    /// }).unwrap();
+    ///
+    /// // Query the view - re-evaluates each time
+    /// let high_earners = db.query("HIGH_EARNERS").unwrap();
+    /// assert_eq!(high_earners.cardinality(), 1);
+    ///
+    /// // Views are read-only - insert fails
+    /// let result = db.insert("HIGH_EARNERS", tuple! { id: 3i64, salary: 200000.0 });
+    /// assert!(result.is_err());
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseError::RelationAlreadyExists`] if a base relvar with the
+    /// same name already exists.
+    ///
+    /// Returns [`DatabaseError::ViewAlreadyExists`] if a view with the same name
+    /// already exists.
+    pub fn create_view<F>(&mut self, name: &str, definition: F) -> Result<(), DatabaseError>
+    where
+        F: Fn(&mut Database) -> Result<Relation, DatabaseError> + Send + Sync + 'static,
+    {
+        // Check if a base relvar with this name exists
+        if self.catalog.get_relation(name).is_ok() {
+            return Err(DatabaseError::RelationAlreadyExists(name.to_string()));
+        }
+
+        // Check if a view with this name already exists
+        if self.views.contains_key(name) {
+            return Err(DatabaseError::ViewAlreadyExists(name.to_string()));
+        }
+
+        // Store the view definition
+        self.views.insert(name.to_string(), Box::new(definition));
+
+        Ok(())
+    }
+
+    /// Drops a view.
+    ///
+    /// Removes the view definition from the database. This does not affect
+    /// any base relvars that the view was derived from.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseError::ViewNotFound`] if no view with the given name exists.
+    pub fn drop_view(&mut self, name: &str) -> Result<(), DatabaseError> {
+        if self.views.remove(name).is_none() {
+            return Err(DatabaseError::ViewNotFound(name.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Checks if a view exists.
+    ///
+    /// Returns `true` if a view with the given name exists, `false` otherwise.
+    /// This only checks for views, not base relvars.
+    pub fn view_exists(&self, name: &str) -> bool {
+        self.views.contains_key(name)
+    }
+
+    /// Lists all view names.
+    ///
+    /// Returns a vector of all view names currently defined in the database.
+    /// This does not include base relvars.
+    pub fn list_views(&self) -> Vec<String> {
+        self.views.keys().cloned().collect()
     }
 
     /// Sets key constraints (primary and candidate keys) for a relation.
@@ -555,6 +706,11 @@ impl Database {
     /// # Ok::<(), relvar::DatabaseError>(())
     /// ```
     pub fn insert(&mut self, relation_name: &str, tuple: Tuple) -> Result<(), DatabaseError> {
+        // Check if trying to insert into a view
+        if self.views.contains_key(relation_name) {
+            return Err(DatabaseError::CannotModifyView(relation_name.to_string()));
+        }
+
         // Get relation metadata
         let metadata = self
             .catalog
@@ -632,22 +788,30 @@ impl Database {
         Ok(())
     }
 
-    /// Queries a relation, returning all tuples as a [`Relation`] value.
+    /// Queries a relation or view, returning all tuples as a [`Relation`] value.
+    ///
+    /// For base relvars, this loads the relation from storage.
+    /// For views, this re-evaluates the view definition and returns the result.
+    ///
+    /// TTM: RM Prescription 10 - Views re-evaluate their defining expression
+    /// on each query, ensuring they always reflect the current state of the
+    /// underlying base relvars.
     ///
     /// The returned relation can be transformed using relational algebra
     /// operators such as `project`, `restrict`, `join`, `union`, etc.
     ///
     /// # Arguments
     ///
-    /// * `relation_name` - The name of the relation to query
+    /// * `relation_name` - The name of the relation or view to query
     ///
     /// # Returns
     ///
-    /// A [`Relation`] containing all tuples from the stored relation.
+    /// A [`Relation`] containing all tuples.
     ///
     /// # Errors
     ///
-    /// Returns [`DatabaseError::RelationNotFound`] if the relation does not exist.
+    /// Returns [`DatabaseError::RelationNotFound`] if neither a relation nor
+    /// a view with the given name exists.
     ///
     /// # Example
     ///
@@ -665,6 +829,17 @@ impl Database {
     /// # Ok::<(), relvar::DatabaseError>(())
     /// ```
     pub fn query(&mut self, relation_name: &str) -> Result<Relation, DatabaseError> {
+        // Check if this is a view - if so, evaluate the view definition
+        if self.views.contains_key(relation_name) {
+            return self.query_view(relation_name);
+        }
+
+        // Otherwise, query the base relvar
+        self.query_base_relvar(relation_name)
+    }
+
+    /// Queries a base relvar (stored relation).
+    fn query_base_relvar(&mut self, relation_name: &str) -> Result<Relation, DatabaseError> {
         // Get relation metadata (clone to avoid borrow issues)
         let relation_type = self
             .catalog
@@ -685,6 +860,26 @@ impl Database {
         }
 
         Ok(relation)
+    }
+
+    /// Queries a view by evaluating its definition.
+    ///
+    /// This temporarily removes the view definition to avoid borrow issues,
+    /// evaluates it, and puts it back.
+    fn query_view(&mut self, view_name: &str) -> Result<Relation, DatabaseError> {
+        // Temporarily remove the view definition to avoid borrow issues
+        let view_def = self
+            .views
+            .remove(view_name)
+            .ok_or_else(|| DatabaseError::ViewNotFound(view_name.to_string()))?;
+
+        // Evaluate the view definition
+        let result = view_def(self);
+
+        // Put the view definition back
+        self.views.insert(view_name.to_string(), view_def);
+
+        result
     }
 
     /// Deletes tuples matching a predicate from a relation.
@@ -723,6 +918,11 @@ impl Database {
     where
         F: Fn(&Tuple) -> bool,
     {
+        // Check if trying to delete from a view
+        if self.views.contains_key(relation_name) {
+            return Err(DatabaseError::CannotModifyView(relation_name.to_string()));
+        }
+
         // Clone foreign key constraints to avoid borrowing issues
         let fk_constraints_clone = self.foreign_key_constraints.clone();
 
@@ -840,6 +1040,11 @@ impl Database {
         F: Fn(&Tuple) -> bool,
         U: Fn(&mut Tuple),
     {
+        // Check if trying to update a view
+        if self.views.contains_key(relation_name) {
+            return Err(DatabaseError::CannotModifyView(relation_name.to_string()));
+        }
+
         // Get metadata (clone to avoid borrow issues)
         let metadata = self
             .catalog
@@ -1396,5 +1601,314 @@ mod tests {
             result.unwrap_err(),
             DatabaseError::TypeConstraintViolation(_)
         ));
+    }
+
+    // ==========================================================================
+    // View Tests (TTM RM Prescription 10 - Virtual Relation Variables)
+    // ==========================================================================
+
+    #[test]
+    fn test_create_view() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let tuple_type = TupleType::new()
+            .with_attribute("id".to_string(), ScalarType::Int)
+            .with_attribute("name".to_string(), ScalarType::String)
+            .with_attribute("salary".to_string(), ScalarType::Float);
+        let relation_type = RelationType::new(tuple_type);
+
+        db.create_relvar("EMP", relation_type).unwrap();
+
+        db.create_view("HIGH_EARNERS", |db| {
+            Ok(db
+                .query("EMP")?
+                .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 100000.0))
+        })
+        .unwrap();
+
+        assert!(db.view_exists("HIGH_EARNERS"));
+    }
+
+    #[test]
+    fn test_view_re_evaluates_on_query() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let tuple_type = TupleType::new()
+            .with_attribute("id".to_string(), ScalarType::Int)
+            .with_attribute("name".to_string(), ScalarType::String)
+            .with_attribute("salary".to_string(), ScalarType::Float);
+        let relation_type = RelationType::new(tuple_type);
+
+        db.create_relvar("EMP", relation_type).unwrap();
+
+        db.insert("EMP", tuple! { id: 1i64, name: "Alice", salary: 150000.0 })
+            .unwrap();
+        db.insert("EMP", tuple! { id: 2i64, name: "Bob", salary: 50000.0 })
+            .unwrap();
+
+        db.create_view("HIGH_EARNERS", |db| {
+            Ok(db
+                .query("EMP")?
+                .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 100000.0))
+        })
+        .unwrap();
+
+        let result = db.query("HIGH_EARNERS").unwrap();
+        assert_eq!(result.cardinality(), 1);
+
+        db.insert(
+            "EMP",
+            tuple! { id: 3i64, name: "Charlie", salary: 200000.0 },
+        )
+        .unwrap();
+
+        let result = db.query("HIGH_EARNERS").unwrap();
+        assert_eq!(result.cardinality(), 2);
+    }
+
+    #[test]
+    fn test_view_appears_in_catalog() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let tuple_type = TupleType::new()
+            .with_attribute("id".to_string(), ScalarType::Int)
+            .with_attribute("name".to_string(), ScalarType::String);
+        let relation_type = RelationType::new(tuple_type);
+
+        db.create_relvar("EMP", relation_type).unwrap();
+
+        db.create_view("NAMES_ONLY", |db| Ok(db.query("EMP")?.project(&["name"])))
+            .unwrap();
+
+        let views = db.list_views();
+        assert!(views.contains(&"NAMES_ONLY".to_string()));
+    }
+
+    #[test]
+    fn test_drop_view() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let tuple_type = TupleType::new()
+            .with_attribute("id".to_string(), ScalarType::Int)
+            .with_attribute("name".to_string(), ScalarType::String);
+        let relation_type = RelationType::new(tuple_type);
+
+        db.create_relvar("EMP", relation_type).unwrap();
+
+        db.create_view("NAMES_ONLY", |db| Ok(db.query("EMP")?.project(&["name"])))
+            .unwrap();
+
+        assert!(db.view_exists("NAMES_ONLY"));
+
+        db.drop_view("NAMES_ONLY").unwrap();
+
+        assert!(!db.view_exists("NAMES_ONLY"));
+    }
+
+    #[test]
+    fn test_insert_into_view_fails() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let tuple_type = TupleType::new()
+            .with_attribute("id".to_string(), ScalarType::Int)
+            .with_attribute("name".to_string(), ScalarType::String);
+        let relation_type = RelationType::new(tuple_type);
+
+        db.create_relvar("EMP", relation_type).unwrap();
+
+        db.create_view("EMP_VIEW", |db| db.query("EMP")).unwrap();
+
+        let result = db.insert("EMP_VIEW", tuple! { id: 1i64, name: "Alice" });
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DatabaseError::CannotModifyView(_)
+        ));
+    }
+
+    #[test]
+    fn test_delete_from_view_fails() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let tuple_type = TupleType::new()
+            .with_attribute("id".to_string(), ScalarType::Int)
+            .with_attribute("name".to_string(), ScalarType::String);
+        let relation_type = RelationType::new(tuple_type);
+
+        db.create_relvar("EMP", relation_type).unwrap();
+        db.insert("EMP", tuple! { id: 1i64, name: "Alice" })
+            .unwrap();
+
+        db.create_view("EMP_VIEW", |db| db.query("EMP")).unwrap();
+
+        let result = db.delete("EMP_VIEW", |_| true);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DatabaseError::CannotModifyView(_)
+        ));
+    }
+
+    #[test]
+    fn test_update_view_fails() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let tuple_type = TupleType::new()
+            .with_attribute("id".to_string(), ScalarType::Int)
+            .with_attribute("name".to_string(), ScalarType::String);
+        let relation_type = RelationType::new(tuple_type);
+
+        db.create_relvar("EMP", relation_type).unwrap();
+        db.insert("EMP", tuple! { id: 1i64, name: "Alice" })
+            .unwrap();
+
+        db.create_view("EMP_VIEW", |db| db.query("EMP")).unwrap();
+
+        let result = db.update(
+            "EMP_VIEW",
+            |_| true,
+            |t| {
+                t.set("name".to_string(), ScalarValue::String("Bob".to_string()))
+                    .unwrap();
+            },
+        );
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DatabaseError::CannotModifyView(_)
+        ));
+    }
+
+    #[test]
+    fn test_query_nonexistent_view_fails() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let result = db.query("NONEXISTENT");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DatabaseError::RelationNotFound(_)
+        ));
+    }
+
+    #[test]
+    fn test_create_duplicate_view_fails() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let tuple_type = TupleType::new().with_attribute("id".to_string(), ScalarType::Int);
+        let relation_type = RelationType::new(tuple_type);
+
+        db.create_relvar("EMP", relation_type).unwrap();
+
+        db.create_view("EMP_VIEW", |db| db.query("EMP")).unwrap();
+
+        let result = db.create_view("EMP_VIEW", |db| db.query("EMP"));
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DatabaseError::ViewAlreadyExists(_)
+        ));
+    }
+
+    #[test]
+    fn test_view_with_same_name_as_relvar_fails() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let tuple_type = TupleType::new().with_attribute("id".to_string(), ScalarType::Int);
+        let relation_type = RelationType::new(tuple_type);
+
+        db.create_relvar("EMP", relation_type).unwrap();
+
+        let result = db.create_view("EMP", |db| db.query("EMP"));
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DatabaseError::RelationAlreadyExists(_)
+        ));
+    }
+
+    #[test]
+    fn test_relvar_with_same_name_as_view_fails() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let tuple_type = TupleType::new().with_attribute("id".to_string(), ScalarType::Int);
+        let relation_type = RelationType::new(tuple_type.clone());
+
+        db.create_relvar("EMP", relation_type).unwrap();
+
+        db.create_view("EMP_VIEW", |db| db.query("EMP")).unwrap();
+
+        let result = db.create_relvar("EMP_VIEW", RelationType::new(tuple_type));
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DatabaseError::ViewAlreadyExists(_)
+        ));
+    }
+
+    #[test]
+    fn test_drop_nonexistent_view_fails() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let result = db.drop_view("NONEXISTENT");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DatabaseError::ViewNotFound(_)
+        ));
+    }
+
+    #[test]
+    fn test_view_with_join() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut db = Database::open(temp_dir.path()).unwrap();
+
+        let emp_type = TupleType::new()
+            .with_attribute("emp_id".to_string(), ScalarType::Int)
+            .with_attribute("name".to_string(), ScalarType::String)
+            .with_attribute("dept_id".to_string(), ScalarType::Int);
+        db.create_relvar("EMP", RelationType::new(emp_type))
+            .unwrap();
+
+        let dept_type = TupleType::new()
+            .with_attribute("dept_id".to_string(), ScalarType::Int)
+            .with_attribute("dept_name".to_string(), ScalarType::String);
+        db.create_relvar("DEPT", RelationType::new(dept_type))
+            .unwrap();
+
+        db.insert(
+            "EMP",
+            tuple! { emp_id: 1i64, name: "Alice", dept_id: 10i64 },
+        )
+        .unwrap();
+        db.insert("EMP", tuple! { emp_id: 2i64, name: "Bob", dept_id: 20i64 })
+            .unwrap();
+        db.insert("DEPT", tuple! { dept_id: 10i64, dept_name: "Engineering" })
+            .unwrap();
+        db.insert("DEPT", tuple! { dept_id: 20i64, dept_name: "Sales" })
+            .unwrap();
+
+        db.create_view("EMP_WITH_DEPT", |db| {
+            let emp = db.query("EMP")?;
+            let dept = db.query("DEPT")?;
+            Ok(emp.join(&dept))
+        })
+        .unwrap();
+
+        let result = db.query("EMP_WITH_DEPT").unwrap();
+        assert_eq!(result.cardinality(), 2);
+        assert_eq!(result.degree(), 4);
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -133,42 +133,41 @@ pub enum DatabaseError {
     #[error("Transaction error: {0}")]
     TransactionError(String),
 
-    /// A view with the given name already exists.
+    /// A virtual relvar with the given name already exists.
     ///
-    /// TTM: RM Prescription 10 - View names must be unique within the database.
-    #[error("View {0} already exists")]
-    ViewAlreadyExists(String),
+    /// TTM: RM Prescription 10 - Virtual relvar names must be unique within the database.
+    #[error("Virtual relvar {0} already exists")]
+    VirtualRelvarAlreadyExists(String),
 
-    /// No view with the given name was found.
+    /// No virtual relvar with the given name was found.
     ///
-    /// TTM: RM Prescription 10 - Views must exist to be queried or dropped.
-    #[error("View {0} not found")]
-    ViewNotFound(String),
+    /// TTM: RM Prescription 10 - Virtual relvars must exist to be queried or dropped.
+    #[error("Virtual relvar {0} not found")]
+    VirtualRelvarNotFound(String),
 
-    /// Cannot modify a view because views are read-only.
+    /// Cannot modify a virtual relvar because virtual relvars are read-only.
     ///
-    /// TTM: RM Prescription 10 - Views are virtual relvars and cannot be
-    /// directly modified. Modifications must be made to the underlying
-    /// base relvars.
-    #[error("Cannot modify view {0}: views are read-only")]
-    CannotModifyView(String),
+    /// TTM: RM Prescription 10 - Virtual relvars cannot be directly modified.
+    /// Modifications must be made to the underlying base relvars.
+    #[error("Cannot modify virtual relvar {0}: virtual relvars are read-only")]
+    CannotModifyVirtualRelvar(String),
 }
 
-/// Type alias for view definition functions.
+/// Type alias for virtual relvar definition functions.
 ///
-/// A view definition is a closure that takes a mutable reference to the database
-/// and returns a [`Relation`] value. The closure is re-evaluated each time the
-/// view is queried, ensuring the view always reflects the current state of the
-/// underlying base relvars.
+/// A virtual relvar definition is a closure that takes a mutable reference to the
+/// database and returns a [`Relation`] value. The closure is re-evaluated each time
+/// the virtual relvar is queried, ensuring it always reflects the current state of
+/// the underlying base relvars.
 ///
-/// TTM: RM Prescription 10 - Views are virtual relation variables defined by
-/// relational expressions. They are not stored, but computed on demand.
+/// TTM: RM Prescription 10 - Virtual relvars (virtual relation variables) are defined
+/// by relational expressions. They are not stored, but computed on demand.
 ///
 /// # Thread Safety
 ///
-/// View definitions must be `Send + Sync` to allow the database to be used
+/// Virtual relvar definitions must be `Send + Sync` to allow the database to be used
 /// across threads safely.
-pub type ViewDefinition =
+pub type VirtualRelvarDefinition =
     Box<dyn Fn(&mut Database) -> Result<Relation, DatabaseError> + Send + Sync>;
 
 /// A database instance managing relations, storage, and constraints.
@@ -176,7 +175,7 @@ pub type ViewDefinition =
 /// `Database` is the main entry point for all database operations. It manages:
 ///
 /// - **Relations (Relvars)**: Create, drop, and query base relations
-/// - **Views**: Virtual relvars defined by expressions (TTM RM Prescription 10)
+/// - **Virtual Relvars**: Virtual relation variables defined by expressions (TTM RM Prescription 10)
 /// - **Data Manipulation**: Insert, update, and delete tuples
 /// - **Constraints**: Primary keys, foreign keys, and type constraints
 /// - **Transactions**: Begin, commit, and rollback operations
@@ -249,11 +248,11 @@ pub struct Database {
     /// This is a simplified implementation that stores full relation snapshots.
     /// A production system would use write-ahead logging (WAL).
     savepoint: Option<HashMap<String, Relation>>,
-    /// Views (virtual relvars) defined by expressions.
+    /// Virtual relvars defined by expressions.
     ///
-    /// TTM: RM Prescription 10 - Views are virtual relation variables that
+    /// TTM: RM Prescription 10 - Virtual relvars (virtual relation variables)
     /// re-evaluate their defining expression on each query.
-    views: HashMap<String, ViewDefinition>,
+    virtual_relvars: HashMap<String, VirtualRelvarDefinition>,
 }
 
 impl Database {
@@ -309,7 +308,7 @@ impl Database {
             type_constraints: HashMap::new(),
             in_transaction: false,
             savepoint: None,
-            views: HashMap::new(),
+            virtual_relvars: HashMap::new(),
         })
     }
 
@@ -353,9 +352,9 @@ impl Database {
             return Err(DatabaseError::RelationAlreadyExists(name.to_string()));
         }
 
-        // Check if a view with this name exists
-        if self.views.contains_key(name) {
-            return Err(DatabaseError::ViewAlreadyExists(name.to_string()));
+        // Check if a virtual relvar with this name exists
+        if self.virtual_relvars.contains_key(name) {
+            return Err(DatabaseError::VirtualRelvarAlreadyExists(name.to_string()));
         }
 
         // Create heap file
@@ -418,14 +417,14 @@ impl Database {
         Ok(())
     }
 
-    /// Creates a new view (virtual relvar).
+    /// Creates a new virtual relvar.
     ///
-    /// TTM: RM Prescription 10 - The system must support views (virtual relation
-    /// variables defined by expressions).
+    /// TTM: RM Prescription 10 - The system must support virtual relvars (virtual
+    /// relation variables defined by expressions).
     ///
-    /// Views are read-only and re-evaluate their defining expression on each query.
-    /// The view definition is a closure that takes a mutable reference to the database
-    /// and returns a relation value.
+    /// Virtual relvars are read-only and re-evaluate their defining expression on
+    /// each query. The definition is a closure that takes a mutable reference to
+    /// the database and returns a relation value.
     ///
     /// # Examples
     ///
@@ -447,17 +446,17 @@ impl Database {
     /// db.insert("EMP", tuple! { id: 1i64, salary: 150000.0 }).unwrap();
     /// db.insert("EMP", tuple! { id: 2i64, salary: 50000.0 }).unwrap();
     ///
-    /// // Create a view for high earners (salary > 100000)
-    /// db.create_view("HIGH_EARNERS", |db| {
+    /// // Create a virtual relvar for high earners (salary > 100000)
+    /// db.create_virtual_relvar("HIGH_EARNERS", |db| {
     ///     Ok(db.query("EMP")?
     ///         .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 100000.0))
     /// }).unwrap();
     ///
-    /// // Query the view - re-evaluates each time
+    /// // Query the virtual relvar - re-evaluates each time
     /// let high_earners = db.query("HIGH_EARNERS").unwrap();
     /// assert_eq!(high_earners.cardinality(), 1);
     ///
-    /// // Views are read-only - insert fails
+    /// // Virtual relvars are read-only - insert fails
     /// let result = db.insert("HIGH_EARNERS", tuple! { id: 3i64, salary: 200000.0 });
     /// assert!(result.is_err());
     /// ```
@@ -467,9 +466,13 @@ impl Database {
     /// Returns [`DatabaseError::RelationAlreadyExists`] if a base relvar with the
     /// same name already exists.
     ///
-    /// Returns [`DatabaseError::ViewAlreadyExists`] if a view with the same name
-    /// already exists.
-    pub fn create_view<F>(&mut self, name: &str, definition: F) -> Result<(), DatabaseError>
+    /// Returns [`DatabaseError::VirtualRelvarAlreadyExists`] if a virtual relvar
+    /// with the same name already exists.
+    pub fn create_virtual_relvar<F>(
+        &mut self,
+        name: &str,
+        definition: F,
+    ) -> Result<(), DatabaseError>
     where
         F: Fn(&mut Database) -> Result<Relation, DatabaseError> + Send + Sync + 'static,
     {
@@ -478,46 +481,48 @@ impl Database {
             return Err(DatabaseError::RelationAlreadyExists(name.to_string()));
         }
 
-        // Check if a view with this name already exists
-        if self.views.contains_key(name) {
-            return Err(DatabaseError::ViewAlreadyExists(name.to_string()));
+        // Check if a virtual relvar with this name already exists
+        if self.virtual_relvars.contains_key(name) {
+            return Err(DatabaseError::VirtualRelvarAlreadyExists(name.to_string()));
         }
 
-        // Store the view definition
-        self.views.insert(name.to_string(), Box::new(definition));
+        // Store the virtual relvar definition
+        self.virtual_relvars
+            .insert(name.to_string(), Box::new(definition));
 
         Ok(())
     }
 
-    /// Drops a view.
+    /// Drops a virtual relvar.
     ///
-    /// Removes the view definition from the database. This does not affect
-    /// any base relvars that the view was derived from.
+    /// Removes the virtual relvar definition from the database. This does not
+    /// affect any base relvars that the virtual relvar was derived from.
     ///
     /// # Errors
     ///
-    /// Returns [`DatabaseError::ViewNotFound`] if no view with the given name exists.
-    pub fn drop_view(&mut self, name: &str) -> Result<(), DatabaseError> {
-        if self.views.remove(name).is_none() {
-            return Err(DatabaseError::ViewNotFound(name.to_string()));
+    /// Returns [`DatabaseError::VirtualRelvarNotFound`] if no virtual relvar with
+    /// the given name exists.
+    pub fn drop_virtual_relvar(&mut self, name: &str) -> Result<(), DatabaseError> {
+        if self.virtual_relvars.remove(name).is_none() {
+            return Err(DatabaseError::VirtualRelvarNotFound(name.to_string()));
         }
         Ok(())
     }
 
-    /// Checks if a view exists.
+    /// Checks if a virtual relvar exists.
     ///
-    /// Returns `true` if a view with the given name exists, `false` otherwise.
-    /// This only checks for views, not base relvars.
-    pub fn view_exists(&self, name: &str) -> bool {
-        self.views.contains_key(name)
+    /// Returns `true` if a virtual relvar with the given name exists, `false` otherwise.
+    /// This only checks for virtual relvars, not base relvars.
+    pub fn virtual_relvar_exists(&self, name: &str) -> bool {
+        self.virtual_relvars.contains_key(name)
     }
 
-    /// Lists all view names.
+    /// Lists all virtual relvar names.
     ///
-    /// Returns a vector of all view names currently defined in the database.
+    /// Returns a vector of all virtual relvar names currently defined in the database.
     /// This does not include base relvars.
-    pub fn list_views(&self) -> Vec<String> {
-        self.views.keys().cloned().collect()
+    pub fn list_virtual_relvars(&self) -> Vec<String> {
+        self.virtual_relvars.keys().cloned().collect()
     }
 
     /// Sets key constraints (primary and candidate keys) for a relation.
@@ -706,9 +711,11 @@ impl Database {
     /// # Ok::<(), relvar::DatabaseError>(())
     /// ```
     pub fn insert(&mut self, relation_name: &str, tuple: Tuple) -> Result<(), DatabaseError> {
-        // Check if trying to insert into a view
-        if self.views.contains_key(relation_name) {
-            return Err(DatabaseError::CannotModifyView(relation_name.to_string()));
+        // Check if trying to insert into a virtual relvar
+        if self.virtual_relvars.contains_key(relation_name) {
+            return Err(DatabaseError::CannotModifyVirtualRelvar(
+                relation_name.to_string(),
+            ));
         }
 
         // Get relation metadata
@@ -788,12 +795,12 @@ impl Database {
         Ok(())
     }
 
-    /// Queries a relation or view, returning all tuples as a [`Relation`] value.
+    /// Queries a relation or virtual relvar, returning all tuples as a [`Relation`] value.
     ///
     /// For base relvars, this loads the relation from storage.
-    /// For views, this re-evaluates the view definition and returns the result.
+    /// For virtual relvars, this re-evaluates the definition and returns the result.
     ///
-    /// TTM: RM Prescription 10 - Views re-evaluate their defining expression
+    /// TTM: RM Prescription 10 - Virtual relvars re-evaluate their defining expression
     /// on each query, ensuring they always reflect the current state of the
     /// underlying base relvars.
     ///
@@ -802,7 +809,7 @@ impl Database {
     ///
     /// # Arguments
     ///
-    /// * `relation_name` - The name of the relation or view to query
+    /// * `relation_name` - The name of the relation or virtual relvar to query
     ///
     /// # Returns
     ///
@@ -810,8 +817,8 @@ impl Database {
     ///
     /// # Errors
     ///
-    /// Returns [`DatabaseError::RelationNotFound`] if neither a relation nor
-    /// a view with the given name exists.
+    /// Returns [`DatabaseError::RelationNotFound`] if neither a base relvar nor
+    /// a virtual relvar with the given name exists.
     ///
     /// # Example
     ///
@@ -829,9 +836,9 @@ impl Database {
     /// # Ok::<(), relvar::DatabaseError>(())
     /// ```
     pub fn query(&mut self, relation_name: &str) -> Result<Relation, DatabaseError> {
-        // Check if this is a view - if so, evaluate the view definition
-        if self.views.contains_key(relation_name) {
-            return self.query_view(relation_name);
+        // Check if this is a virtual relvar - if so, evaluate the definition
+        if self.virtual_relvars.contains_key(relation_name) {
+            return self.query_virtual_relvar(relation_name);
         }
 
         // Otherwise, query the base relvar
@@ -862,22 +869,22 @@ impl Database {
         Ok(relation)
     }
 
-    /// Queries a view by evaluating its definition.
+    /// Queries a virtual relvar by evaluating its definition.
     ///
-    /// This temporarily removes the view definition to avoid borrow issues,
+    /// This temporarily removes the virtual relvar definition to avoid borrow issues,
     /// evaluates it, and puts it back.
-    fn query_view(&mut self, view_name: &str) -> Result<Relation, DatabaseError> {
-        // Temporarily remove the view definition to avoid borrow issues
-        let view_def = self
-            .views
-            .remove(view_name)
-            .ok_or_else(|| DatabaseError::ViewNotFound(view_name.to_string()))?;
+    fn query_virtual_relvar(&mut self, name: &str) -> Result<Relation, DatabaseError> {
+        // Temporarily remove the virtual relvar definition to avoid borrow issues
+        let definition = self
+            .virtual_relvars
+            .remove(name)
+            .ok_or_else(|| DatabaseError::VirtualRelvarNotFound(name.to_string()))?;
 
-        // Evaluate the view definition
-        let result = view_def(self);
+        // Evaluate the virtual relvar definition
+        let result = definition(self);
 
-        // Put the view definition back
-        self.views.insert(view_name.to_string(), view_def);
+        // Put the virtual relvar definition back
+        self.virtual_relvars.insert(name.to_string(), definition);
 
         result
     }
@@ -918,9 +925,11 @@ impl Database {
     where
         F: Fn(&Tuple) -> bool,
     {
-        // Check if trying to delete from a view
-        if self.views.contains_key(relation_name) {
-            return Err(DatabaseError::CannotModifyView(relation_name.to_string()));
+        // Check if trying to delete from a virtual relvar
+        if self.virtual_relvars.contains_key(relation_name) {
+            return Err(DatabaseError::CannotModifyVirtualRelvar(
+                relation_name.to_string(),
+            ));
         }
 
         // Clone foreign key constraints to avoid borrowing issues
@@ -1040,9 +1049,11 @@ impl Database {
         F: Fn(&Tuple) -> bool,
         U: Fn(&mut Tuple),
     {
-        // Check if trying to update a view
-        if self.views.contains_key(relation_name) {
-            return Err(DatabaseError::CannotModifyView(relation_name.to_string()));
+        // Check if trying to update a virtual relvar
+        if self.virtual_relvars.contains_key(relation_name) {
+            return Err(DatabaseError::CannotModifyVirtualRelvar(
+                relation_name.to_string(),
+            ));
         }
 
         // Get metadata (clone to avoid borrow issues)
@@ -1604,11 +1615,11 @@ mod tests {
     }
 
     // ==========================================================================
-    // View Tests (TTM RM Prescription 10 - Virtual Relation Variables)
+    // Virtual Relvar Tests (TTM RM Prescription 10 - Virtual Relation Variables)
     // ==========================================================================
 
     #[test]
-    fn test_create_view() {
+    fn test_create_virtual_relvar() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
@@ -1620,18 +1631,18 @@ mod tests {
 
         db.create_relvar("EMP", relation_type).unwrap();
 
-        db.create_view("HIGH_EARNERS", |db| {
+        db.create_virtual_relvar("HIGH_EARNERS", |db| {
             Ok(db
                 .query("EMP")?
                 .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 100000.0))
         })
         .unwrap();
 
-        assert!(db.view_exists("HIGH_EARNERS"));
+        assert!(db.virtual_relvar_exists("HIGH_EARNERS"));
     }
 
     #[test]
-    fn test_view_re_evaluates_on_query() {
+    fn test_virtual_relvar_re_evaluates_on_query() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
@@ -1648,7 +1659,7 @@ mod tests {
         db.insert("EMP", tuple! { id: 2i64, name: "Bob", salary: 50000.0 })
             .unwrap();
 
-        db.create_view("HIGH_EARNERS", |db| {
+        db.create_virtual_relvar("HIGH_EARNERS", |db| {
             Ok(db
                 .query("EMP")?
                 .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 100000.0))
@@ -1669,7 +1680,7 @@ mod tests {
     }
 
     #[test]
-    fn test_view_appears_in_catalog() {
+    fn test_virtual_relvar_appears_in_listing() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
@@ -1680,15 +1691,15 @@ mod tests {
 
         db.create_relvar("EMP", relation_type).unwrap();
 
-        db.create_view("NAMES_ONLY", |db| Ok(db.query("EMP")?.project(&["name"])))
+        db.create_virtual_relvar("NAMES_ONLY", |db| Ok(db.query("EMP")?.project(&["name"])))
             .unwrap();
 
-        let views = db.list_views();
-        assert!(views.contains(&"NAMES_ONLY".to_string()));
+        let virtual_relvars = db.list_virtual_relvars();
+        assert!(virtual_relvars.contains(&"NAMES_ONLY".to_string()));
     }
 
     #[test]
-    fn test_drop_view() {
+    fn test_drop_virtual_relvar() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
@@ -1699,18 +1710,18 @@ mod tests {
 
         db.create_relvar("EMP", relation_type).unwrap();
 
-        db.create_view("NAMES_ONLY", |db| Ok(db.query("EMP")?.project(&["name"])))
+        db.create_virtual_relvar("NAMES_ONLY", |db| Ok(db.query("EMP")?.project(&["name"])))
             .unwrap();
 
-        assert!(db.view_exists("NAMES_ONLY"));
+        assert!(db.virtual_relvar_exists("NAMES_ONLY"));
 
-        db.drop_view("NAMES_ONLY").unwrap();
+        db.drop_virtual_relvar("NAMES_ONLY").unwrap();
 
-        assert!(!db.view_exists("NAMES_ONLY"));
+        assert!(!db.virtual_relvar_exists("NAMES_ONLY"));
     }
 
     #[test]
-    fn test_insert_into_view_fails() {
+    fn test_insert_into_virtual_relvar_fails() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
@@ -1721,18 +1732,19 @@ mod tests {
 
         db.create_relvar("EMP", relation_type).unwrap();
 
-        db.create_view("EMP_VIEW", |db| db.query("EMP")).unwrap();
+        db.create_virtual_relvar("EMP_VIRTUAL", |db| db.query("EMP"))
+            .unwrap();
 
-        let result = db.insert("EMP_VIEW", tuple! { id: 1i64, name: "Alice" });
+        let result = db.insert("EMP_VIRTUAL", tuple! { id: 1i64, name: "Alice" });
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            DatabaseError::CannotModifyView(_)
+            DatabaseError::CannotModifyVirtualRelvar(_)
         ));
     }
 
     #[test]
-    fn test_delete_from_view_fails() {
+    fn test_delete_from_virtual_relvar_fails() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
@@ -1745,18 +1757,19 @@ mod tests {
         db.insert("EMP", tuple! { id: 1i64, name: "Alice" })
             .unwrap();
 
-        db.create_view("EMP_VIEW", |db| db.query("EMP")).unwrap();
+        db.create_virtual_relvar("EMP_VIRTUAL", |db| db.query("EMP"))
+            .unwrap();
 
-        let result = db.delete("EMP_VIEW", |_| true);
+        let result = db.delete("EMP_VIRTUAL", |_| true);
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            DatabaseError::CannotModifyView(_)
+            DatabaseError::CannotModifyVirtualRelvar(_)
         ));
     }
 
     #[test]
-    fn test_update_view_fails() {
+    fn test_update_virtual_relvar_fails() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
@@ -1769,10 +1782,11 @@ mod tests {
         db.insert("EMP", tuple! { id: 1i64, name: "Alice" })
             .unwrap();
 
-        db.create_view("EMP_VIEW", |db| db.query("EMP")).unwrap();
+        db.create_virtual_relvar("EMP_VIRTUAL", |db| db.query("EMP"))
+            .unwrap();
 
         let result = db.update(
-            "EMP_VIEW",
+            "EMP_VIRTUAL",
             |_| true,
             |t| {
                 t.set("name".to_string(), ScalarValue::String("Bob".to_string()))
@@ -1782,12 +1796,12 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            DatabaseError::CannotModifyView(_)
+            DatabaseError::CannotModifyVirtualRelvar(_)
         ));
     }
 
     #[test]
-    fn test_query_nonexistent_view_fails() {
+    fn test_query_nonexistent_relvar_fails() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
@@ -1800,7 +1814,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_duplicate_view_fails() {
+    fn test_create_duplicate_virtual_relvar_fails() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
@@ -1809,18 +1823,19 @@ mod tests {
 
         db.create_relvar("EMP", relation_type).unwrap();
 
-        db.create_view("EMP_VIEW", |db| db.query("EMP")).unwrap();
+        db.create_virtual_relvar("EMP_VIRTUAL", |db| db.query("EMP"))
+            .unwrap();
 
-        let result = db.create_view("EMP_VIEW", |db| db.query("EMP"));
+        let result = db.create_virtual_relvar("EMP_VIRTUAL", |db| db.query("EMP"));
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            DatabaseError::ViewAlreadyExists(_)
+            DatabaseError::VirtualRelvarAlreadyExists(_)
         ));
     }
 
     #[test]
-    fn test_view_with_same_name_as_relvar_fails() {
+    fn test_virtual_relvar_with_same_name_as_relvar_fails() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
@@ -1829,7 +1844,7 @@ mod tests {
 
         db.create_relvar("EMP", relation_type).unwrap();
 
-        let result = db.create_view("EMP", |db| db.query("EMP"));
+        let result = db.create_virtual_relvar("EMP", |db| db.query("EMP"));
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -1838,7 +1853,7 @@ mod tests {
     }
 
     #[test]
-    fn test_relvar_with_same_name_as_view_fails() {
+    fn test_relvar_with_same_name_as_virtual_relvar_fails() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
@@ -1847,31 +1862,32 @@ mod tests {
 
         db.create_relvar("EMP", relation_type).unwrap();
 
-        db.create_view("EMP_VIEW", |db| db.query("EMP")).unwrap();
+        db.create_virtual_relvar("EMP_VIRTUAL", |db| db.query("EMP"))
+            .unwrap();
 
-        let result = db.create_relvar("EMP_VIEW", RelationType::new(tuple_type));
+        let result = db.create_relvar("EMP_VIRTUAL", RelationType::new(tuple_type));
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            DatabaseError::ViewAlreadyExists(_)
+            DatabaseError::VirtualRelvarAlreadyExists(_)
         ));
     }
 
     #[test]
-    fn test_drop_nonexistent_view_fails() {
+    fn test_drop_nonexistent_virtual_relvar_fails() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
-        let result = db.drop_view("NONEXISTENT");
+        let result = db.drop_virtual_relvar("NONEXISTENT");
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            DatabaseError::ViewNotFound(_)
+            DatabaseError::VirtualRelvarNotFound(_)
         ));
     }
 
     #[test]
-    fn test_view_with_join() {
+    fn test_virtual_relvar_with_join() {
         let temp_dir = TempDir::new().unwrap();
         let mut db = Database::open(temp_dir.path()).unwrap();
 
@@ -1900,7 +1916,7 @@ mod tests {
         db.insert("DEPT", tuple! { dept_id: 20i64, dept_name: "Sales" })
             .unwrap();
 
-        db.create_view("EMP_WITH_DEPT", |db| {
+        db.create_virtual_relvar("EMP_WITH_DEPT", |db| {
             let emp = db.query("EMP")?;
             let dept = db.query("DEPT")?;
             Ok(emp.join(&dept))


### PR DESCRIPTION
## Summary

- Implements views (virtual relation variables) per TTM RM Prescription 10
- Views are defined by expressions that re-evaluate on each query
- Views are read-only (cannot insert/update/delete)
- Namespace shared with base relvars to prevent collisions
- Includes comprehensive tests (12 test cases) and benchmarks

## TTM Compliance

This implements **RM Prescription 10** from The Third Manifesto:
> The system shall support virtual relvars (views).

Key TTM properties:
- Views are relation variables (can be queried like base relvars)
- View expressions re-evaluate on each query (no materialization)
- Views participate in the relvar namespace (no duplicate names)

## API

```rust
// Create a view
db.create_view("HIGH_EARNERS", |db| {
    Ok(db.query("EMP")?
        .restrict(|t| t.get_typed::<f64>("salary").unwrap() > 60000.0))
})?;

// Query the view (re-evaluates expression)
let result = db.query("HIGH_EARNERS")?;

// Views are read-only
db.insert("HIGH_EARNERS", tuple)?;  // Error: CannotModifyView

// Management
db.view_exists("HIGH_EARNERS");  // true
db.list_views();  // ["HIGH_EARNERS"]
db.drop_view("HIGH_EARNERS")?;
```

## Test plan

- [x] Basic view creation and query
- [x] Views re-evaluate on underlying data changes
- [x] Views appear in catalog/listing
- [x] Drop view works correctly
- [x] Insert/update/delete on views return errors
- [x] Namespace collision prevention (view vs relvar)
- [x] Error handling for nonexistent views
- [x] Complex views (with joins)
- [x] Benchmarks for performance profiling

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)