### PR TITLE
feat: remove attribute ordering (TTM Proscription 4)

### DIFF
--- a/src/algebra/divide.rs
+++ b/src/algebra/divide.rs
@@ -132,7 +132,7 @@ fn filter_matching_candidates(
     dividend: &Relation,
     dividend_heading: &crate::types::TupleType,
 ) -> Vec<crate::values::Tuple> {
-    use std::collections::BTreeMap;
+    use std::collections::HashMap;
 
     // Clone dividend_heading once outside the loop to avoid repeated clones
     let dividend_heading = dividend_heading.clone();
@@ -143,7 +143,7 @@ fn filter_matching_candidates(
             // Check if ALL divisor tuples match when extended with this candidate
             divisor.tuples().all(|divisor_tuple| {
                 // Extend candidate with divisor tuple using iterator-based approach
-                let extended_values: BTreeMap<_, _> = candidate
+                let extended_values: HashMap<_, _> = candidate
                     .values()
                     .iter()
                     .chain(divisor_tuple.values())

--- a/src/algebra/group.rs
+++ b/src/algebra/group.rs
@@ -36,7 +36,7 @@
 
 use crate::types::{RelationType, ScalarType, TupleType};
 use crate::values::{Relation, ScalarValue, Tuple};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use thiserror::Error;
 
 /// Errors that can occur during group operations.
@@ -206,7 +206,7 @@ impl GroupOps for Relation {
                 .collect();
 
             // Extract grouped attributes for RVA
-            let mut rva_values = BTreeMap::new();
+            let mut rva_values = HashMap::new();
             for attr in attrs_to_group {
                 rva_values.insert(attr.to_string(), tuple.get(attr).unwrap().clone());
             }
@@ -220,7 +220,7 @@ impl GroupOps for Relation {
         // Build result tuples
         let mut result_tuples = Vec::new();
         for (key, rva_tuples) in groups {
-            let mut values = BTreeMap::new();
+            let mut values = HashMap::new();
 
             // Add grouping attribute values
             for (i, attr) in grouping_attrs.iter().enumerate() {
@@ -300,7 +300,7 @@ impl GroupOps for Relation {
 
             // For each tuple in the RVA, create a new tuple combining non-RVA and RVA attributes
             for rva_tuple in rva_relation.tuples() {
-                let mut values = BTreeMap::new();
+                let mut values = HashMap::new();
 
                 // Add non-RVA attribute values
                 for attr_name in self.relation_type().tuple_type().attribute_names() {

--- a/src/algebra/join.rs
+++ b/src/algebra/join.rs
@@ -42,7 +42,7 @@
 
 use crate::types::{RelationType, TupleType};
 use crate::values::{Relation, Tuple};
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 impl Relation {
     /// Performs a natural join with another relation.
@@ -138,7 +138,7 @@ impl Relation {
 
                 if matches {
                     // Combine tuples
-                    let mut combined_values = BTreeMap::new();
+                    let mut combined_values = HashMap::new();
 
                     // Add all values from tuple1
                     for (attr_name, value) in tuple1.values() {
@@ -256,7 +256,7 @@ impl Relation {
             for tuple2 in other.tuples() {
                 if predicate(tuple1, tuple2) {
                     // Combine tuples
-                    let mut combined_values = BTreeMap::new();
+                    let mut combined_values = HashMap::new();
 
                     for (attr_name, value) in tuple1.values() {
                         combined_values.insert(attr_name.clone(), value.clone());

--- a/src/algebra/project.rs
+++ b/src/algebra/project.rs
@@ -32,7 +32,7 @@
 
 use crate::types::{RelationType, TupleType};
 use crate::values::{Relation, Tuple};
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 impl Relation {
     /// Projects this relation onto a subset of attributes.
@@ -87,7 +87,7 @@ impl Relation {
         let projected_tuples: Vec<_> = self
             .tuples()
             .map(|tuple| {
-                let mut values = BTreeMap::new();
+                let mut values = HashMap::new();
                 for attr_name in attributes {
                     if let Some(value) = tuple.get(attr_name) {
                         values.insert(attr_name.to_string(), value.clone());

--- a/src/algebra/rename.rs
+++ b/src/algebra/rename.rs
@@ -31,7 +31,7 @@
 
 use crate::types::{RelationType, TupleType};
 use crate::values::{Relation, Tuple};
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 impl Relation {
     /// Renames attributes in this relation according to the provided mapping.
@@ -103,7 +103,7 @@ impl Relation {
         let renamed_tuples: Vec<_> = self
             .tuples()
             .map(|tuple| {
-                let mut values = BTreeMap::new();
+                let mut values = HashMap::new();
 
                 for (old_name, value) in tuple.values() {
                     let new_name = mappings

--- a/src/algebra/summarize.rs
+++ b/src/algebra/summarize.rs
@@ -40,7 +40,7 @@
 
 use crate::types::{RelationType, ScalarType, TupleType};
 use crate::values::{Relation, ScalarValue, Tuple};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use thiserror::Error;
 
 /// Errors that can occur during summarize operations.
@@ -475,7 +475,7 @@ impl SummarizeOps for Relation {
         // Compute aggregations for each group
         let mut result_tuples = Vec::new();
         for (key, group_tuples) in groups {
-            let mut values = BTreeMap::new();
+            let mut values = HashMap::new();
 
             // Add grouping attribute values
             for (i, attr) in group_by.iter().enumerate() {

--- a/src/types/relation_type.rs
+++ b/src/types/relation_type.rs
@@ -60,7 +60,7 @@ use serde::{Deserialize, Serialize};
 /// assert!(employee_type.has_attribute("emp_id"));
 /// assert!(!employee_type.has_attribute("salary"));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RelationType {
     /// The heading (tuple type) that defines this relation type.
     heading: TupleType,
@@ -168,6 +168,13 @@ impl RelationType {
     /// ```
     pub fn has_attribute(&self, name: &str) -> bool {
         self.heading.has_attribute(name)
+    }
+}
+
+impl std::hash::Hash for RelationType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Just hash the heading
+        self.heading.hash(state);
     }
 }
 

--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -432,4 +432,188 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), int_value);
     }
+
+    // Tests for Ord/PartialOrd implementations (for coverage)
+    #[test]
+    fn test_scalar_type_ord_basic_types() {
+        use std::cmp::Ordering;
+
+        // Test discriminant ordering: Int < Float < String < Bool < Bytes < Relation < UserDefined
+        assert_eq!(ScalarType::Int.cmp(&ScalarType::Float), Ordering::Less);
+        assert_eq!(ScalarType::Float.cmp(&ScalarType::String), Ordering::Less);
+        assert_eq!(ScalarType::String.cmp(&ScalarType::Bool), Ordering::Less);
+        assert_eq!(ScalarType::Bool.cmp(&ScalarType::Bytes), Ordering::Less);
+
+        // Same types are equal
+        assert_eq!(ScalarType::Int.cmp(&ScalarType::Int), Ordering::Equal);
+        assert_eq!(ScalarType::Float.cmp(&ScalarType::Float), Ordering::Equal);
+        assert_eq!(ScalarType::String.cmp(&ScalarType::String), Ordering::Equal);
+        assert_eq!(ScalarType::Bool.cmp(&ScalarType::Bool), Ordering::Equal);
+        assert_eq!(ScalarType::Bytes.cmp(&ScalarType::Bytes), Ordering::Equal);
+    }
+
+    #[test]
+    fn test_scalar_type_ord_relation_types() {
+        use crate::types::{RelationType, TupleType};
+        use std::cmp::Ordering;
+
+        // Create relation types with different headings
+        let heading_a = TupleType::new().with_attribute("a", ScalarType::Int);
+        let heading_b = TupleType::new().with_attribute("b", ScalarType::Int);
+        let heading_a_copy = TupleType::new().with_attribute("a", ScalarType::Int);
+
+        let rel_type_a = ScalarType::Relation(Box::new(RelationType::new(heading_a)));
+        let rel_type_b = ScalarType::Relation(Box::new(RelationType::new(heading_b)));
+        let rel_type_a_copy = ScalarType::Relation(Box::new(RelationType::new(heading_a_copy)));
+
+        // Same heading should be equal
+        assert_eq!(rel_type_a.cmp(&rel_type_a_copy), Ordering::Equal);
+
+        // Different headings should have consistent ordering
+        let result = rel_type_a.cmp(&rel_type_b);
+        assert_ne!(result, Ordering::Equal);
+
+        // Ordering should be transitive and antisymmetric
+        assert_eq!(rel_type_b.cmp(&rel_type_a), result.reverse());
+    }
+
+    #[test]
+    fn test_scalar_type_ord_relation_types_different_degrees() {
+        use crate::types::{RelationType, TupleType};
+        use std::cmp::Ordering;
+
+        // Different degree headings
+        let heading_1 = TupleType::new().with_attribute("a", ScalarType::Int);
+        let heading_2 = TupleType::new()
+            .with_attribute("a", ScalarType::Int)
+            .with_attribute("b", ScalarType::Int);
+
+        let rel_type_1 = ScalarType::Relation(Box::new(RelationType::new(heading_1)));
+        let rel_type_2 = ScalarType::Relation(Box::new(RelationType::new(heading_2)));
+
+        // Different degrees should have consistent ordering
+        let result = rel_type_1.cmp(&rel_type_2);
+        assert_ne!(result, Ordering::Equal);
+        assert_eq!(rel_type_2.cmp(&rel_type_1), result.reverse());
+    }
+
+    #[test]
+    fn test_scalar_type_ord_user_defined_by_name() {
+        use std::cmp::Ordering;
+
+        let widget_id = ScalarType::user_defined("WidgetId", ScalarType::Int);
+        let supplier_id = ScalarType::user_defined("SupplierId", ScalarType::Int);
+        let widget_id_copy = ScalarType::user_defined("WidgetId", ScalarType::Int);
+
+        // Same name and representation should be equal
+        assert_eq!(widget_id.cmp(&widget_id_copy), Ordering::Equal);
+
+        // Different names should have consistent ordering
+        let result = widget_id.cmp(&supplier_id);
+        assert_ne!(result, Ordering::Equal);
+        assert_eq!(supplier_id.cmp(&widget_id), result.reverse());
+    }
+
+    #[test]
+    fn test_scalar_type_ord_user_defined_by_representation() {
+        use std::cmp::Ordering;
+
+        // Same name but different representation
+        let widget_id_int = ScalarType::user_defined("WidgetId", ScalarType::Int);
+        let widget_id_string = ScalarType::user_defined("WidgetId", ScalarType::String);
+
+        // Different representations should have consistent ordering
+        let result = widget_id_int.cmp(&widget_id_string);
+        assert_ne!(result, Ordering::Equal);
+        assert_eq!(widget_id_string.cmp(&widget_id_int), result.reverse());
+    }
+
+    #[test]
+    fn test_scalar_type_ord_mixed_variants() {
+        use crate::types::{RelationType, TupleType};
+        use std::cmp::Ordering;
+
+        let int_type = ScalarType::Int;
+        let relation_type = ScalarType::Relation(Box::new(RelationType::new(
+            TupleType::new().with_attribute("a", ScalarType::Int),
+        )));
+        let user_type = ScalarType::user_defined("CustomType", ScalarType::Int);
+
+        // Relation comes after basic types
+        assert_eq!(int_type.cmp(&relation_type), Ordering::Less);
+
+        // UserDefined comes after Relation
+        assert_eq!(relation_type.cmp(&user_type), Ordering::Less);
+
+        // Transitive property
+        assert_eq!(int_type.cmp(&user_type), Ordering::Less);
+    }
+
+    #[test]
+    fn test_scalar_type_partial_ord_consistency() {
+        // PartialOrd should be consistent with Ord
+        let int_type = ScalarType::Int;
+        let float_type = ScalarType::Float;
+
+        assert_eq!(
+            int_type.partial_cmp(&float_type),
+            Some(int_type.cmp(&float_type))
+        );
+        assert_eq!(
+            int_type.partial_cmp(&int_type),
+            Some(std::cmp::Ordering::Equal)
+        );
+    }
+
+    #[test]
+    fn test_scalar_type_ord_reflexivity() {
+        // x.cmp(x) == Equal (reflexivity)
+        let types = vec![
+            ScalarType::Int,
+            ScalarType::Float,
+            ScalarType::String,
+            ScalarType::Bool,
+            ScalarType::Bytes,
+            ScalarType::user_defined("Test", ScalarType::Int),
+        ];
+
+        for ty in types {
+            assert_eq!(ty.cmp(&ty), std::cmp::Ordering::Equal);
+        }
+    }
+
+    #[test]
+    fn test_scalar_type_ord_transitivity() {
+        use std::cmp::Ordering;
+
+        // If a < b and b < c, then a < c (transitivity)
+        let a = ScalarType::Int;
+        let b = ScalarType::Float;
+        let c = ScalarType::String;
+
+        assert_eq!(a.cmp(&b), Ordering::Less);
+        assert_eq!(b.cmp(&c), Ordering::Less);
+        assert_eq!(a.cmp(&c), Ordering::Less);
+    }
+
+    #[test]
+    fn test_scalar_type_can_be_sorted() {
+        // Practical test: should be able to sort a Vec of ScalarTypes
+        let mut types = [
+            ScalarType::String,
+            ScalarType::Int,
+            ScalarType::Float,
+            ScalarType::Bool,
+            ScalarType::Bytes,
+        ];
+
+        types.sort();
+
+        // Should be sorted by discriminant order
+        assert_eq!(types[0], ScalarType::Int);
+        assert_eq!(types[1], ScalarType::Float);
+        assert_eq!(types[2], ScalarType::String);
+        assert_eq!(types[3], ScalarType::Bool);
+        assert_eq!(types[4], ScalarType::Bytes);
+    }
 }

--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -92,7 +92,7 @@ pub enum ScalarTypeError {
 /// // These are different types despite same representation
 /// assert_ne!(employee_id, department_id);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ScalarType {
     /// 64-bit signed integer.
     ///
@@ -224,6 +224,122 @@ impl ScalarType {
                 }
                 Ok(value)
             }
+        }
+    }
+}
+
+impl std::hash::Hash for ScalarType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Hash the discriminant first
+        std::mem::discriminant(self).hash(state);
+
+        // Then hash the data based on variant
+        match self {
+            ScalarType::Int => {}
+            ScalarType::Float => {}
+            ScalarType::String => {}
+            ScalarType::Bool => {}
+            ScalarType::Bytes => {}
+            ScalarType::Relation(rel_type) => {
+                // Hash the relation type's heading
+                rel_type.heading().hash(state);
+            }
+            ScalarType::UserDefined {
+                name,
+                representation,
+            } => {
+                name.hash(state);
+                representation.hash(state);
+            }
+        }
+    }
+}
+
+impl PartialOrd for ScalarType {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ScalarType {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+
+        // Helper to get a discriminant value for ordering
+        let disc_value = |t: &ScalarType| match t {
+            ScalarType::Int => 0,
+            ScalarType::Float => 1,
+            ScalarType::String => 2,
+            ScalarType::Bool => 3,
+            ScalarType::Bytes => 4,
+            ScalarType::Relation(_) => 5,
+            ScalarType::UserDefined { .. } => 6,
+        };
+
+        match disc_value(self).cmp(&disc_value(other)) {
+            Ordering::Equal => {
+                // Same variant, compare data
+                match (self, other) {
+                    (ScalarType::Int, ScalarType::Int)
+                    | (ScalarType::Float, ScalarType::Float)
+                    | (ScalarType::String, ScalarType::String)
+                    | (ScalarType::Bool, ScalarType::Bool)
+                    | (ScalarType::Bytes, ScalarType::Bytes) => Ordering::Equal,
+                    (ScalarType::Relation(a), ScalarType::Relation(b)) => {
+                        // Compare relation types by their headings
+                        // Since TupleType doesn't have Ord, we need a custom comparison
+                        let a_attrs: Vec<_> = a
+                            .heading()
+                            .attribute_names()
+                            .map(|n| (n, a.heading().get_attribute_type(n).unwrap()))
+                            .collect();
+                        let b_attrs: Vec<_> = b
+                            .heading()
+                            .attribute_names()
+                            .map(|n| (n, b.heading().get_attribute_type(n).unwrap()))
+                            .collect();
+
+                        // Compare by count first, then by sorted attributes
+                        match a_attrs.len().cmp(&b_attrs.len()) {
+                            Ordering::Equal => {
+                                let mut a_sorted = a_attrs;
+                                let mut b_sorted = b_attrs;
+                                a_sorted.sort_by_key(|(name, _)| *name);
+                                b_sorted.sort_by_key(|(name, _)| *name);
+
+                                for ((a_name, a_ty), (b_name, b_ty)) in
+                                    a_sorted.iter().zip(b_sorted.iter())
+                                {
+                                    match a_name.cmp(b_name) {
+                                        Ordering::Equal => match a_ty.cmp(b_ty) {
+                                            Ordering::Equal => continue,
+                                            other => return other,
+                                        },
+                                        other => return other,
+                                    }
+                                }
+                                Ordering::Equal
+                            }
+                            other => other,
+                        }
+                    }
+                    (
+                        ScalarType::UserDefined {
+                            name: a_name,
+                            representation: a_rep,
+                        },
+                        ScalarType::UserDefined {
+                            name: b_name,
+                            representation: b_rep,
+                        },
+                    ) => match a_name.cmp(b_name) {
+                        Ordering::Equal => a_rep.cmp(b_rep),
+                        other => other,
+                    },
+                    _ => unreachable!("Discriminants matched but variants don't"),
+                }
+            }
+            other => other,
         }
     }
 }

--- a/src/types/tuple_type.rs
+++ b/src/types/tuple_type.rs
@@ -26,7 +26,7 @@
 
 use crate::types::ScalarType;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 /// Defines the structure (heading) of tuples.
 ///
@@ -37,9 +37,8 @@ use std::collections::BTreeMap;
 /// # Attribute Ordering
 ///
 /// Per TTM Proscription 4, attributes have no inherent ordering. They are
-/// identified solely by name. The implementation uses `BTreeMap` internally
-/// for deterministic iteration, but this ordering should not be relied upon
-/// for semantic purposes.
+/// identified solely by name. The implementation uses `HashMap` to enforce
+/// that there is no guaranteed ordering of attributes.
 ///
 /// # Type Equality
 ///
@@ -63,10 +62,10 @@ use std::collections::BTreeMap;
 /// assert_eq!(person_type.get_attribute_type("id"), Some(&ScalarType::Int));
 /// assert!(!person_type.has_attribute("nonexistent"));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TupleType {
     /// The attributes of this tuple type, mapping names to scalar types.
-    attributes: BTreeMap<String, ScalarType>,
+    attributes: HashMap<String, ScalarType>,
 }
 
 impl TupleType {
@@ -86,7 +85,7 @@ impl TupleType {
     /// ```
     pub fn new() -> Self {
         Self {
-            attributes: BTreeMap::new(),
+            attributes: HashMap::new(),
         }
     }
 
@@ -163,8 +162,8 @@ impl TupleType {
 
     /// Returns an iterator over all attribute names.
     ///
-    /// The order of iteration is deterministic (sorted by name) but should
-    /// not be relied upon for semantic purposes per TTM Proscription 4.
+    /// Per TTM Proscription 4, the order of iteration is arbitrary and
+    /// should not be relied upon. Attributes are identified by name only.
     ///
     /// # Example
     ///
@@ -219,7 +218,7 @@ impl TupleType {
     ///     println!("{}: {:?}", name, scalar_type);
     /// }
     /// ```
-    pub fn attributes(&self) -> &BTreeMap<String, ScalarType> {
+    pub fn attributes(&self) -> &HashMap<String, ScalarType> {
         &self.attributes
     }
 }
@@ -227,6 +226,23 @@ impl TupleType {
 impl Default for TupleType {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl std::hash::Hash for TupleType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Hash in a deterministic way by sorting the entries
+        let mut entries: Vec<_> = self.attributes.iter().collect();
+        entries.sort_by_key(|(name, _)| *name);
+
+        // Hash the count first
+        self.attributes.len().hash(state);
+
+        // Then hash each entry
+        for (name, ty) in entries {
+            name.hash(state);
+            ty.hash(state);
+        }
     }
 }
 
@@ -299,6 +315,34 @@ mod tests {
         assert!(!tuple_type.has_attribute("salary"));
     }
 
+    /// TTM Proscription 4: Attributes have no ordering.
+    ///
+    /// This test verifies that we don't guarantee any particular ordering
+    /// of attributes. The iteration order should be considered arbitrary
+    /// and must not be relied upon for semantic purposes.
+    #[test]
+    fn test_ttm_proscription_4_no_attribute_ordering() {
+        let tuple_type = TupleType::new()
+            .with_attribute("emp_id", ScalarType::Int)
+            .with_attribute("name", ScalarType::String)
+            .with_attribute("dept_id", ScalarType::Int);
+
+        let names: Vec<_> = tuple_type.attribute_names().cloned().collect();
+
+        // TTM Proscription 4: Attributes must have no ordering.
+        // We verify all expected attributes are present, but we do NOT
+        // check for any particular order.
+        assert_eq!(names.len(), 3);
+        assert!(names.contains(&"emp_id".to_string()));
+        assert!(names.contains(&"name".to_string()));
+        assert!(names.contains(&"dept_id".to_string()));
+
+        // PHILOSOPHICAL ISSUE with current BTreeMap implementation:
+        // BTreeMap imposes alphabetical ordering, which violates TTM even if
+        // we don't rely on it. The correct implementation should use HashMap
+        // to make it clear there is NO guaranteed ordering.
+    }
+
     #[test]
     fn test_attribute_names_iterator() {
         let tuple_type = TupleType::new()
@@ -308,8 +352,12 @@ mod tests {
 
         let names: Vec<_> = tuple_type.attribute_names().cloned().collect();
 
-        // BTreeMap maintains sorted order
-        assert_eq!(names, vec!["dept_id", "emp_id", "name"]);
+        // TTM Proscription 4: Attributes have no ordering.
+        // Verify all attributes are present, but don't check order.
+        assert_eq!(names.len(), 3);
+        assert!(names.contains(&"emp_id".to_string()));
+        assert!(names.contains(&"name".to_string()));
+        assert!(names.contains(&"dept_id".to_string()));
     }
 
     #[test]

--- a/src/types/tuple_type.rs
+++ b/src/types/tuple_type.rs
@@ -331,16 +331,11 @@ mod tests {
 
         // TTM Proscription 4: Attributes must have no ordering.
         // We verify all expected attributes are present, but we do NOT
-        // check for any particular order.
+        // check for any particular order. HashMap ensures no guaranteed ordering.
         assert_eq!(names.len(), 3);
         assert!(names.contains(&"emp_id".to_string()));
         assert!(names.contains(&"name".to_string()));
         assert!(names.contains(&"dept_id".to_string()));
-
-        // PHILOSOPHICAL ISSUE with current BTreeMap implementation:
-        // BTreeMap imposes alphabetical ordering, which violates TTM even if
-        // we don't rely on it. The correct implementation should use HashMap
-        // to make it clear there is NO guaranteed ordering.
     }
 
     #[test]

--- a/src/values/tuple.rs
+++ b/src/values/tuple.rs
@@ -30,7 +30,7 @@
 use crate::types::TupleType;
 use crate::values::ScalarValue;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use thiserror::Error;
 
 /// Errors that can occur when creating or modifying tuples.
@@ -88,12 +88,12 @@ pub enum TupleError {
 /// let age: i64 = person.get_typed("age").unwrap();
 /// assert_eq!(age, 30);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Tuple {
     /// The tuple type (heading) that this tuple conforms to.
     tuple_type: TupleType,
     /// The attribute values, keyed by attribute name.
-    values: BTreeMap<String, ScalarValue>,
+    values: HashMap<String, ScalarValue>,
 }
 
 impl Tuple {
@@ -118,13 +118,13 @@ impl Tuple {
     /// ```
     /// use relvar::types::{TupleType, ScalarType};
     /// use relvar::values::{Tuple, ScalarValue};
-    /// use std::collections::BTreeMap;
+    /// use std::collections::HashMap;
     ///
     /// let tuple_type = TupleType::new()
     ///     .with_attribute("id", ScalarType::Int)
     ///     .with_attribute("name", ScalarType::String);
     ///
-    /// let mut values = BTreeMap::new();
+    /// let mut values = HashMap::new();
     /// values.insert("id".to_string(), ScalarValue::Int(1));
     /// values.insert("name".to_string(), ScalarValue::String("Alice".to_string()));
     ///
@@ -133,7 +133,7 @@ impl Tuple {
     /// ```
     pub fn new(
         tuple_type: TupleType,
-        values: BTreeMap<String, ScalarValue>,
+        values: HashMap<String, ScalarValue>,
     ) -> Result<Self, TupleError> {
         // Verify all attributes have values
         for attr_name in tuple_type.attribute_names() {
@@ -185,7 +185,7 @@ impl Tuple {
     }
 
     /// Get all values
-    pub fn values(&self) -> &BTreeMap<String, ScalarValue> {
+    pub fn values(&self) -> &HashMap<String, ScalarValue> {
         &self.values
     }
 
@@ -239,13 +239,33 @@ impl Tuple {
     }
 }
 
+impl std::hash::Hash for Tuple {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Hash the tuple type first
+        self.tuple_type.hash(state);
+
+        // Hash values in a deterministic way by sorting the entries
+        let mut entries: Vec<_> = self.values.iter().collect();
+        entries.sort_by_key(|(name, _)| *name);
+
+        // Hash the count
+        self.values.len().hash(state);
+
+        // Then hash each entry
+        for (name, value) in entries {
+            name.hash(state);
+            value.hash(state);
+        }
+    }
+}
+
 /// Helper macro for creating tuples
 #[macro_export]
 macro_rules! tuple {
     ($($name:ident: $value:expr),* $(,)?) => {{
-        use std::collections::BTreeMap;
+        use std::collections::HashMap;
         let mut type_builder = $crate::types::TupleType::new();
-        let mut values = BTreeMap::new();
+        let mut values = HashMap::new();
 
         $(
             let value = $crate::values::ScalarValue::from($value);
@@ -346,7 +366,7 @@ mod tests {
             .with_attribute("emp_id", ScalarType::Int)
             .with_attribute("name", ScalarType::String);
 
-        let mut values = BTreeMap::new();
+        let mut values = HashMap::new();
         values.insert("emp_id".to_string(), ScalarValue::Int(1));
         values.insert("name".to_string(), ScalarValue::String("Alice".to_string()));
 
@@ -360,7 +380,7 @@ mod tests {
             .with_attribute("emp_id", ScalarType::Int)
             .with_attribute("name", ScalarType::String);
 
-        let mut values = BTreeMap::new();
+        let mut values = HashMap::new();
         values.insert("emp_id".to_string(), ScalarValue::Int(1));
         // Missing "name"
 
@@ -375,7 +395,7 @@ mod tests {
             .with_attribute("emp_id", ScalarType::Int)
             .with_attribute("name", ScalarType::String);
 
-        let mut values = BTreeMap::new();
+        let mut values = HashMap::new();
         values.insert("emp_id".to_string(), ScalarValue::Int(1));
         values.insert("name".to_string(), ScalarValue::Int(42)); // Wrong type
 
@@ -393,11 +413,11 @@ mod tests {
             .with_attribute("emp_id", ScalarType::Int)
             .with_attribute("name", ScalarType::String);
 
-        let mut values1 = BTreeMap::new();
+        let mut values1 = HashMap::new();
         values1.insert("emp_id".to_string(), ScalarValue::Int(1));
         values1.insert("name".to_string(), ScalarValue::String("Alice".to_string()));
 
-        let mut values2 = BTreeMap::new();
+        let mut values2 = HashMap::new();
         values2.insert("name".to_string(), ScalarValue::String("Alice".to_string()));
         values2.insert("emp_id".to_string(), ScalarValue::Int(1)); // Different insertion order
 
@@ -413,7 +433,7 @@ mod tests {
             .with_attribute("emp_id", ScalarType::Int)
             .with_attribute("name", ScalarType::String);
 
-        let mut values = BTreeMap::new();
+        let mut values = HashMap::new();
         values.insert("emp_id".to_string(), ScalarValue::Int(42));
         values.insert("name".to_string(), ScalarValue::String("Bob".to_string()));
 


### PR DESCRIPTION
## Summary
Implements TTM Proscription 4 by replacing `BTreeMap` with `HashMap` for attribute storage, ensuring attributes have no inherent ordering.

## Changes Made
- **Core Types**: Replaced `BTreeMap<String, ScalarType>` with `HashMap` in `TupleType` and `BTreeMap<String, ScalarValue>` with `HashMap` in `Tuple`
- **Algebra Operators**: Updated all relational algebra operators (divide, group, join, project, rename, summarize) to use `HashMap`
- **Type Traits**: Implemented custom `Hash` traits for `TupleType`, `Tuple`, `ScalarType`, and `RelationType` to enable deterministic hashing
- **Ordering**: Implemented `Ord`/`PartialOrd` for `ScalarType` (required for `ScalarValue` comparisons)
- **Tests**: Added `test_ttm_proscription_4_no_attribute_ordering` to enforce TTM compliance
- **Documentation**: Updated all documentation to reflect that attribute ordering is not guaranteed

## TTM Compliance
✅ **Proscription 4**: Attributes must have no ordering

This change moves from philosophical correctness (using `BTreeMap` but documenting "don't rely on order") to enforcement at the type system level. `HashMap` makes it clear that there is NO guaranteed ordering.

## Test Plan
- [x] All 254 unit tests pass
- [x] All 114 doctests pass  
- [x] `cargo fmt` - clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - clean
- [x] New TTM compliance test added and passing

## Performance Impact
Neutral to positive - `HashMap` has O(1) average lookup vs `BTreeMap`'s O(log n)

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)