### PR TITLE
🎻 Bard: Enhance algebraic operator visibility and transaction docs

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -1,9 +1,9 @@
 # Bard's Journal
 
-## 2024-05-23 - The Case of the Vanishing Attributes
+## The Case of the Vanishing Attributes
 **Confusion:** The `theta_join` operation silently drops attributes from the right-hand relation if they share a name with an attribute in the left-hand relation.
 **Clarification:** This is a known limitation of the current implementation (lack of automatic renaming). Documented this behavior explicitly in `relvar-core/src/algebra/join.rs` and added a regression test to ensure it remains consistent until a proper renaming mechanism is implemented.
 
-## 2024-05-24 - The Case of the Hidden Traits
+## The Case of the Hidden Traits
 **Confusion:** Users could not use advanced operators like `extend`, `summarize`, and `group` because the necessary traits were not re-exported, requiring deep and undocumented import paths (e.g. `relvar::algebra::extend::ExtendOps`).
 **Clarification:** Re-exported `ExtendOps`, `GroupOps`, and `SummarizeOps` in `relvar-core/src/algebra/mod.rs` (accessible via `relvar::algebra::*`) and added comprehensive examples to the main `relvar` crate documentation demonstrating their usage and the required imports.

--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -3,3 +3,7 @@
 ## 2024-05-23 - The Case of the Vanishing Attributes
 **Confusion:** The `theta_join` operation silently drops attributes from the right-hand relation if they share a name with an attribute in the left-hand relation.
 **Clarification:** This is a known limitation of the current implementation (lack of automatic renaming). Documented this behavior explicitly in `relvar-core/src/algebra/join.rs` and added a regression test to ensure it remains consistent until a proper renaming mechanism is implemented.
+
+## 2024-05-24 - The Case of the Hidden Traits
+**Confusion:** Users could not use advanced operators like `extend`, `summarize`, and `group` because the necessary traits were not re-exported, requiring deep and undocumented import paths (e.g. `relvar::algebra::extend::ExtendOps`).
+**Clarification:** Re-exported `ExtendOps`, `GroupOps`, and `SummarizeOps` in `relvar-core/src/algebra/mod.rs` (accessible via `relvar::algebra::*`) and added comprehensive examples to the main `relvar` crate documentation demonstrating their usage and the required imports.

--- a/relvar-core/src/algebra/mod.rs
+++ b/relvar-core/src/algebra/mod.rs
@@ -83,9 +83,11 @@ pub mod divide;
 
 /// Extend operator for adding computed attributes.
 pub mod extend;
+pub use extend::ExtendOps;
 
 /// Group and ungroup operators for relation-valued attributes.
 pub mod group;
+pub use group::GroupOps;
 
 /// Set intersection operator.
 pub mod intersect;
@@ -107,6 +109,7 @@ pub mod semijoin;
 
 /// Summarize operator for aggregation with grouping.
 pub mod summarize;
+pub use summarize::{Aggregation, AggregationFn, SummarizeOps};
 
 /// Set union operator.
 pub mod union;

--- a/relvar/src/lib.rs
+++ b/relvar/src/lib.rs
@@ -55,6 +55,69 @@
 //! db.insert("EMPLOYEES", tuple! { id: 1i64, name: "Alice" }).unwrap();
 //! # }
 //! ```
+//!
+//! ### Advanced Relational Algebra
+//!
+//! Advanced operators like `extend`, `summarize`, and `group` require importing
+//! their corresponding traits. These are re-exported in `relvar::algebra`.
+//!
+//! ```
+//! use relvar::{Database, InMemoryEngine, tuple};
+//! use relvar::types::{TupleType, RelationType, ScalarType};
+//! use relvar::values::ScalarValue;
+//! // Import traits for advanced operators!
+//! use relvar::algebra::{ExtendOps, SummarizeOps, Aggregation};
+//!
+//! let mut db = Database::new(InMemoryEngine::new());
+//! // ... setup relvar ...
+//! # let rel_type = RelationType::new(
+//! #     TupleType::new()
+//! #         .with_attribute("id", ScalarType::Int)
+//! #         .with_attribute("salary", ScalarType::Int)
+//! # );
+//! # db.create_relvar("EMPLOYEES", rel_type).unwrap();
+//! # db.insert("EMPLOYEES", tuple! { id: 1i64, salary: 50000i64 }).unwrap();
+//!
+//! let employees = db.query("EMPLOYEES").unwrap();
+//!
+//! // Compute annual bonus (10%)
+//! let with_bonus = employees.extend("bonus", ScalarType::Int, |t| {
+//!     let salary = t.get_typed::<i64>("salary").unwrap();
+//!     ScalarValue::Int(salary / 10)
+//! }).unwrap();
+//!
+//! // Summarize total salary
+//! let stats = employees.summarize(&[], &[
+//!     Aggregation::sum("total_salary", "salary")
+//! ]).unwrap();
+//! ```
+//!
+//! ### Transactions
+//!
+//! Transactions allow grouping multiple operations into an atomic unit.
+//!
+//! ```
+//! use relvar::{Database, InMemoryEngine, tuple};
+//! # use relvar::types::{TupleType, RelationType, ScalarType};
+//!
+//! let mut db = Database::new(InMemoryEngine::new());
+//! # let rel_type = RelationType::new(TupleType::new().with_attribute("id", ScalarType::Int));
+//! # db.create_relvar("TEST", rel_type).unwrap();
+//!
+//! db.begin().unwrap();
+//!
+//! // These changes are tentative
+//! db.insert("TEST", tuple! { id: 1i64 }).unwrap();
+//! db.insert("TEST", tuple! { id: 2i64 }).unwrap();
+//!
+//! // Commit makes them permanent
+//! db.commit().unwrap();
+//!
+//! // Or use rollback to discard changes
+//! db.begin().unwrap();
+//! db.insert("TEST", tuple! { id: 3i64 }).unwrap();
+//! db.rollback().unwrap();
+//! ```
 
 #![warn(missing_docs)]
 


### PR DESCRIPTION
📖 Chapter: The `relvar` crate documentation and `algebra` module re-exports.
🔦 Insight: Users struggled to find and import traits needed for advanced operators like `extend` and `summarize`. Re-exported them for easier access and added comprehensive examples.
🧪 Example: Added executable doctests for `extend`, `summarize`, and transactions in `relvar/src/lib.rs`.


---
*PR created automatically by Jules for task [4746789403981736580](https://jules.google.com/task/4746789403981736580) started by @madmax983*