### PR TITLE
🔒 Warden: Fix constraints bypass in Database::update

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -1,4 +1,4 @@
-## HeapFile Error Handling and KeyConstraints Panic
+## 2024-05-23 - HeapFile Error Handling and KeyConstraints Panic
 **Threat:**
 1. `HeapFile` operations (`insert_tuple`, `scan`) were masking I/O errors (e.g., permission denied, hardware failure) by treating them as EOF/New Page.
 2. `KeyConstraints::would_violate` could panic if passed a tuple missing a key attribute.
@@ -7,6 +7,6 @@
 1. Modified `HeapFile::try_insert_into_page` and `scan` to propagate errors from `read_page` using `?`. Note: `read_page` handles EOF by returning `Ok(empty_page)`, so propagating `Err` correctly surfaces *real* I/O errors without breaking page growth.
 2. Modified `KeyConstraints::extract_key_value` to return `Result` and added `KeyConstraintError::TupleMissingAttribute`. Updated call sites to propagate this error.
 
-## Database Update Constraint Bypass
+## 2024-05-24 - Database Update Constraint Bypass
 **Threat:** `Database::update` bypassed Type, Check, and Foreign Key constraints, allowing invalid data to be persisted and referential integrity to be violated.
 **Defense:** Refactored constraint validation logic into helper methods and enforced them in `Database::update`.

--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -1,4 +1,4 @@
-## 2024-05-23 - HeapFile Error Handling and KeyConstraints Panic
+## HeapFile Error Handling and KeyConstraints Panic
 **Threat:**
 1. `HeapFile` operations (`insert_tuple`, `scan`) were masking I/O errors (e.g., permission denied, hardware failure) by treating them as EOF/New Page.
 2. `KeyConstraints::would_violate` could panic if passed a tuple missing a key attribute.
@@ -7,6 +7,6 @@
 1. Modified `HeapFile::try_insert_into_page` and `scan` to propagate errors from `read_page` using `?`. Note: `read_page` handles EOF by returning `Ok(empty_page)`, so propagating `Err` correctly surfaces *real* I/O errors without breaking page growth.
 2. Modified `KeyConstraints::extract_key_value` to return `Result` and added `KeyConstraintError::TupleMissingAttribute`. Updated call sites to propagate this error.
 
-## 2024-05-24 - Database Update Constraint Bypass
+## Database Update Constraint Bypass
 **Threat:** `Database::update` bypassed Type, Check, and Foreign Key constraints, allowing invalid data to be persisted and referential integrity to be violated.
 **Defense:** Refactored constraint validation logic into helper methods and enforced them in `Database::update`.

--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -6,3 +6,7 @@
 **Defense:**
 1. Modified `HeapFile::try_insert_into_page` and `scan` to propagate errors from `read_page` using `?`. Note: `read_page` handles EOF by returning `Ok(empty_page)`, so propagating `Err` correctly surfaces *real* I/O errors without breaking page growth.
 2. Modified `KeyConstraints::extract_key_value` to return `Result` and added `KeyConstraintError::TupleMissingAttribute`. Updated call sites to propagate this error.
+
+## 2024-05-24 - Database Update Constraint Bypass
+**Threat:** `Database::update` bypassed Type, Check, and Foreign Key constraints, allowing invalid data to be persisted and referential integrity to be violated.
+**Defense:** Refactored constraint validation logic into helper methods and enforced them in `Database::update`.

--- a/benches/database.rs
+++ b/benches/database.rs
@@ -104,6 +104,73 @@ fn bench_insert(c: &mut Criterion) {
     group.finish();
 }
 
+// Update benchmark with constraints
+fn bench_update_with_constraints(c: &mut Criterion) {
+    let mut group = c.benchmark_group("update_with_constraints");
+
+    for count in [10, 50, 100].iter() {
+        group.throughput(Throughput::Elements(*count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &count| {
+            b.iter_batched(
+                || {
+                    // Setup: create database, add constraints, and pre-populate
+                    let (_temp_dir, mut db) = create_database_with_relvar();
+
+                    // 1. Add CHECK constraint: salary > 0
+                    let check_constraints = CheckConstraints::new().with_constraint(
+                        CheckConstraint::from_expression(
+                            "positive_salary",
+                            "Salary must be positive",
+                            ConstraintExpression::Gt(
+                                "salary".to_string(),
+                                ValueOrRef::Value(ScalarValue::Float(0.0)),
+                            ),
+                        ),
+                    );
+                    db.set_check_constraints("EMP", check_constraints).unwrap();
+
+                    // 2. Add Key Constraint (Primary Key)
+                    let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+                    db.set_key_constraints("EMP", KeyConstraints::new().with_primary_key(pk))
+                        .unwrap();
+
+                    for i in 0..count {
+                        let tuple = tuple! {
+                            emp_id: i as i64,
+                            name: format!("Employee_{}", i),
+                            dept_id: (i % 10) as i64,
+                            salary: 50000.0 + (i as f64 * 100.0)
+                        };
+                        db.insert("EMP", tuple).unwrap();
+                    }
+                    (_temp_dir, db)
+                },
+                |(_temp_dir, mut db)| {
+                    // Measured: just the update operation (valid updates)
+                    db.update(
+                        "EMP",
+                        |_| true,
+                        |t| {
+                            let mut t = t.clone();
+                            let current_salary = t.get_typed::<f64>("salary").unwrap();
+                            t.set(
+                                "salary".to_string(),
+                                relvar::values::ScalarValue::Float(current_salary * 1.1),
+                            )
+                            .unwrap();
+                            t
+                        },
+                    )
+                    .unwrap();
+                    black_box(db);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
 // Insert with key constraint benchmark
 fn bench_insert_with_key_constraint(c: &mut Criterion) {
     let mut group = c.benchmark_group("insert_with_key_constraint");
@@ -267,12 +334,14 @@ fn bench_update(c: &mut Criterion) {
                         "EMP",
                         |_| true,
                         |t| {
+                            let mut t = t.clone();
                             let current_salary = t.get_typed::<f64>("salary").unwrap();
                             t.set(
                                 "salary".to_string(),
                                 relvar::values::ScalarValue::Float(current_salary * 1.1),
                             )
                             .unwrap();
+                            t
                         },
                     )
                     .unwrap();
@@ -377,11 +446,13 @@ fn bench_realistic_workload(c: &mut Criterion) {
                     "EMP",
                     |t| t.get_typed::<i64>("dept_id").unwrap() == 5,
                     |t| {
+                        let mut t = t.clone();
                         t.set(
                             "salary".to_string(),
                             relvar::values::ScalarValue::Float(60000.0),
                         )
                         .unwrap();
+                        t
                     },
                 )
                 .unwrap();
@@ -687,6 +758,7 @@ criterion_group!(
     bench_query_with_operations,
     bench_delete,
     bench_update,
+    bench_update_with_constraints,
     bench_transaction,
     bench_realistic_workload,
     // Virtual relvar benchmarks (TTM RM Prescription 10)

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -367,25 +367,10 @@ impl<E: StorageEngine> Database<E> {
         }
 
         // Check type constraints
-        if let Some(attr_constraints) = self.type_constraints.get(relation_name) {
-            for (attr_name, constraints) in attr_constraints {
-                if let Some(value) = tuple.get(attr_name)
-                    && !constraints
-                        .is_satisfied_by(value)
-                        .map_err(|e| DatabaseError::TypeConstraintViolation(e.to_string()))?
-                {
-                    return Err(DatabaseError::TypeConstraintViolation(format!(
-                        "Attribute {} violates constraint",
-                        attr_name
-                    )));
-                }
-            }
-        }
+        self.validate_type_constraints(relation_name, &tuple)?;
 
         // Check CHECK constraints (tuple-level predicates)
-        if let Some(check_constraints) = self.check_constraints.get(relation_name) {
-            check_constraints.are_all_satisfied_by(&tuple)?;
-        }
+        self.validate_check_constraints(relation_name, &tuple)?;
 
         // Load current relation to check key constraints
         let current_relation = self.query(relation_name)?;
@@ -411,21 +396,7 @@ impl<E: StorageEngine> Database<E> {
         }
 
         // Check foreign key constraints
-        let fk_constraints_opt = self.foreign_key_constraints.get(relation_name).cloned();
-        if let Some(fk_constraints) = fk_constraints_opt {
-            for fk in fk_constraints.foreign_keys() {
-                let referenced_relation = self.query(fk.referenced_relation_name())?;
-
-                if fk
-                    .would_violate_on_insert(&tuple, &referenced_relation)
-                    .map_err(|e| DatabaseError::ForeignKeyViolation(e.to_string()))?
-                {
-                    return Err(DatabaseError::ForeignKeyViolation(
-                        "Foreign key constraint violated".to_string(),
-                    ));
-                }
-            }
-        }
+        self.validate_child_foreign_keys(relation_name, &tuple)?;
 
         // Insert into engine
         self.engine.insert_tuple(relation_name, tuple)?;
@@ -477,41 +448,7 @@ impl<E: StorageEngine> Database<E> {
         }
 
         // Check foreign key constraints (other relations referencing this one)
-        // TODO: Implement cascading deletes
-        let fk_constraints_clone = self.foreign_key_constraints.clone();
-        for (ref_name, fk_constraints) in &fk_constraints_clone {
-            for fk in fk_constraints.foreign_keys() {
-                if fk.referenced_relation_name() == relation_name {
-                    let referencing_relation = self.query(ref_name)?;
-
-                    // Check if any referencing tuples would be orphaned
-                    for ref_tuple in referencing_relation.tuples() {
-                        let ref_key_values: Vec<ScalarValue> = fk
-                            .foreign_key_attributes()
-                            .iter()
-                            .filter_map(|attr| ref_tuple.get(attr).cloned())
-                            .collect();
-
-                        // Check if the key exists in the new relation
-                        let exists = new_relation.tuples().any(|t| {
-                            let key_values: Vec<ScalarValue> = fk
-                                .referenced_attributes()
-                                .iter()
-                                .filter_map(|attr| t.get(attr).cloned())
-                                .collect();
-                            key_values == ref_key_values
-                        });
-
-                        if !exists {
-                            return Err(DatabaseError::ForeignKeyViolation(format!(
-                                "Deleting tuples would orphan referencing tuples in {}",
-                                ref_name
-                            )));
-                        }
-                    }
-                }
-            }
-        }
+        self.validate_referential_integrity(relation_name, &new_relation)?;
 
         // Store the new relation
         self.engine.store_relation(relation_name, &new_relation)?;
@@ -554,6 +491,15 @@ impl<E: StorageEngine> Database<E> {
                     return Err(DatabaseError::TupleMismatch);
                 }
 
+                // Validate Type constraints
+                self.validate_type_constraints(relation_name, &updated_tuple)?;
+
+                // Validate CHECK constraints
+                self.validate_check_constraints(relation_name, &updated_tuple)?;
+
+                // Validate Child Foreign Key constraints
+                self.validate_child_foreign_keys(relation_name, &updated_tuple)?;
+
                 new_relation.insert(updated_tuple)?;
                 update_count += 1;
             } else {
@@ -585,6 +531,9 @@ impl<E: StorageEngine> Database<E> {
                 }
             }
         }
+
+        // Validate referential integrity (Parent Foreign Keys)
+        self.validate_referential_integrity(relation_name, &new_relation)?;
 
         // Store the new relation
         self.engine.store_relation(relation_name, &new_relation)?;
@@ -685,6 +634,110 @@ impl<E: StorageEngine> Database<E> {
         self.virtual_relvars
             .remove(name)
             .ok_or_else(|| DatabaseError::RelationNotFound(name.to_string()))?;
+        Ok(())
+    }
+
+    /// Check type constraints for a tuple.
+    fn validate_type_constraints(
+        &self,
+        relation_name: &str,
+        tuple: &Tuple,
+    ) -> Result<(), DatabaseError> {
+        if let Some(attr_constraints) = self.type_constraints.get(relation_name) {
+            for (attr_name, constraints) in attr_constraints {
+                if let Some(value) = tuple.get(attr_name)
+                    && !constraints
+                        .is_satisfied_by(value)
+                        .map_err(|e| DatabaseError::TypeConstraintViolation(e.to_string()))?
+                {
+                    return Err(DatabaseError::TypeConstraintViolation(format!(
+                        "Attribute {} violates constraint",
+                        attr_name
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Check CHECK constraints for a tuple.
+    fn validate_check_constraints(
+        &self,
+        relation_name: &str,
+        tuple: &Tuple,
+    ) -> Result<(), DatabaseError> {
+        if let Some(check_constraints) = self.check_constraints.get(relation_name) {
+            check_constraints.are_all_satisfied_by(tuple)?;
+        }
+        Ok(())
+    }
+
+    /// Check foreign key constraints where this tuple is the child (referencing another).
+    fn validate_child_foreign_keys(
+        &mut self,
+        relation_name: &str,
+        tuple: &Tuple,
+    ) -> Result<(), DatabaseError> {
+        let fk_constraints_opt = self.foreign_key_constraints.get(relation_name).cloned();
+        if let Some(fk_constraints) = fk_constraints_opt {
+            for fk in fk_constraints.foreign_keys() {
+                let referenced_relation = self.query(fk.referenced_relation_name())?;
+
+                if fk
+                    .would_violate_on_insert(tuple, &referenced_relation)
+                    .map_err(|e| DatabaseError::ForeignKeyViolation(e.to_string()))?
+                {
+                    return Err(DatabaseError::ForeignKeyViolation(
+                        "Foreign key constraint violated".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Check referential integrity: ensure no other relation references a key that is missing in `new_relation`.
+    fn validate_referential_integrity(
+        &mut self,
+        relation_name: &str,
+        new_relation: &Relation,
+    ) -> Result<(), DatabaseError> {
+        // Check foreign key constraints (other relations referencing this one)
+        // TODO: Implement cascading deletes
+        let fk_constraints_clone = self.foreign_key_constraints.clone();
+        for (ref_name, fk_constraints) in &fk_constraints_clone {
+            for fk in fk_constraints.foreign_keys() {
+                if fk.referenced_relation_name() == relation_name {
+                    let referencing_relation = self.query(ref_name)?;
+
+                    // Check if any referencing tuples would be orphaned
+                    for ref_tuple in referencing_relation.tuples() {
+                        let ref_key_values: Vec<ScalarValue> = fk
+                            .foreign_key_attributes()
+                            .iter()
+                            .filter_map(|attr| ref_tuple.get(attr).cloned())
+                            .collect();
+
+                        // Check if the key exists in the new relation
+                        let exists = new_relation.tuples().any(|t| {
+                            let key_values: Vec<ScalarValue> = fk
+                                .referenced_attributes()
+                                .iter()
+                                .filter_map(|attr| t.get(attr).cloned())
+                                .collect();
+                            key_values == ref_key_values
+                        });
+
+                        if !exists {
+                            return Err(DatabaseError::ForeignKeyViolation(format!(
+                                "Operation would orphan referencing tuples in {}",
+                                ref_name
+                            )));
+                        }
+                    }
+                }
+            }
+        }
         Ok(())
     }
 }
@@ -1558,5 +1611,83 @@ mod tests {
         // Insert with invalid age (too high) should fail
         let result = db.insert("PERSONS", tuple! { id: 3i64, age: 200i64 });
         assert!(result.is_err());
+    }
+}
+
+#[cfg(test)]
+mod security_tests {
+    use super::*;
+    use crate::constraints::{
+        AttributeConstraints, CheckConstraint, CheckConstraints, ConstraintExpression,
+        TypeConstraint, ValueOrRef,
+    };
+    use crate::storage_engine::InMemoryEngine;
+    use crate::tuple;
+    use crate::types::{RelationType, ScalarType, TupleType};
+
+    #[test]
+    fn test_update_enforces_constraints() {
+        let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
+        let rel_type = RelationType::new(
+            TupleType::new()
+                .with_attribute("id", ScalarType::Int)
+                .with_attribute("age", ScalarType::Int),
+        );
+
+        db.create_relvar("VICTIM", rel_type).unwrap();
+
+        // 1. Add Type Constraint: age must be positive
+        let type_constraints = AttributeConstraints::new("age".to_string(), ScalarType::Int)
+            .with_constraint(TypeConstraint::PositiveInt);
+        db.set_type_constraints("VICTIM", "age", type_constraints)
+            .unwrap();
+
+        // 2. Add CHECK Constraint: age < 150
+        let check_constraints =
+            CheckConstraints::new().with_constraint(CheckConstraint::from_expression(
+                "valid_age",
+                "Age must be less than 150",
+                ConstraintExpression::Lt(
+                    "age".to_string(),
+                    ValueOrRef::Value(ScalarValue::Int(150)),
+                ),
+            ));
+        db.set_check_constraints("VICTIM", check_constraints)
+            .unwrap();
+
+        // 3. Insert valid data
+        db.insert("VICTIM", tuple! { id: 1i64, age: 30i64 })
+            .unwrap();
+
+        // 4. Attempt Update to invalid age (negative) - Violates Type Constraint
+        let result = db.update(
+            "VICTIM",
+            |t| t.get_typed::<i64>("id").unwrap() == 1,
+            |_| tuple! { id: 1i64, age: -50i64 },
+        );
+
+        assert!(
+            result.is_err(),
+            "Security Flaw: Update bypassed Type Constraints!"
+        );
+
+        // 5. Attempt Update to invalid age (too high) - Violates CHECK Constraint
+        // Reset data first (if update succeeded above, it might be corrupted, but we proceed)
+        let _ = db.update(
+            "VICTIM",
+            |t| t.get_typed::<i64>("id").unwrap() == 1,
+            |_| tuple! { id: 1i64, age: 30i64 },
+        );
+
+        let result = db.update(
+            "VICTIM",
+            |t| t.get_typed::<i64>("id").unwrap() == 1,
+            |_| tuple! { id: 1i64, age: 200i64 },
+        );
+
+        assert!(
+            result.is_err(),
+            "Security Flaw: Update bypassed CHECK Constraints!"
+        );
     }
 }


### PR DESCRIPTION
This PR addresses a critical security vulnerability where `Database::update` bypassed data integrity constraints (Type, Check, Foreign Keys). It introduces strict validation in the update workflow, ensuring that all modified tuples conform to the defined schema and constraints. This prevents potential data corruption and referential integrity violations.


---
*PR created automatically by Jules for task [3075419537273662552](https://jules.google.com/task/3075419537273662552) started by @madmax983*