### PR TITLE
Simplify algebra operators by removing unnecessary traits

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -1,0 +1,4 @@
+## [Reduction]
+**Bloat:** Single-implementation extension traits (`ExtendOps`, `GroupOps`, `SummarizeOps`) for `Relation`.
+**Cut:** Moved methods directly to `Relation` struct.
+**Saved:** ~3 traits, removed unnecessary imports, simplified API.

--- a/benches/algebra.rs
+++ b/benches/algebra.rs
@@ -1,6 +1,5 @@
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use relvar::algebra::extend::ExtendOps;
-use relvar::algebra::summarize::{Aggregation, AggregationFn, SummarizeOps};
+use relvar::algebra::summarize::{Aggregation, AggregationFn};
 use relvar::tuple;
 use relvar::types::{RelationType, ScalarType, TupleType};
 use relvar::values::{Relation, ScalarValue};

--- a/relvar-core/benches/algebra.rs
+++ b/relvar-core/benches/algebra.rs
@@ -1,6 +1,5 @@
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use relvar_core::algebra::extend::ExtendOps;
-use relvar_core::algebra::summarize::{Aggregation, AggregationFn, SummarizeOps};
+use relvar_core::algebra::summarize::{Aggregation, AggregationFn};
 use relvar_core::tuple;
 use relvar_core::types::{RelationType, ScalarType, TupleType};
 use relvar_core::values::{Relation, ScalarValue};

--- a/relvar-core/src/algebra/extend.rs
+++ b/relvar-core/src/algebra/extend.rs
@@ -15,7 +15,6 @@
 //! ```
 //! use relvar_core::types::{TupleType, RelationType, ScalarType};
 //! use relvar_core::values::{Relation, ScalarValue};
-//! use relvar_core::algebra::extend::ExtendOps;
 //! use relvar_core::tuple;
 //!
 //! let heading = TupleType::new()
@@ -56,11 +55,7 @@ pub enum ExtendError {
     TupleCreation(String),
 }
 
-/// Trait providing the extend operation for relations.
-///
-/// This trait defines the `extend` method which adds computed attributes
-/// to relations. It is implemented for [`Relation`].
-pub trait ExtendOps {
+impl Relation {
     /// Extends the relation with a new computed attribute.
     ///
     /// This operator adds a new attribute to each tuple, where the value
@@ -82,18 +77,7 @@ pub trait ExtendOps {
     ///
     /// Returns [`ExtendError::AttributeExists`] if an attribute with the
     /// given name already exists in the relation.
-    fn extend<F>(
-        &self,
-        attr_name: &str,
-        attr_type: crate::types::ScalarType,
-        compute: F,
-    ) -> Result<Relation, ExtendError>
-    where
-        F: Fn(&Tuple) -> ScalarValue;
-}
-
-impl ExtendOps for Relation {
-    fn extend<F>(
+    pub fn extend<F>(
         &self,
         attr_name: &str,
         attr_type: crate::types::ScalarType,

--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -15,7 +15,6 @@
 //! ```
 //! use relvar_core::types::{TupleType, RelationType, ScalarType};
 //! use relvar_core::values::{Relation, ScalarValue};
-//! use relvar_core::algebra::group::GroupOps;
 //! use relvar_core::tuple;
 //!
 //! let heading = TupleType::new()
@@ -46,7 +45,7 @@ pub enum GroupError {
     #[error("Grouping attribute '{0}' does not exist in relation")]
     AttributeNotFound(String),
 
-    /// No attributes were specified to group into the RVA.
+    /// No attributes were specified for grouping.
     #[error("No attributes specified for grouping")]
     NoAttributesSpecified,
 
@@ -79,11 +78,7 @@ pub enum UngroupError {
     TupleCreation(String),
 }
 
-/// Trait providing group and ungroup operations for relations.
-///
-/// This trait defines methods for creating and flattening relation-valued
-/// attributes (RVAs), which allow nested relations within tuples.
-pub trait GroupOps {
+impl Relation {
     /// Groups specified attributes into a relation-valued attribute.
     ///
     /// This operator collects tuples with matching values on the non-grouped
@@ -106,31 +101,7 @@ pub trait GroupOps {
     /// - [`GroupError::NoAttributesSpecified`] - Empty attributes list
     /// - [`GroupError::AllAttributesGrouped`] - No grouping key attributes remain
     /// - [`GroupError::ResultAttributeExists`] - RVA name conflicts
-    fn group(&self, attrs_to_group: &[&str], rva_name: &str) -> Result<Relation, GroupError>;
-
-    /// Ungroups a relation-valued attribute back into regular attributes.
-    ///
-    /// This is the inverse of [`group`](Self::group). It flattens a nested
-    /// relation by combining each inner tuple with its parent tuple's
-    /// non-RVA attributes.
-    ///
-    /// # Arguments
-    ///
-    /// * `rva_name` - The name of the relation-valued attribute to flatten
-    ///
-    /// # Returns
-    ///
-    /// A new relation with the RVA replaced by its constituent attributes.
-    ///
-    /// # Errors
-    ///
-    /// - [`UngroupError::AttributeNotFound`] - The attribute doesn't exist
-    /// - [`UngroupError::NotRelationValued`] - The attribute is not an RVA
-    fn ungroup(&self, rva_name: &str) -> Result<Relation, UngroupError>;
-}
-
-impl GroupOps for Relation {
-    fn group(&self, attrs_to_group: &[&str], rva_name: &str) -> Result<Relation, GroupError> {
+    pub fn group(&self, attrs_to_group: &[&str], rva_name: &str) -> Result<Relation, GroupError> {
         if attrs_to_group.is_empty() {
             return Err(GroupError::NoAttributesSpecified);
         }
@@ -244,7 +215,25 @@ impl GroupOps for Relation {
         )
     }
 
-    fn ungroup(&self, rva_name: &str) -> Result<Relation, UngroupError> {
+    /// Ungroups a relation-valued attribute back into regular attributes.
+    ///
+    /// This is the inverse of [`group`](Self::group). It flattens a nested
+    /// relation by combining each inner tuple with its parent tuple's
+    /// non-RVA attributes.
+    ///
+    /// # Arguments
+    ///
+    /// * `rva_name` - The name of the relation-valued attribute to flatten
+    ///
+    /// # Returns
+    ///
+    /// A new relation with the RVA replaced by its constituent attributes.
+    ///
+    /// # Errors
+    ///
+    /// - [`UngroupError::AttributeNotFound`] - The attribute doesn't exist
+    /// - [`UngroupError::NotRelationValued`] - The attribute is not an RVA
+    pub fn ungroup(&self, rva_name: &str) -> Result<Relation, UngroupError> {
         // Check attribute exists
         if !self.relation_type().has_attribute(rva_name) {
             return Err(UngroupError::AttributeNotFound(rva_name.to_string()));

--- a/relvar-core/src/algebra/mod.rs
+++ b/relvar-core/src/algebra/mod.rs
@@ -35,10 +35,10 @@
 //!
 //! | Operator | Method | Description |
 //! |----------|--------|-------------|
-//! | Extend | [`extend()`](crate::algebra::extend::ExtendOps::extend) | Adds computed attributes |
-//! | Group | [`group()`](crate::algebra::group::GroupOps::group) | Creates relation-valued attributes |
-//! | Ungroup | [`ungroup()`](crate::algebra::group::GroupOps::ungroup) | Flattens relation-valued attributes |
-//! | Summarize | [`summarize()`](crate::algebra::summarize::SummarizeOps::summarize) | Aggregation with grouping |
+//! | Extend | [`extend()`](crate::values::Relation::extend) | Adds computed attributes |
+//! | Group | [`group()`](crate::values::Relation::group) | Creates relation-valued attributes |
+//! | Ungroup | [`ungroup()`](crate::values::Relation::ungroup) | Flattens relation-valued attributes |
+//! | Summarize | [`summarize()`](crate::values::Relation::summarize) | Aggregation with grouping |
 //!
 //! # Example
 //!
@@ -83,11 +83,9 @@ pub mod divide;
 
 /// Extend operator for adding computed attributes.
 pub mod extend;
-pub use extend::ExtendOps;
 
 /// Group and ungroup operators for relation-valued attributes.
 pub mod group;
-pub use group::GroupOps;
 
 /// Set intersection operator.
 pub mod intersect;
@@ -109,7 +107,7 @@ pub mod semijoin;
 
 /// Summarize operator for aggregation with grouping.
 pub mod summarize;
-pub use summarize::{Aggregation, AggregationFn, SummarizeOps};
+pub use summarize::{Aggregation, AggregationFn};
 
 /// Set union operator.
 pub mod union;

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -13,8 +13,8 @@
 //!
 //! ```
 //! use relvar_core::types::{TupleType, RelationType, ScalarType};
-//! use relvar_core::values::Relation;
-//! use relvar_core::algebra::summarize::{SummarizeOps, Aggregation};
+//! use relvar_core::values::{Relation, ScalarValue};
+//! use relvar_core::algebra::summarize::Aggregation;
 //! use relvar_core::tuple;
 //!
 //! let heading = TupleType::new()
@@ -348,11 +348,7 @@ impl Aggregation {
     }
 }
 
-/// Trait providing the summarize operation for relations.
-///
-/// This trait defines the `summarize` method which computes aggregate
-/// values over groups of tuples. It is implemented for [`Relation`].
-pub trait SummarizeOps {
+impl Relation {
     /// Summarizes the relation by computing aggregations over groups.
     ///
     /// This operator groups tuples by the specified attributes and computes
@@ -379,44 +375,7 @@ pub trait SummarizeOps {
     ///   conflicts with a grouping attribute
     /// - [`SummarizeError::AggregationError`] - An aggregation failed (e.g.,
     ///   MIN/MAX on empty set)
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use relvar_core::types::{TupleType, RelationType, ScalarType};
-    /// use relvar_core::values::Relation;
-    /// use relvar_core::algebra::summarize::{SummarizeOps, Aggregation};
-    /// use relvar_core::tuple;
-    ///
-    /// let heading = TupleType::new()
-    ///     .with_attribute("dept_id", ScalarType::Int)
-    ///     .with_attribute("salary", ScalarType::Int);
-    ///
-    /// let mut relation = Relation::new(RelationType::new(heading));
-    /// relation.insert(tuple! { dept_id: 10i64, salary: 50000i64 }).unwrap();
-    /// relation.insert(tuple! { dept_id: 10i64, salary: 60000i64 }).unwrap();
-    /// relation.insert(tuple! { dept_id: 20i64, salary: 70000i64 }).unwrap();
-    ///
-    /// // Compute aggregates per department
-    /// let result = relation.summarize(
-    ///     &["dept_id"],
-    ///     &[
-    ///         Aggregation::count("emp_count"),
-    ///         Aggregation::avg("avg_salary", "salary"),
-    ///     ],
-    /// ).unwrap();
-    ///
-    /// assert_eq!(result.cardinality(), 2);  // One row per department
-    /// ```
-    fn summarize(
-        &self,
-        group_by: &[&str],
-        aggregations: &[Aggregation],
-    ) -> Result<Relation, SummarizeError>;
-}
-
-impl SummarizeOps for Relation {
-    fn summarize(
+    pub fn summarize(
         &self,
         group_by: &[&str],
         aggregations: &[Aggregation],

--- a/relvar/src/lib.rs
+++ b/relvar/src/lib.rs
@@ -58,15 +58,13 @@
 //!
 //! ### Advanced Relational Algebra
 //!
-//! Advanced operators like `extend`, `summarize`, and `group` require importing
-//! their corresponding traits. These are re-exported in `relvar::algebra`.
+//! Advanced operators like `extend`, `summarize`, and `group` are available directly on the `Relation` type.
 //!
 //! ```
 //! use relvar::{Database, InMemoryEngine, tuple};
 //! use relvar::types::{TupleType, RelationType, ScalarType};
 //! use relvar::values::ScalarValue;
-//! // Import traits for advanced operators!
-//! use relvar::algebra::{ExtendOps, SummarizeOps, Aggregation};
+//! use relvar::algebra::Aggregation;
 //!
 //! let mut db = Database::new(InMemoryEngine::new());
 //! // ... setup relvar ...


### PR DESCRIPTION
This PR simplifies the codebase by removing the `ExtendOps`, `GroupOps`, and `SummarizeOps` traits, which were only implemented for `Relation`. These methods are now implemented directly on the `Relation` struct, reducing unnecessary abstraction and simplifying imports for users. This change aligns with the "Razor" persona's goal of enforcing KISS and YAGNI principles.

**Changes:**
- Deleted `ExtendOps`, `GroupOps`, `SummarizeOps` traits.
- Moved `extend`, `group`, `ungroup`, `summarize` methods to `impl Relation` blocks.
- Updated `relvar-core/src/algebra/mod.rs` exports.
- Updated benchmarks and examples to remove trait imports.
- Created `.jules/razor.md` to document the reduction.

**Verification:**
- `cargo test` passed.
- `cargo clippy` passed.

---
*PR created automatically by Jules for task [6824754606519760964](https://jules.google.com/task/6824754606519760964) started by @madmax983*