### PR TITLE
🎻 Bard: Documented theta_join attribute collision behavior

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -1,0 +1,5 @@
+# Bard's Journal
+
+## 2024-05-23 - The Case of the Vanishing Attributes
+**Confusion:** The `theta_join` operation silently drops attributes from the right-hand relation if they share a name with an attribute in the left-hand relation.
+**Clarification:** This is a known limitation of the current implementation (lack of automatic renaming). Documented this behavior explicitly in `relvar-core/src/algebra/join.rs` and added a regression test to ensure it remains consistent until a proper renaming mechanism is implemented.

--- a/relvar-core/src/algebra/divide.rs
+++ b/relvar-core/src/algebra/divide.rs
@@ -32,7 +32,7 @@ impl Relation {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```text
     /// // SUPPLIES(supplier_id, part_id):
     /// // S1 supplies: P1, P2
     /// // S2 supplies: P1

--- a/relvar-core/src/algebra/join.rs
+++ b/relvar-core/src/algebra/join.rs
@@ -185,7 +185,7 @@ impl Relation {
     ///
     /// # Behavior
     ///
-    /// - All attribute pairs are combined.
+    /// - Attributes from both relations are combined, subject to the collision rule below.
     /// - **Attribute Collision Warning:** If relations have common attribute names,
     ///   the attribute from the *second* relation is silently dropped from the result
     ///   heading, and its values are discarded. The first relation's attribute takes

--- a/relvar-core/src/algebra/join.rs
+++ b/relvar-core/src/algebra/join.rs
@@ -185,10 +185,13 @@ impl Relation {
     ///
     /// # Behavior
     ///
-    /// - All attribute pairs are combined (no automatic deduplication of common names)
-    /// - If relations have common attribute names, the first relation's values
-    ///   take precedence
-    /// - Result maintains set semantics
+    /// - All attribute pairs are combined.
+    /// - **Attribute Collision Warning:** If relations have common attribute names,
+    ///   the attribute from the *second* relation is silently dropped from the result
+    ///   heading, and its values are discarded. The first relation's attribute takes
+    ///   precedence. This is a known limitation; ensure attributes are uniquely named
+    ///   before joining.
+    /// - Result maintains set semantics.
     ///
     /// # Complexity
     ///
@@ -469,5 +472,41 @@ mod tests {
 
         assert_eq!(result.cardinality(), 0);
         assert!(result.is_empty());
+    }
+
+    /// Verifies the documented behavior that theta_join drops conflicting attributes
+    /// from the second relation.
+    #[test]
+    fn test_theta_join_attribute_collision_resolution() {
+        // Relation 1: id=1
+        let heading1 = TupleType::new().with_attribute("id", ScalarType::Int);
+        let mut rel1 = Relation::new(RelationType::new(heading1));
+        rel1.insert(tuple! { id: 1i64 }).unwrap();
+
+        // Relation 2: id=2 (SAME ATTRIBUTE NAME)
+        let heading2 = TupleType::new().with_attribute("id", ScalarType::Int);
+        let mut rel2 = Relation::new(RelationType::new(heading2));
+        rel2.insert(tuple! { id: 2i64 }).unwrap();
+
+        // Theta join with a predicate that is always true
+        // If this were a proper Cartesian product (renaming aside), we'd expect
+        // something like (id_left: 1, id_right: 2).
+        //
+        // Current behavior: The second 'id' is dropped.
+        let result = rel1.theta_join(&rel2, |_, _| true);
+
+        // Assert that the result only has degree 1 (from rel1), not 2
+        assert_eq!(
+            result.degree(),
+            1,
+            "Expected colliding attribute to be dropped per current behavior"
+        );
+
+        // Assert that the value preserved is from the first relation (id=1)
+        let tuple = result.tuples().next().expect("Should have one tuple");
+        assert_eq!(
+            tuple.get_typed::<i64>("id").expect("id attribute missing"),
+            1
+        );
     }
 }


### PR DESCRIPTION
🎻 Bard: Documented theta_join attribute collision behavior

📖 Chapter: Relational Algebra (`theta_join`)
🔦 Insight: Clarified the "magic" behavior where `theta_join` silently drops attributes from the second relation if they collide with the first relation. This is a known limitation (no automatic renaming).
🧪 Example: Added `test_theta_join_attribute_collision_resolution` to codify this behavior.
🔧 Fix: Also fixed a rustdoc warning in `divide.rs` (empty code block).

---
*PR created automatically by Jules for task [3791776291277681104](https://jules.google.com/task/3791776291277681104) started by @madmax983*