### PR TITLE
🎻 Bard: Document the missing `divide` operator

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -15,3 +15,7 @@
 ## The Case of the Undocumented Constraints
 **Confusion:** The critical database constraint methods (`set_key_constraints`, `set_foreign_key_constraints`, `set_type_constraints`) had no examples, leaving users to guess how to construct the complex constraint objects.
 **Clarification:** Added comprehensive `## Example` sections to each method, demonstrating the full workflow of creating relation types, instantiating constraint objects, and applying them to the database.
+
+## The Case of the Missing Operator
+**Confusion:** The `divide` operator was implemented and re-exported, but missing from the "Operators" summary table in the `relvar-core/src/algebra/mod.rs` documentation, making it undiscoverable via the module index.
+**Clarification:** Added `Division` to the "Join Operators" table in the module-level documentation with a link to the `divide()` method.

--- a/relvar-core/src/algebra/mod.rs
+++ b/relvar-core/src/algebra/mod.rs
@@ -30,6 +30,7 @@
 //! | Theta Join | [`theta_join()`](crate::values::Relation::theta_join) | Joins with arbitrary predicate |
 //! | Semijoin | [`semijoin()`](crate::values::Relation::semijoin) | Tuples from A matching B |
 //! | Semidifference | [`semidifference()`](crate::values::Relation::semidifference) | Tuples from A not matching B |
+//! | Division | [`divide()`](crate::values::Relation::divide) | Relational division (A ÷ B) |
 //!
 //! ## Extended Operators
 //!


### PR DESCRIPTION
📖 Chapter: The `relvar-core::algebra` module documentation.
🔦 Insight: The `divide` operator was implemented but missing from the summary table, making it hard to find.
🧪 Example: Verified via `cargo test` and code review.
🖼️ Preview: Added `| Division | [divide()](...) | Relational division (A ÷ B) |` to the operators table.

---
*PR created automatically by Jules for task [6911965215415403360](https://jules.google.com/task/6911965215415403360) started by @madmax983*