### PR TITLE
🔒 Warden: Enforce file size limits on Catalog and Index loading

### DIFF
--- a/relvar-storage/src/storage/btree.rs
+++ b/relvar-storage/src/storage/btree.rs
@@ -317,7 +317,7 @@ impl BTreeIndex {
 
     fn load_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> Result<Self, BTreeIndexError> {
         let file = File::open(path)?;
-        let mut reader = file.take(limit + 1);
+        let mut reader = file.take(limit.saturating_add(1));
         let mut contents = Vec::new();
         reader.read_to_end(&mut contents)?;
 

--- a/relvar-storage/src/storage/btree.rs
+++ b/relvar-storage/src/storage/btree.rs
@@ -547,7 +547,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             BTreeIndexError::Serialization(msg) => {
-                assert_eq!(msg, "Index file too large");
+                assert!(msg.contains("Index file too large"));
             }
             err => panic!("Expected Serialization error, got {:?}", err),
         }

--- a/relvar-storage/src/storage/btree.rs
+++ b/relvar-storage/src/storage/btree.rs
@@ -309,7 +309,8 @@ impl BTreeIndex {
     /// # Errors
     ///
     /// Returns [`BTreeIndexError::Io`] if the file cannot be read.
-    /// Returns [`BTreeIndexError::Serialization`] if deserialization fails.
+    /// Returns [`BTreeIndexError::Serialization`] if deserialization fails or if the
+    /// index file exceeds the configured size limit (e.g., [`MAX_INDEX_SIZE`]).
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, BTreeIndexError> {
         Self::load_with_limit(path, MAX_INDEX_SIZE)
     }

--- a/relvar-storage/src/storage/btree.rs
+++ b/relvar-storage/src/storage/btree.rs
@@ -46,7 +46,7 @@ use relvar_core::values::{ScalarValue, Tuple};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs::{File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::{BufReader, Read, Write};
 use std::path::Path;
 use thiserror::Error;
 
@@ -66,7 +66,7 @@ pub enum BTreeIndexError {
     KeyNotFound,
 }
 
-const MAX_INDEX_SIZE: u64 = 1024 * 1024 * 1024; // 1 GiB
+const MAX_INDEX_SIZE: u64 = 1024 * 1024 * 1024; // 1 GB
 
 /// A B-tree index mapping scalar key values to tuples.
 ///
@@ -309,29 +309,28 @@ impl BTreeIndex {
     /// # Errors
     ///
     /// Returns [`BTreeIndexError::Io`] if the file cannot be read.
-    /// Returns [`BTreeIndexError::Serialization`] if deserialization fails or if the
-    /// index file exceeds the configured size limit (e.g., [`MAX_INDEX_SIZE`]).
+    /// Returns [`BTreeIndexError::Serialization`] if deserialization fails.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, BTreeIndexError> {
         Self::load_with_limit(path, MAX_INDEX_SIZE)
     }
 
     fn load_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> Result<Self, BTreeIndexError> {
         let file = File::open(path)?;
-        let mut reader = file.take(limit.saturating_add(1));
-        let mut contents = Vec::new();
-        reader.read_to_end(&mut contents)?;
+        let len = file.metadata()?.len();
 
-        if contents.len() as u64 > limit {
+        if len > limit {
             return Err(BTreeIndexError::Serialization(
                 "Index file too large".to_string(),
             ));
         }
 
-        if contents.is_empty() {
+        if len == 0 {
             return Ok(Self::new());
         }
 
-        bincode::deserialize(&contents).map_err(|e| BTreeIndexError::Serialization(e.to_string()))
+        let reader = BufReader::new(file);
+        bincode::deserialize_from(reader.take(limit))
+            .map_err(|e| BTreeIndexError::Serialization(e.to_string()))
     }
 }
 
@@ -548,7 +547,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             BTreeIndexError::Serialization(msg) => {
-                assert!(msg.contains("Index file too large"));
+                assert_eq!(msg, "Index file too large");
             }
             err => panic!("Expected Serialization error, got {:?}", err),
         }

--- a/relvar-storage/src/storage/btree.rs
+++ b/relvar-storage/src/storage/btree.rs
@@ -66,6 +66,8 @@ pub enum BTreeIndexError {
     KeyNotFound,
 }
 
+const MAX_INDEX_SIZE: u64 = 1024 * 1024 * 1024; // 1 GB
+
 /// A B-tree index mapping scalar key values to tuples.
 ///
 /// This index provides O(log n) lookup, insertion, and deletion. Multiple
@@ -309,9 +311,20 @@ impl BTreeIndex {
     /// Returns [`BTreeIndexError::Io`] if the file cannot be read.
     /// Returns [`BTreeIndexError::Serialization`] if deserialization fails.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, BTreeIndexError> {
-        let mut file = File::open(path)?;
+        Self::load_with_limit(path, MAX_INDEX_SIZE)
+    }
+
+    fn load_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> Result<Self, BTreeIndexError> {
+        let file = File::open(path)?;
+        let mut reader = file.take(limit + 1);
         let mut contents = Vec::new();
-        file.read_to_end(&mut contents)?;
+        reader.read_to_end(&mut contents)?;
+
+        if contents.len() as u64 > limit {
+            return Err(BTreeIndexError::Serialization(
+                "Index file too large".to_string(),
+            ));
+        }
 
         if contents.is_empty() {
             return Ok(Self::new());
@@ -516,5 +529,27 @@ mod tests {
         // Type check: search returns &[Tuple] not &[TupleId]
         let results = index.search(&key).unwrap();
         assert_eq!(results[0], tuple);
+    }
+
+    #[test]
+    fn test_btree_load_limit() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+
+        // Write 20 bytes
+        {
+            let mut file = File::create(path).unwrap();
+            file.write_all(&[b'a'; 20]).unwrap();
+        }
+
+        // Try to load with limit 10
+        let result = BTreeIndex::load_with_limit(path, 10);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            BTreeIndexError::Serialization(msg) => {
+                assert_eq!(msg, "Index file too large");
+            }
+            err => panic!("Expected Serialization error, got {:?}", err),
+        }
     }
 }

--- a/relvar-storage/src/storage/btree.rs
+++ b/relvar-storage/src/storage/btree.rs
@@ -66,7 +66,7 @@ pub enum BTreeIndexError {
     KeyNotFound,
 }
 
-const MAX_INDEX_SIZE: u64 = 1024 * 1024 * 1024; // 1 GB
+const MAX_INDEX_SIZE: u64 = 1024 * 1024 * 1024; // 1 GiB
 
 /// A B-tree index mapping scalar key values to tuples.
 ///

--- a/relvar-storage/src/storage/catalog.rs
+++ b/relvar-storage/src/storage/catalog.rs
@@ -42,7 +42,7 @@ use relvar_core::types::RelationType;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -66,7 +66,7 @@ pub enum CatalogError {
     RelationExists(String),
 }
 
-const MAX_CATALOG_SIZE: u64 = 10 * 1024 * 1024; // 10 MiB
+const MAX_CATALOG_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
 
 /// Metadata for a stored relation (relvar).
 ///
@@ -157,29 +157,28 @@ impl Catalog {
     /// # Errors
     ///
     /// Returns [`CatalogError::Io`] if the file cannot be read.
-    /// Returns [`CatalogError::Serialization`] if the JSON is invalid or the
-    /// catalog file exceeds the maximum allowed size.
+    /// Returns [`CatalogError::Serialization`] if the JSON is invalid.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, CatalogError> {
         Self::load_with_limit(path, MAX_CATALOG_SIZE)
     }
 
     fn load_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> Result<Self, CatalogError> {
         let file = File::open(path)?;
-        let mut reader = file.take(limit.saturating_add(1));
-        let mut contents = String::new();
-        reader.read_to_string(&mut contents)?;
+        let len = file.metadata()?.len();
 
-        if contents.len() as u64 > limit {
+        if len > limit {
             return Err(CatalogError::Serialization(
                 "Catalog file too large".to_string(),
             ));
         }
 
-        if contents.is_empty() {
+        if len == 0 {
             return Ok(Self::new());
         }
 
-        serde_json::from_str(&contents).map_err(|e| CatalogError::Serialization(e.to_string()))
+        let reader = BufReader::new(file);
+        serde_json::from_reader(reader.take(limit))
+            .map_err(|e| CatalogError::Serialization(e.to_string()))
     }
 
     /// Saves the catalog to a JSON file.
@@ -511,7 +510,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             CatalogError::Serialization(msg) => {
-                assert!(msg.contains("Catalog file too large"));
+                assert_eq!(msg, "Catalog file too large");
             }
             err => panic!("Expected Serialization error, got {:?}", err),
         }

--- a/relvar-storage/src/storage/catalog.rs
+++ b/relvar-storage/src/storage/catalog.rs
@@ -66,7 +66,7 @@ pub enum CatalogError {
     RelationExists(String),
 }
 
-const MAX_CATALOG_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
+const MAX_CATALOG_SIZE: u64 = 10 * 1024 * 1024; // 10 MiB
 
 /// Metadata for a stored relation (relvar).
 ///

--- a/relvar-storage/src/storage/catalog.rs
+++ b/relvar-storage/src/storage/catalog.rs
@@ -66,6 +66,8 @@ pub enum CatalogError {
     RelationExists(String),
 }
 
+const MAX_CATALOG_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
+
 /// Metadata for a stored relation (relvar).
 ///
 /// Contains all the information needed to locate and interpret a relation's
@@ -157,9 +159,20 @@ impl Catalog {
     /// Returns [`CatalogError::Io`] if the file cannot be read.
     /// Returns [`CatalogError::Serialization`] if the JSON is invalid.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, CatalogError> {
-        let mut file = File::open(path)?;
+        Self::load_with_limit(path, MAX_CATALOG_SIZE)
+    }
+
+    fn load_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> Result<Self, CatalogError> {
+        let file = File::open(path)?;
+        let mut reader = file.take(limit + 1);
         let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
+        reader.read_to_string(&mut contents)?;
+
+        if contents.len() as u64 > limit {
+            return Err(CatalogError::Serialization(
+                "Catalog file too large".to_string(),
+            ));
+        }
 
         if contents.is_empty() {
             return Ok(Self::new());
@@ -479,5 +492,27 @@ mod tests {
             result.unwrap_err(),
             CatalogError::RelationNotFound(_)
         ));
+    }
+
+    #[test]
+    fn test_catalog_load_limit() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+
+        // Write 20 bytes
+        {
+            let mut file = File::create(path).unwrap();
+            file.write_all(&[b'a'; 20]).unwrap();
+        }
+
+        // Try to load with limit 10
+        let result = Catalog::load_with_limit(path, 10);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CatalogError::Serialization(msg) => {
+                assert_eq!(msg, "Catalog file too large");
+            }
+            err => panic!("Expected Serialization error, got {:?}", err),
+        }
     }
 }

--- a/relvar-storage/src/storage/catalog.rs
+++ b/relvar-storage/src/storage/catalog.rs
@@ -157,7 +157,8 @@ impl Catalog {
     /// # Errors
     ///
     /// Returns [`CatalogError::Io`] if the file cannot be read.
-    /// Returns [`CatalogError::Serialization`] if the JSON is invalid.
+    /// Returns [`CatalogError::Serialization`] if the JSON is invalid or the
+    /// catalog file exceeds the maximum allowed size.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, CatalogError> {
         Self::load_with_limit(path, MAX_CATALOG_SIZE)
     }

--- a/relvar-storage/src/storage/catalog.rs
+++ b/relvar-storage/src/storage/catalog.rs
@@ -510,7 +510,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             CatalogError::Serialization(msg) => {
-                assert_eq!(msg, "Catalog file too large");
+                assert!(msg.contains("Catalog file too large"));
             }
             err => panic!("Expected Serialization error, got {:?}", err),
         }

--- a/relvar-storage/src/storage/catalog.rs
+++ b/relvar-storage/src/storage/catalog.rs
@@ -165,7 +165,7 @@ impl Catalog {
 
     fn load_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> Result<Self, CatalogError> {
         let file = File::open(path)?;
-        let mut reader = file.take(limit + 1);
+        let mut reader = file.take(limit.saturating_add(1));
         let mut contents = String::new();
         reader.read_to_string(&mut contents)?;
 


### PR DESCRIPTION
**Threat:** Denial of Service (DoS) via resource exhaustion. Unbounded `read_to_end` and `read_to_string` calls in `Catalog::load` and `BTreeIndex::load` could allow an attacker (or corrupted filesystem) to crash the server by providing a massive file, causing an Out-Of-Memory (OOM) panic.

**Defense:** Implemented "Capped Readers" strategy.
- `Catalog::load` is now capped at 10MB.
- `BTreeIndex::load` is now capped at 1GB.
- Loading logic now uses `file.take(LIMIT)` to enforce these bounds.
- If a file exceeds the limit, a `Serialization` error is returned instead of crashing.

**Severity:** High (Potential OOM crash).

**Verification:**
- Added `test_catalog_load_limit` in `storage/catalog.rs` which verifies that loading a file larger than the limit returns an error.
- Added `test_btree_load_limit` in `storage/btree.rs` which verifies the same for indexes.
- All existing tests passed.

---
*PR created automatically by Jules for task [9676951420612702407](https://jules.google.com/task/9676951420612702407) started by @madmax983*