### PR TITLE
🛡️ Sentry: Fix arbitrary 1000-page limit in HeapFile scan

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Arbitrary Limits in Loops
+**Learning:** Found a hardcoded `if page_id > 1000` break in `HeapFile::scan`, intended as a safety guard but acting as a severe data truncation bug for datasets > 4MB.
+**Action:** Always scrutinize "magic numbers" in loop termination conditions. Test boundaries explicitly (e.g., if limit is 1000, test 1001).

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -626,6 +626,7 @@ mod tests {
 
     #[test]
     fn test_heap_scan_large_volume() {
+        const NUM_PAGES: u64 = 1005;
         let temp_file = NamedTempFile::new().unwrap();
         let path = temp_file.path();
 
@@ -641,7 +642,7 @@ mod tests {
         // We just need > 1000 pages, the content size doesn't matter as long as it's valid
         let payload = vec![0u8; 100];
 
-        for i in 0..1005 {
+        for i in 0..NUM_PAGES {
             let tuple = tuple! {
                 id: i as i64,
                 data: payload.clone(),
@@ -651,8 +652,8 @@ mod tests {
             // Construct a SlottedPage with one tuple
             // We place tuple at the end of the page (standard behavior)
             let tuple_len = tuple_data.len();
-            // USABLE_PAGE_SIZE = 4096 - 8 = 4088
-            let offset = 4088 - tuple_len;
+            // USABLE_PAGE_SIZE = PAGE_SIZE - 8
+            let offset = (PAGE_SIZE - 8) - tuple_len;
 
             let slotted_page = SlottedPage {
                 slot_count: 1,
@@ -667,16 +668,17 @@ mod tests {
                 .serialize_slotted_page_with_tuples(&slotted_page, &[tuple_data])
                 .unwrap();
 
-            let page = Page::from_data(i as u64, page_data).unwrap();
+            let page = Page::from_data(i, page_data).unwrap();
             heap.page_file.write_page(&page).unwrap();
         }
 
         // Scan and verify count
         let tuples = heap.scan().unwrap();
         assert_eq!(
-            tuples.len(),
-            1005,
-            "Scan stopped early! Expected 1005 tuples, got {}",
+            tuples.len() as u64,
+            NUM_PAGES,
+            "Scan stopped early! Expected {} tuples, got {}",
+            NUM_PAGES,
             tuples.len()
         );
     }

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -407,11 +407,6 @@ impl HeapFile {
             }
 
             page_id += 1;
-
-            // Stop scanning after reasonable number of pages
-            if page_id > 1000 {
-                break;
-            }
         }
 
         Ok(results)
@@ -627,5 +622,62 @@ mod tests {
         let result = heap.store_relation(&relation);
         assert!(result.is_ok());
         let _unit: () = result.unwrap();
+    }
+
+    #[test]
+    fn test_heap_scan_large_volume() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+
+        // Create a relation type with a Bytes attribute
+        let heading = TupleType::new()
+            .with_attribute("id", ScalarType::Int)
+            .with_attribute("data", ScalarType::Bytes);
+        let rel_type = RelationType::new(heading);
+
+        let mut heap = HeapFile::create(path, rel_type).unwrap();
+
+        // Manually craft pages to avoid O(N^2) insert performance
+        // We just need > 1000 pages, the content size doesn't matter as long as it's valid
+        let payload = vec![0u8; 100];
+
+        for i in 0..1005 {
+            let tuple = tuple! {
+                id: i as i64,
+                data: payload.clone(),
+            };
+            let tuple_data = bincode::serialize(&tuple).unwrap();
+
+            // Construct a SlottedPage with one tuple
+            // We place tuple at the end of the page (standard behavior)
+            let tuple_len = tuple_data.len();
+            // USABLE_PAGE_SIZE = 4096 - 8 = 4088
+            let offset = 4088 - tuple_len;
+
+            let slotted_page = SlottedPage {
+                slot_count: 1,
+                slots: vec![Some(SlotEntry {
+                    offset: offset as u32,
+                    length: tuple_len as u32,
+                })],
+            };
+
+            // We can use the helper method since we are in the same module (tests)
+            let page_data = heap
+                .serialize_slotted_page_with_tuples(&slotted_page, &[tuple_data])
+                .unwrap();
+
+            let page = Page::from_data(i as u64, page_data).unwrap();
+            heap.page_file.write_page(&page).unwrap();
+        }
+
+        // Scan and verify count
+        let tuples = heap.scan().unwrap();
+        assert_eq!(
+            tuples.len(),
+            1005,
+            "Scan stopped early! Expected 1005 tuples, got {}",
+            tuples.len()
+        );
     }
 }


### PR DESCRIPTION
🎯 Target: `relvar-storage/src/storage/heap.rs`
💣 Risk: `scan()` would silently stop returning tuples after reading 1000 pages (approx 4MB). This is a critical correctness bug for any non-trivial dataset.
🧪 Strategy: Removed the `if page_id > 1000` check.
🔬 Verification: Added `test_heap_scan_large_volume` which manually constructs 1005 pages (bypassing O(N^2) insert performance issues in test) and verifies `scan()` returns all 1005 tuples. Verified that the test fails without the fix and passes with it.

---
*PR created automatically by Jules for task [15066208002982953731](https://jules.google.com/task/15066208002982953731) started by @madmax983*