### PR TITLE
🗺️ Atlas: Implement constraint persistence

### DIFF
--- a/relvar-core/src/constraints/check.rs
+++ b/relvar-core/src/constraints/check.rs
@@ -37,10 +37,12 @@
 
 use crate::constraints::expression::ConstraintExpression;
 use crate::values::Tuple;
+use serde::{Deserialize, Serialize, Serializer};
+use std::sync::Arc;
 use thiserror::Error;
 
 /// Errors that can occur during CHECK constraint evaluation.
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error, Serialize, Deserialize)]
 pub enum CheckConstraintError {
     /// The constraint was violated.
     #[error("CHECK constraint '{constraint_name}' violated: {description}")]
@@ -60,12 +62,18 @@ pub enum CheckConstraintError {
 ///
 /// Supports both closure-based (flexible, not serializable) and
 /// expression-based (serializable, persistent) predicates.
+#[derive(Clone, Serialize, Deserialize)]
 pub enum CheckPredicate {
     /// Closure-based predicate (not serializable).
     ///
     /// Use for complex business logic that can't be expressed in the DSL.
     /// Must be re-registered on database restart.
-    Dynamic(Box<dyn Fn(&Tuple) -> bool + Send + Sync>),
+    #[serde(skip)]
+    Dynamic(
+        #[serde(skip)]
+        #[allow(clippy::type_complexity)]
+        Arc<dyn Fn(&Tuple) -> bool + Send + Sync>,
+    ),
 
     /// Expression-based predicate (serializable).
     ///
@@ -106,7 +114,7 @@ impl std::fmt::Debug for CheckPredicate {
 /// let valid = tuple! { name: "Alice", salary: 50000i64 };
 /// assert!(constraint.is_satisfied_by(&valid).unwrap());
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckConstraint {
     /// Constraint name (unique identifier).
     name: String,
@@ -141,7 +149,7 @@ impl CheckConstraint {
     {
         Self {
             name: name.into(),
-            predicate: CheckPredicate::Dynamic(Box::new(f)),
+            predicate: CheckPredicate::Dynamic(Arc::new(f)),
             description: description.into(),
         }
     }
@@ -211,9 +219,29 @@ impl CheckConstraint {
 ///
 /// This manages multiple CHECK constraints and provides methods to check
 /// if all constraints are satisfied by a tuple.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct CheckConstraints {
     constraints: Vec<CheckConstraint>,
+}
+
+impl Serialize for CheckConstraints {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        // Filter out non-serializable constraints (Dynamic predicates)
+        // We only persist constraints defined via expressions
+        let serializable: Vec<&CheckConstraint> = self
+            .constraints
+            .iter()
+            .filter(|c| c.is_serializable())
+            .collect();
+
+        let mut state = serializer.serialize_struct("CheckConstraints", 1)?;
+        state.serialize_field("constraints", &serializable)?;
+        state.end()
+    }
 }
 
 impl CheckConstraints {

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -7,7 +7,7 @@ use crate::constraints::{
     AttributeConstraints, CheckConstraintError, CheckConstraints, ForeignKeyConstraints,
     KeyConstraints,
 };
-use crate::storage_engine::{StorageEngine, StorageError};
+use crate::storage_engine::{ConstraintMetadata, StorageEngine, StorageError};
 use crate::types::RelationType;
 use crate::values::relation::RelationError;
 use crate::values::{Relation, ScalarValue, Tuple};
@@ -141,9 +141,9 @@ pub struct Database<E: StorageEngine> {
 }
 
 impl<E: StorageEngine> Database<E> {
-    /// Create a new database with the given storage engine.
-    pub fn new(engine: E) -> Self {
-        Self {
+    /// Open a database with the given storage engine, loading any existing metadata.
+    pub fn open(engine: E) -> Result<Self, DatabaseError> {
+        let mut db = Self {
             engine,
             key_constraints: HashMap::new(),
             foreign_key_constraints: HashMap::new(),
@@ -152,7 +152,44 @@ impl<E: StorageEngine> Database<E> {
             in_transaction: false,
             transaction_snapshot: None,
             virtual_relvars: HashMap::new(),
+        };
+
+        // Load metadata for all relations
+        for relation_name in db.engine.list_relations() {
+            match db.engine.load_constraints(&relation_name) {
+                Ok(metadata) => {
+                    if let Some(kc) = metadata.key_constraints {
+                        db.key_constraints.insert(relation_name.clone(), kc);
+                    }
+                    if let Some(fkc) = metadata.foreign_key_constraints {
+                        db.foreign_key_constraints
+                            .insert(relation_name.clone(), fkc);
+                    }
+                    if !metadata.type_constraints.is_empty() {
+                        db.type_constraints
+                            .insert(relation_name.clone(), metadata.type_constraints);
+                    }
+                    if let Some(cc) = metadata.check_constraints {
+                        db.check_constraints.insert(relation_name.clone(), cc);
+                    }
+                }
+                Err(StorageError::RelationNotFound(_)) => {
+                    // Relation might have been dropped concurrently, ignore.
+                }
+                Err(e) => return Err(DatabaseError::Storage(e)),
+            }
         }
+
+        Ok(db)
+    }
+
+    /// Create a new database with the given storage engine.
+    ///
+    /// # Panics
+    ///
+    /// Panics if loading metadata fails. Use `open` for safe initialization.
+    pub fn new(engine: E) -> Self {
+        Self::open(engine).expect("Failed to open database")
     }
 
     /// Create a new base relvar (stored relation).
@@ -217,6 +254,7 @@ impl<E: StorageEngine> Database<E> {
 
         self.key_constraints
             .insert(relation_name.to_string(), constraints);
+        self.persist_constraints(relation_name)?;
         Ok(())
     }
 
@@ -250,6 +288,7 @@ impl<E: StorageEngine> Database<E> {
 
         self.foreign_key_constraints
             .insert(relation_name.to_string(), constraints);
+        self.persist_constraints(relation_name)?;
         Ok(())
     }
 
@@ -288,6 +327,7 @@ impl<E: StorageEngine> Database<E> {
             .entry(relation_name.to_string())
             .or_default()
             .insert(attribute_name.to_string(), constraints);
+        self.persist_constraints(relation_name)?;
         Ok(())
     }
 
@@ -318,6 +358,7 @@ impl<E: StorageEngine> Database<E> {
 
         self.check_constraints
             .insert(relation_name.to_string(), constraints);
+        self.persist_constraints(relation_name)?;
         Ok(())
     }
 
@@ -664,6 +705,21 @@ impl<E: StorageEngine> Database<E> {
                 return Err(DatabaseError::CandidateKeyViolation);
             }
         }
+        Ok(())
+    }
+
+    fn persist_constraints(&mut self, relation_name: &str) -> Result<(), DatabaseError> {
+        let metadata = ConstraintMetadata {
+            key_constraints: self.key_constraints.get(relation_name).cloned(),
+            foreign_key_constraints: self.foreign_key_constraints.get(relation_name).cloned(),
+            type_constraints: self
+                .type_constraints
+                .get(relation_name)
+                .cloned()
+                .unwrap_or_default(),
+            check_constraints: self.check_constraints.get(relation_name).cloned(),
+        };
+        self.engine.save_constraints(relation_name, metadata)?;
         Ok(())
     }
 

--- a/relvar-core/src/storage_engine/in_memory.rs
+++ b/relvar-core/src/storage_engine/in_memory.rs
@@ -6,7 +6,7 @@
 //! - Benchmarking pure relational operations
 //! - Temporary databases that don't need persistence
 
-use super::{RelationMetadata, StorageEngine, StorageError};
+use super::{ConstraintMetadata, RelationMetadata, StorageEngine, StorageError};
 use crate::types::RelationType;
 use crate::values::{Relation, Tuple};
 use std::collections::HashMap;
@@ -16,13 +16,14 @@ use std::collections::HashMap;
 struct StoredRelation {
     metadata: RelationMetadata,
     relation: Relation,
+    constraints: ConstraintMetadata,
 }
 
 /// Snapshot for in-memory transactions.
 #[derive(Debug, Clone)]
 pub struct InMemorySnapshot {
     /// Saved relations, keyed by name.
-    pub saved_relations: HashMap<String, Relation>,
+    saved_relations: HashMap<String, StoredRelation>,
 }
 
 /// Pure in-memory storage engine.
@@ -86,9 +87,16 @@ impl StorageEngine for InMemoryEngine {
         };
 
         let relation = Relation::new(relation_type);
+        let constraints = ConstraintMetadata::default();
 
-        self.relations
-            .insert(name.to_string(), StoredRelation { metadata, relation });
+        self.relations.insert(
+            name.to_string(),
+            StoredRelation {
+                metadata,
+                relation,
+                constraints,
+            },
+        );
 
         Ok(())
     }
@@ -154,12 +162,33 @@ impl StorageEngine for InMemoryEngine {
         Ok(())
     }
 
+    fn save_constraints(
+        &mut self,
+        relation_name: &str,
+        constraints: ConstraintMetadata,
+    ) -> Result<(), StorageError> {
+        let stored = self
+            .relations
+            .get_mut(relation_name)
+            .ok_or_else(|| StorageError::RelationNotFound(relation_name.to_string()))?;
+
+        stored.constraints = constraints;
+        Ok(())
+    }
+
+    fn load_constraints(&self, relation_name: &str) -> Result<ConstraintMetadata, StorageError> {
+        self.relations
+            .get(relation_name)
+            .map(|stored| stored.constraints.clone())
+            .ok_or_else(|| StorageError::RelationNotFound(relation_name.to_string()))
+    }
+
     fn begin_transaction(&mut self) -> Result<Self::Snapshot, StorageError> {
         // Save current state
-        let saved_relations: HashMap<String, Relation> = self
+        let saved_relations: HashMap<String, StoredRelation> = self
             .relations
             .iter()
-            .map(|(name, stored)| (name.clone(), stored.relation.clone()))
+            .map(|(name, stored)| (name.clone(), stored.clone()))
             .collect();
 
         Ok(InMemorySnapshot { saved_relations })
@@ -167,12 +196,7 @@ impl StorageEngine for InMemoryEngine {
 
     fn rollback_transaction(&mut self, snapshot: Self::Snapshot) -> Result<(), StorageError> {
         // Restore saved state
-        for (name, relation) in snapshot.saved_relations {
-            if let Some(stored) = self.relations.get_mut(&name) {
-                stored.relation = relation;
-            }
-        }
-
+        self.relations = snapshot.saved_relations;
         Ok(())
     }
 }

--- a/relvar-core/src/storage_engine/mod.rs
+++ b/relvar-core/src/storage_engine/mod.rs
@@ -9,8 +9,13 @@
 //! The storage engine is purely an implementation detail (RM Proscription 3).
 //! The logical relational model is independent of how data is physically stored.
 
+use crate::constraints::{
+    AttributeConstraints, CheckConstraints, ForeignKeyConstraints, KeyConstraints,
+};
 use crate::types::RelationType;
 use crate::values::{Relation, Tuple};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use thiserror::Error;
 
 pub mod in_memory;
@@ -44,6 +49,19 @@ pub struct RelationMetadata {
     pub name: String,
     /// The type (heading) of the relation.
     pub relation_type: RelationType,
+}
+
+/// Metadata about constraints on a relation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ConstraintMetadata {
+    /// Key constraints (primary and candidate keys).
+    pub key_constraints: Option<KeyConstraints>,
+    /// Foreign key constraints.
+    pub foreign_key_constraints: Option<ForeignKeyConstraints>,
+    /// Type constraints (per attribute).
+    pub type_constraints: HashMap<String, AttributeConstraints>,
+    /// CHECK constraints.
+    pub check_constraints: Option<CheckConstraints>,
 }
 
 /// Trait for storage engine backends.
@@ -125,6 +143,24 @@ pub trait StorageEngine: Send + Sync {
     ///
     /// Returns `StorageError::RelationNotFound` if the relation doesn't exist.
     fn insert_tuple(&mut self, name: &str, tuple: Tuple) -> Result<(), StorageError>;
+
+    /// Save constraints for a relation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StorageError::RelationNotFound` if the relation doesn't exist.
+    fn save_constraints(
+        &mut self,
+        relation_name: &str,
+        constraints: ConstraintMetadata,
+    ) -> Result<(), StorageError>;
+
+    /// Load constraints for a relation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StorageError::RelationNotFound` if the relation doesn't exist.
+    fn load_constraints(&self, relation_name: &str) -> Result<ConstraintMetadata, StorageError>;
 
     /// Begin a transaction (save current state).
     ///

--- a/relvar-storage/src/persistent_engine.rs
+++ b/relvar-storage/src/persistent_engine.rs
@@ -1,7 +1,9 @@
 //! Persistent storage engine implementation using heap files and catalog.
 
 use crate::storage::{Catalog, CatalogError, HeapError, HeapFile};
-use relvar_core::storage_engine::{RelationMetadata, StorageEngine, StorageError};
+use relvar_core::storage_engine::{
+    ConstraintMetadata, RelationMetadata, StorageEngine, StorageError,
+};
 use relvar_core::types::RelationType;
 use relvar_core::values::{Relation, Tuple};
 use std::collections::HashMap;
@@ -325,6 +327,46 @@ impl StorageEngine for PersistentEngine {
         heap_file
             .insert_tuple(&tuple)
             .map_err(Self::convert_heap_error)
+    }
+
+    fn save_constraints(
+        &mut self,
+        relation_name: &str,
+        constraints: ConstraintMetadata,
+    ) -> Result<(), StorageError> {
+        self.catalog
+            .update_constraints(relation_name, constraints)
+            .map_err(|e| match e {
+                CatalogError::RelationNotFound(r) => StorageError::RelationNotFound(r),
+                CatalogError::Io(io_err) => {
+                    StorageError::Other(format!("Catalog I/O error: {}", io_err))
+                }
+                CatalogError::Serialization(s) => {
+                    StorageError::Other(format!("Catalog error: {}", s))
+                }
+                CatalogError::RelationExists(r) => StorageError::RelationAlreadyExists(r),
+            })?;
+
+        self.save_catalog()?;
+        Ok(())
+    }
+
+    fn load_constraints(&self, relation_name: &str) -> Result<ConstraintMetadata, StorageError> {
+        let metadata = self
+            .catalog
+            .get_relation(relation_name)
+            .map_err(|e| match e {
+                CatalogError::RelationNotFound(r) => StorageError::RelationNotFound(r),
+                CatalogError::Io(io_err) => {
+                    StorageError::Other(format!("Catalog I/O error: {}", io_err))
+                }
+                CatalogError::Serialization(s) => {
+                    StorageError::Other(format!("Catalog error: {}", s))
+                }
+                CatalogError::RelationExists(r) => StorageError::RelationAlreadyExists(r),
+            })?;
+
+        Ok(metadata.constraints.clone())
     }
 
     fn begin_transaction(&mut self) -> Result<Self::Snapshot, StorageError> {
@@ -777,5 +819,106 @@ mod tests {
 
         let relation = engine.load_relation("TEST").unwrap();
         assert_eq!(relation.cardinality(), 2);
+    }
+
+    #[test]
+    fn test_constraint_persistence() {
+        use relvar_core::constraints::{KeyConstraints, PrimaryKey};
+        use relvar_core::database::{Database, DatabaseError};
+
+        let temp_dir = TempDir::new().unwrap();
+
+        // 1. Create DB, add relation and constraint
+        {
+            let engine = PersistentEngine::open(temp_dir.path()).unwrap();
+            let mut db = Database::open(engine).unwrap();
+
+            db.create_relvar("USERS", test_rel_type()).unwrap();
+
+            let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+            let constraints = KeyConstraints::new().with_primary_key(pk);
+            db.set_key_constraints("USERS", constraints).unwrap();
+
+            db.insert("USERS", tuple! { id: 1i64, name: "Alice" })
+                .unwrap();
+        }
+
+        // 2. Re-open DB and verify constraint
+        {
+            let engine = PersistentEngine::open(temp_dir.path()).unwrap();
+            let mut db = Database::open(engine).unwrap();
+
+            // Insert duplicate PK
+            let result = db.insert("USERS", tuple! { id: 1i64, name: "Bob" });
+            assert!(result.is_err());
+            assert!(matches!(result, Err(DatabaseError::PrimaryKeyViolation)));
+        }
+    }
+
+    #[test]
+    fn test_dynamic_constraint_persistence() {
+        use relvar_core::constraints::expression::{ConstraintExpression, ValueOrRef};
+        use relvar_core::constraints::{CheckConstraint, CheckConstraints};
+        use relvar_core::database::{Database, DatabaseError};
+        use relvar_core::values::ScalarValue;
+
+        let temp_dir = TempDir::new().unwrap();
+
+        // 1. Create DB with dynamic and expression constraints
+        {
+            let engine = PersistentEngine::open(temp_dir.path()).unwrap();
+            let mut db = Database::open(engine).unwrap();
+
+            db.create_relvar("TEST", test_rel_type()).unwrap();
+
+            // Dynamic constraint: fail if id == 100 (should be dropped on save)
+            let dynamic = CheckConstraint::from_closure("dynamic", "desc", |t| {
+                if let Some(ScalarValue::Int(id)) = t.get("id") {
+                    *id != 100
+                } else {
+                    true
+                }
+            });
+
+            // Expression constraint: fail if id < 0 (should be persisted)
+            let expr = CheckConstraint::from_expression(
+                "expr",
+                "desc",
+                ConstraintExpression::Ge("id".to_string(), ValueOrRef::Value(ScalarValue::Int(0))),
+            );
+
+            let constraints = CheckConstraints::new()
+                .with_constraint(dynamic)
+                .with_constraint(expr);
+
+            db.set_check_constraints("TEST", constraints).unwrap();
+
+            // Verify constraints active in memory
+            assert!(
+                db.insert("TEST", tuple! { id: 100i64, name: "Bad" })
+                    .is_err()
+            );
+            assert!(
+                db.insert("TEST", tuple! { id: -1i64, name: "Bad" })
+                    .is_err()
+            );
+        }
+
+        // 2. Re-open and verify
+        {
+            let engine = PersistentEngine::open(temp_dir.path()).unwrap();
+            let mut db = Database::open(engine).unwrap();
+
+            // Dynamic constraint should be gone: id=100 should succeed
+            assert!(db.insert("TEST", tuple! { id: 100i64, name: "Ok" }).is_ok());
+
+            // Expression constraint should persist: id=-1 should fail
+            let result = db.insert("TEST", tuple! { id: -1i64, name: "Bad" });
+            assert!(result.is_err());
+            assert!(matches!(
+                result,
+                Err(DatabaseError::CheckConstraintViolation(_))
+            ));
+        }
     }
 }

--- a/relvar-storage/src/storage/catalog.rs
+++ b/relvar-storage/src/storage/catalog.rs
@@ -38,6 +38,7 @@
 //! assert_eq!(metadata.name, "employees");
 //! ```
 
+use relvar_core::storage_engine::ConstraintMetadata;
 use relvar_core::types::RelationType;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -84,6 +85,9 @@ pub struct RelationMetadata {
     pub relation_type: RelationType,
     /// Path to the heap file storing the relation's data.
     pub heap_file_path: PathBuf,
+    /// Constraints defined on the relation.
+    #[serde(default)]
+    pub constraints: ConstraintMetadata,
 }
 
 /// The system catalog storing metadata for all relations in the database.
@@ -218,9 +222,30 @@ impl Catalog {
             name: name.clone(),
             relation_type,
             heap_file_path,
+            constraints: ConstraintMetadata::default(),
         };
 
         self.relations.insert(name, metadata);
+        Ok(())
+    }
+
+    /// Updates constraints for a relation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::RelationNotFound`] if no relation with
+    /// this name exists.
+    pub fn update_constraints(
+        &mut self,
+        name: &str,
+        constraints: ConstraintMetadata,
+    ) -> Result<(), CatalogError> {
+        let metadata = self
+            .relations
+            .get_mut(name)
+            .ok_or_else(|| CatalogError::RelationNotFound(name.to_string()))?;
+
+        metadata.constraints = constraints;
         Ok(())
     }
 


### PR DESCRIPTION
This PR implements constraint persistence for `relvar`.

**The Tangle:** 
Previously, `Database` managed constraints in-memory, while `PersistentEngine` only persisted relation data (tuples). This meant that defining a Primary Key or Foreign Key was transient; if the database was closed and re-opened, all constraints were lost, allowing data integrity violations.

**The Blueprint:**
1.  **Extended `StorageEngine`:** Added `save_constraints` and `load_constraints` methods to the `StorageEngine` trait.
2.  **Constraint Metadata:** Defined `ConstraintMetadata` in `relvar-core` to bundle all constraints for a relation.
3.  **Persistence Implementation:** Updated `PersistentEngine` (and `Catalog`) to serialize and store `ConstraintMetadata` alongside relation metadata.
4.  **Database Integration:** Updated `Database` to load constraints on open and save them on modification.
5.  **Dynamic Constraints:** Implemented filtering logic to ensure that closure-based CHECK constraints (which cannot be serialized) are gracefully dropped during persistence, while expression-based constraints are preserved.

**Verification:**
-   `cargo test` passes (core logic, storage logic, and new persistence tests).
-   `cargo clippy` is clean.
-   Added specific tests verifying that duplicate keys are rejected after restart, and that expression constraints survive restart while dynamic ones are dropped.

---
*PR created automatically by Jules for task [18189115523594973846](https://jules.google.com/task/18189115523594973846) started by @madmax983*