### PR TITLE
🗺️ Atlas: Decouple StorageEngine Snapshot

### DIFF
--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -135,7 +135,7 @@ pub struct Database<E: StorageEngine> {
     /// Whether a transaction is currently in progress.
     in_transaction: bool,
     /// Transaction savepoint.
-    transaction_snapshot: Option<crate::storage_engine::TransactionSnapshot>,
+    transaction_snapshot: Option<E::Snapshot>,
     /// Virtual relvars defined by expressions.
     virtual_relvars: HashMap<String, VirtualRelvarDefinition<E>>,
 }

--- a/relvar-core/src/storage_engine/in_memory.rs
+++ b/relvar-core/src/storage_engine/in_memory.rs
@@ -6,7 +6,7 @@
 //! - Benchmarking pure relational operations
 //! - Temporary databases that don't need persistence
 
-use super::{RelationMetadata, StorageEngine, StorageError, TransactionSnapshot};
+use super::{RelationMetadata, StorageEngine, StorageError};
 use crate::types::RelationType;
 use crate::values::{Relation, Tuple};
 use std::collections::HashMap;
@@ -16,6 +16,13 @@ use std::collections::HashMap;
 struct StoredRelation {
     metadata: RelationMetadata,
     relation: Relation,
+}
+
+/// Snapshot for in-memory transactions.
+#[derive(Debug, Clone)]
+pub struct InMemorySnapshot {
+    /// Saved relations, keyed by name.
+    pub saved_relations: HashMap<String, Relation>,
 }
 
 /// Pure in-memory storage engine.
@@ -62,6 +69,8 @@ impl InMemoryEngine {
 }
 
 impl StorageEngine for InMemoryEngine {
+    type Snapshot = InMemorySnapshot;
+
     fn create_relation(
         &mut self,
         name: &str,
@@ -145,7 +154,7 @@ impl StorageEngine for InMemoryEngine {
         Ok(())
     }
 
-    fn begin_transaction(&mut self) -> Result<TransactionSnapshot, StorageError> {
+    fn begin_transaction(&mut self) -> Result<Self::Snapshot, StorageError> {
         // Save current state
         let saved_relations: HashMap<String, Relation> = self
             .relations
@@ -153,10 +162,10 @@ impl StorageEngine for InMemoryEngine {
             .map(|(name, stored)| (name.clone(), stored.relation.clone()))
             .collect();
 
-        Ok(TransactionSnapshot { saved_relations })
+        Ok(InMemorySnapshot { saved_relations })
     }
 
-    fn rollback_transaction(&mut self, snapshot: TransactionSnapshot) -> Result<(), StorageError> {
+    fn rollback_transaction(&mut self, snapshot: Self::Snapshot) -> Result<(), StorageError> {
         // Restore saved state
         for (name, relation) in snapshot.saved_relations {
             if let Some(stored) = self.relations.get_mut(&name) {

--- a/relvar-core/src/storage_engine/mod.rs
+++ b/relvar-core/src/storage_engine/mod.rs
@@ -11,7 +11,6 @@
 
 use crate::types::RelationType;
 use crate::values::{Relation, Tuple};
-use std::collections::HashMap;
 use thiserror::Error;
 
 pub mod in_memory;
@@ -47,15 +46,6 @@ pub struct RelationMetadata {
     pub relation_type: RelationType,
 }
 
-/// Snapshot of storage state for transaction support.
-///
-/// This is an opaque type that storage engines use to save/restore state.
-#[derive(Debug, Clone)]
-pub struct TransactionSnapshot {
-    /// Saved relations, keyed by name.
-    pub saved_relations: HashMap<String, Relation>,
-}
-
 /// Trait for storage engine backends.
 ///
 /// This trait abstracts over different storage implementations:
@@ -78,6 +68,9 @@ pub struct TransactionSnapshot {
 /// assert!(engine.relation_exists("TEST"));
 /// ```
 pub trait StorageEngine: Send + Sync {
+    /// The snapshot type used for transactions.
+    type Snapshot: Send + Sync;
+
     /// Create a new relation.
     ///
     /// # Errors
@@ -138,7 +131,7 @@ pub trait StorageEngine: Send + Sync {
     /// # Errors
     ///
     /// Returns an error if transaction creation fails.
-    fn begin_transaction(&mut self) -> Result<TransactionSnapshot, StorageError>;
+    fn begin_transaction(&mut self) -> Result<Self::Snapshot, StorageError>;
 
     /// Commit a transaction (discard snapshot).
     ///
@@ -147,7 +140,7 @@ pub trait StorageEngine: Send + Sync {
     /// # Errors
     ///
     /// Returns an error if commit fails.
-    fn commit_transaction(&mut self, _snapshot: TransactionSnapshot) -> Result<(), StorageError> {
+    fn commit_transaction(&mut self, _snapshot: Self::Snapshot) -> Result<(), StorageError> {
         Ok(())
     }
 
@@ -156,5 +149,5 @@ pub trait StorageEngine: Send + Sync {
     /// # Errors
     ///
     /// Returns an error if rollback fails.
-    fn rollback_transaction(&mut self, snapshot: TransactionSnapshot) -> Result<(), StorageError>;
+    fn rollback_transaction(&mut self, snapshot: Self::Snapshot) -> Result<(), StorageError>;
 }

--- a/relvar-storage/src/persistent_engine.rs
+++ b/relvar-storage/src/persistent_engine.rs
@@ -1,13 +1,18 @@
 //! Persistent storage engine implementation using heap files and catalog.
 
 use crate::storage::{Catalog, CatalogError, HeapError, HeapFile};
-use relvar_core::storage_engine::{
-    RelationMetadata, StorageEngine, StorageError, TransactionSnapshot,
-};
+use relvar_core::storage_engine::{RelationMetadata, StorageEngine, StorageError};
 use relvar_core::types::RelationType;
 use relvar_core::values::{Relation, Tuple};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+
+/// Snapshot for persistent transactions.
+#[derive(Debug, Clone)]
+pub struct PersistentSnapshot {
+    /// Saved relations, keyed by name.
+    pub saved_relations: HashMap<String, Relation>,
+}
 
 /// Persistent storage engine using heap files and JSON catalog.
 ///
@@ -160,6 +165,8 @@ impl PersistentEngine {
 }
 
 impl StorageEngine for PersistentEngine {
+    type Snapshot = PersistentSnapshot;
+
     fn create_relation(
         &mut self,
         name: &str,
@@ -320,7 +327,7 @@ impl StorageEngine for PersistentEngine {
             .map_err(Self::convert_heap_error)
     }
 
-    fn begin_transaction(&mut self) -> Result<TransactionSnapshot, StorageError> {
+    fn begin_transaction(&mut self) -> Result<Self::Snapshot, StorageError> {
         // Save current state of all relations
         let mut saved_relations = HashMap::new();
 
@@ -329,10 +336,10 @@ impl StorageEngine for PersistentEngine {
             saved_relations.insert(name, relation);
         }
 
-        Ok(TransactionSnapshot { saved_relations })
+        Ok(PersistentSnapshot { saved_relations })
     }
 
-    fn rollback_transaction(&mut self, snapshot: TransactionSnapshot) -> Result<(), StorageError> {
+    fn rollback_transaction(&mut self, snapshot: Self::Snapshot) -> Result<(), StorageError> {
         // Restore all relations from snapshot
         for (name, relation) in snapshot.saved_relations {
             self.store_relation(&name, &relation)?;


### PR DESCRIPTION
🗺️ **Atlas: Decoupled StorageEngine from TransactionSnapshot**

**🕸️ Tangle:** The `StorageEngine` trait in `relvar-core` was tightly coupled to a concrete `TransactionSnapshot` struct that exposed internal implementation details (`HashMap<String, Relation>`). This forced all storage engines (including persistent ones) to implement transactions by cloning the entire database into memory, which is a massive performance bottleneck and architectural violation ("The Leak").

**📐 Blueprint:**
- Refactored `StorageEngine` to use an associated type `type Snapshot: Send + Sync`.
- Removed the public `TransactionSnapshot` struct from `relvar-core`.
- `InMemoryEngine` now defines its own `InMemorySnapshot`.
- `PersistentEngine` now defines its own `PersistentSnapshot`.
- `Database<E>` now holds `Option<E::Snapshot>`.

**🧱 Stability:**
- Strictly enforces the boundary between interface (Trait) and implementation (Struct).
- Allows `PersistentEngine` to implement efficient WAL-based or COW-based transactions in the future without breaking the core API.
- No changes to the public `relvar` facade API usage (users still call `db.begin()`).

**🔬 Verification:**
- `cargo check -p relvar-core` passed.
- `cargo test --all-features` passed.
- `cargo clippy` clean.


---
*PR created automatically by Jules for task [278446293116672569](https://jules.google.com/task/278446293116672569) started by @madmax983*