### PR TITLE
🎻 Bard: Documentation improvements for relational operators and constraints

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -7,3 +7,11 @@
 ## The Case of the Hidden Traits
 **Confusion:** Users could not use advanced operators like `extend`, `summarize`, and `group` because the necessary traits were not re-exported, requiring deep and undocumented import paths (e.g. `relvar::algebra::extend::ExtendOps`).
 **Clarification:** Re-exported `ExtendOps`, `GroupOps`, and `SummarizeOps` in `relvar-core/src/algebra/mod.rs` (accessible via `relvar::algebra::*`) and added comprehensive examples to the main `relvar` crate documentation demonstrating their usage and the required imports.
+
+## The Case of the Theoretical Division
+**Confusion:** The `divide` operator's documentation relied on a text-based ASCII art example that described the mathematical concept but didn't show how to actually use the Rust API to perform division.
+**Clarification:** Replaced the text block with a fully executable `doctest` that constructs the classic "Suppliers and Parts" example relations and verifies the division result programmatically.
+
+## The Case of the Undocumented Constraints
+**Confusion:** The critical database constraint methods (`set_key_constraints`, `set_foreign_key_constraints`, `set_type_constraints`) had no examples, leaving users to guess how to construct the complex constraint objects.
+**Clarification:** Added comprehensive `## Example` sections to each method, demonstrating the full workflow of creating relation types, instantiating constraint objects, and applying them to the database.

--- a/relvar-core/src/algebra/divide.rs
+++ b/relvar-core/src/algebra/divide.rs
@@ -32,16 +32,41 @@ impl Relation {
     ///
     /// # Examples
     ///
-    /// ```text
-    /// // SUPPLIES(supplier_id, part_id):
-    /// // S1 supplies: P1, P2
-    /// // S2 supplies: P1
-    /// // S3 supplies: P1, P2
-    /// //
+    /// ```
+    /// use relvar_core::types::{TupleType, RelationType, ScalarType};
+    /// use relvar_core::values::Relation;
+    /// use relvar_core::tuple;
+    ///
+    /// // SUPPLIES(supplier_id, part_id)
+    /// let supplies_heading = TupleType::new()
+    ///     .with_attribute("supplier_id", ScalarType::String)
+    ///     .with_attribute("part_id", ScalarType::String);
+    /// let mut supplies = Relation::new(RelationType::new(supplies_heading));
+    ///
+    /// // S1 supplies P1, P2
+    /// supplies.insert(tuple! { supplier_id: "S1", part_id: "P1" }).unwrap();
+    /// supplies.insert(tuple! { supplier_id: "S1", part_id: "P2" }).unwrap();
+    /// // S2 supplies only P1
+    /// supplies.insert(tuple! { supplier_id: "S2", part_id: "P1" }).unwrap();
+    /// // S3 supplies P1, P2
+    /// supplies.insert(tuple! { supplier_id: "S3", part_id: "P1" }).unwrap();
+    /// supplies.insert(tuple! { supplier_id: "S3", part_id: "P2" }).unwrap();
+    ///
     /// // PARTS(part_id): P1, P2
-    /// //
-    /// // SUPPLIES.divide(&PARTS) = {supplier_id}
-    /// // Result: {S1, S3} - suppliers who supply ALL parts
+    /// let parts_heading = TupleType::new()
+    ///     .with_attribute("part_id", ScalarType::String);
+    /// let mut parts = Relation::new(RelationType::new(parts_heading));
+    /// parts.insert(tuple! { part_id: "P1" }).unwrap();
+    /// parts.insert(tuple! { part_id: "P2" }).unwrap();
+    ///
+    /// // Find suppliers who supply ALL parts
+    /// let result = supplies.divide(&parts).unwrap();
+    ///
+    /// // Result: {S1, S3}
+    /// assert_eq!(result.cardinality(), 2);
+    /// assert!(result.contains(&tuple! { supplier_id: "S1" }));
+    /// assert!(result.contains(&tuple! { supplier_id: "S3" }));
+    /// assert!(!result.contains(&tuple! { supplier_id: "S2" }));
     /// ```
     ///
     /// # Errors

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -314,7 +314,7 @@ impl<E: StorageEngine> Database<E> {
     /// use relvar_core::storage_engine::InMemoryEngine;
     /// use relvar_core::types::{TupleType, RelationType, ScalarType};
     /// use relvar_core::constraints::AttributeConstraints;
-    /// use relvar_core::constraints::type_constraint::TypeConstraint;
+    /// use relvar_core::constraints::TypeConstraint;
     ///
     /// let mut db = Database::new(InMemoryEngine::new());
     /// let rel_type = RelationType::new(

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -202,6 +202,26 @@ impl<E: StorageEngine> Database<E> {
     }
 
     /// Set key constraints for a relation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar_core::database::Database;
+    /// use relvar_core::storage_engine::InMemoryEngine;
+    /// use relvar_core::types::{TupleType, RelationType, ScalarType};
+    /// use relvar_core::constraints::{KeyConstraints, PrimaryKey};
+    ///
+    /// let mut db = Database::new(InMemoryEngine::new());
+    /// let rel_type = RelationType::new(
+    ///     TupleType::new().with_attribute("id", ScalarType::Int)
+    /// );
+    /// db.create_relvar("TEST", rel_type).unwrap();
+    ///
+    /// let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    /// let constraints = KeyConstraints::new().with_primary_key(pk);
+    ///
+    /// db.set_key_constraints("TEST", constraints).unwrap();
+    /// ```
     pub fn set_key_constraints(
         &mut self,
         relation_name: &str,
@@ -221,6 +241,38 @@ impl<E: StorageEngine> Database<E> {
     }
 
     /// Set foreign key constraints for a relation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar_core::database::Database;
+    /// use relvar_core::storage_engine::InMemoryEngine;
+    /// use relvar_core::types::{TupleType, RelationType, ScalarType};
+    /// use relvar_core::constraints::{ForeignKeyConstraints, ForeignKey};
+    ///
+    /// let mut db = Database::new(InMemoryEngine::new());
+    ///
+    /// // Create referenced relvar
+    /// let dept_type = RelationType::new(
+    ///     TupleType::new().with_attribute("dept_id", ScalarType::Int)
+    /// );
+    /// db.create_relvar("DEPT", dept_type).unwrap();
+    ///
+    /// // Create referencing relvar
+    /// let emp_type = RelationType::new(
+    ///     TupleType::new().with_attribute("dept_id", ScalarType::Int)
+    /// );
+    /// db.create_relvar("EMP", emp_type).unwrap();
+    ///
+    /// let fk = ForeignKey::new(
+    ///     vec!["dept_id".to_string()],
+    ///     "DEPT".to_string(),
+    ///     vec!["dept_id".to_string()]
+    /// ).unwrap();
+    /// let constraints = ForeignKeyConstraints::new().with_foreign_key(fk);
+    ///
+    /// db.set_foreign_key_constraints("EMP", constraints).unwrap();
+    /// ```
     pub fn set_foreign_key_constraints(
         &mut self,
         relation_name: &str,
@@ -254,6 +306,27 @@ impl<E: StorageEngine> Database<E> {
     }
 
     /// Set type constraints for an attribute.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar_core::database::Database;
+    /// use relvar_core::storage_engine::InMemoryEngine;
+    /// use relvar_core::types::{TupleType, RelationType, ScalarType};
+    /// use relvar_core::constraints::AttributeConstraints;
+    /// use relvar_core::constraints::type_constraint::TypeConstraint;
+    ///
+    /// let mut db = Database::new(InMemoryEngine::new());
+    /// let rel_type = RelationType::new(
+    ///     TupleType::new().with_attribute("count", ScalarType::Int)
+    /// );
+    /// db.create_relvar("TEST", rel_type).unwrap();
+    ///
+    /// let attr_constraints = AttributeConstraints::new("count".to_string(), ScalarType::Int)
+    ///     .with_constraint(TypeConstraint::PositiveInt);
+    ///
+    /// db.set_type_constraints("TEST", "count", attr_constraints).unwrap();
+    /// ```
     pub fn set_type_constraints(
         &mut self,
         relation_name: &str,


### PR DESCRIPTION
Improved documentation by replacing text-based examples with executable Rust doctests.

- Replaced the theoretical text example in `relvar-core/src/algebra/divide.rs` with a working code example demonstrating the `divide` operator using the "Suppliers and Parts" scenario.
- Added comprehensive examples to `set_key_constraints`, `set_foreign_key_constraints`, and `set_type_constraints` in `relvar-core/src/database.rs`, showing how to construct and apply these constraints.
- Updated `Bard's Journal` (.jules/bard.md) with learnings.

This ensures that the documentation is accurate, verifiable, and helpful for users.

---
*PR created automatically by Jules for task [18403309318011076856](https://jules.google.com/task/18403309318011076856) started by @madmax983*