### PR TITLE
Prevent silent data loss on corrupted heap pages

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -9,3 +9,7 @@
 ## 2026-01-31 - Silent Error Swallowing in Collection Iterators
 **Learning:** `HeapFile::scan` was silently ignoring deserialization errors during iteration, effectively hiding data corruption from the caller.
 **Action:** Avoid `filter_map` or swallowing `Result::Err` in core storage loops. Always propagate serialization errors up to the caller to fail fast on corruption.
+
+## 2026-02-18 - Silent Corruption Healing in Storage Operations
+**Learning:** `HeapFile` modification methods (`insert`, `update`, `delete`) were silently swallowing corrupted slots (pointing outside page bounds) by replacing them with empty tuples during page rewrite. This effectively "healed" the page by deleting the inaccessible data without warning.
+**Action:** In storage modification paths, always treat structural corruption (e.g., out-of-bounds pointers) as a hard error. Never "skip" or "default" corrupted data during a rewrite, as this makes data loss permanent.

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -2986,10 +2986,17 @@ mod tests {
 
         // 3. Assert failure
         // Currently this fails (returns Ok) because of the bug
-        assert!(result.is_err(), "Insert should fail on corrupted page, but succeeded");
+        assert!(
+            result.is_err(),
+            "Insert should fail on corrupted page, but succeeded"
+        );
         match result {
             Err(HeapError::Serialization(msg)) => {
-                assert!(msg.contains("Corrupted slot") || msg.contains("outside page data"), "Unexpected error message: {}", msg);
+                assert!(
+                    msg.contains("Corrupted slot") || msg.contains("outside page data"),
+                    "Unexpected error message: {}",
+                    msg
+                );
             }
             _ => panic!("Expected Serialization error, got {:?}", result),
         }

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -258,7 +258,10 @@ impl HeapFile {
                 if end <= page.data().len() {
                     existing_tuples.push(page.data()[start..end].to_vec());
                 } else {
-                    existing_tuples.push(Vec::new());
+                    return Err(HeapError::Serialization(format!(
+                        "Corrupted slot on page {} points outside page data",
+                        page_id
+                    )));
                 }
             }
 
@@ -677,7 +680,10 @@ impl HeapFile {
                 if end <= page.data().len() {
                     existing_tuples.push(page.data()[start..end].to_vec());
                 } else {
-                    existing_tuples.push(Vec::new());
+                    return Err(HeapError::Serialization(format!(
+                        "Corrupted slot on page {} points outside page data",
+                        page_id
+                    )));
                 }
             }
 
@@ -884,7 +890,10 @@ impl HeapFile {
             if end <= page.data().len() {
                 existing_tuples.push(page.data()[start..end].to_vec());
             } else {
-                existing_tuples.push(Vec::new());
+                return Err(HeapError::Serialization(format!(
+                    "Corrupted slot on page {} points outside page data",
+                    old_tuple_id.page_id
+                )));
             }
         }
 
@@ -955,7 +964,10 @@ impl HeapFile {
                 if end <= page.data().len() {
                     existing_tuples.push(page.data()[start..end].to_vec());
                 } else {
-                    existing_tuples.push(Vec::new());
+                    return Err(HeapError::Serialization(format!(
+                        "Corrupted slot on page {} points outside page data",
+                        page_id
+                    )));
                 }
             }
 
@@ -1095,7 +1107,10 @@ impl HeapFile {
             if end <= page.data().len() {
                 existing_tuples.push(page.data()[start..end].to_vec());
             } else {
-                existing_tuples.push(Vec::new());
+                return Err(HeapError::Serialization(format!(
+                    "Corrupted slot on page {} points outside page data",
+                    tuple_id.page_id
+                )));
             }
         }
 
@@ -1176,7 +1191,10 @@ impl HeapFile {
                     if end <= page.data().len() {
                         existing_tuples.push(page.data()[start..end].to_vec());
                     } else {
-                        existing_tuples.push(Vec::new());
+                        return Err(HeapError::Serialization(format!(
+                            "Corrupted slot on page {} points outside page data",
+                            page_id
+                        )));
                     }
                 } else {
                     // None slot - push empty to maintain index alignment
@@ -2934,5 +2952,46 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_heap_insert_on_corrupted_page_fails() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+        let rel_type = create_test_relation_type();
+        let mut heap = HeapFile::create(path, rel_type).unwrap();
+
+        // 1. Create a corrupted page
+        // Slot points to offset > PAGE_SIZE
+        let slotted_page = SlottedPage {
+            slot_count: 1,
+            slots: vec![Some(SlotEntry {
+                offset: (PAGE_SIZE + 100) as u32, // Invalid offset
+                length: 10,
+            })],
+        };
+
+        // Serialize header
+        let slot_dir = bincode::serialize(&slotted_page).unwrap();
+        let mut page_data = vec![0u8; PAGE_SIZE - 8];
+        page_data[..slot_dir.len()].copy_from_slice(&slot_dir);
+
+        let page = Page::from_data(0, page_data).unwrap();
+        heap.page_file.write_page(&page).unwrap();
+
+        // 2. Try to insert a new tuple
+        // This should fail because it needs to read existing tuples to shift them
+        let tuple = tuple! { id: 1i64, name: "NewTuple" };
+        let result = heap.insert_tuple(&tuple);
+
+        // 3. Assert failure
+        // Currently this fails (returns Ok) because of the bug
+        assert!(result.is_err(), "Insert should fail on corrupted page, but succeeded");
+        match result {
+            Err(HeapError::Serialization(msg)) => {
+                assert!(msg.contains("Corrupted slot") || msg.contains("outside page data"), "Unexpected error message: {}", msg);
+            }
+            _ => panic!("Expected Serialization error, got {:?}", result),
+        }
     }
 }

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -3001,4 +3001,236 @@ mod tests {
             _ => panic!("Expected Serialization error, got {:?}", result),
         }
     }
+    #[test]
+    fn test_heap_insert_versioned_on_corrupted_page_fails() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+        let rel_type = create_test_relation_type();
+        let mut heap = HeapFile::create(path, rel_type).unwrap();
+
+        // 1. Create a corrupted versioned page
+        // Slot points to offset > PAGE_SIZE
+        let versioned_page = VersionedSlottedPage {
+            magic: VERSIONED_PAGE_MAGIC,
+            slot_count: 1,
+            slots: vec![Some(VersionedSlotEntry {
+                offset: (PAGE_SIZE + 100) as u32, // Invalid offset
+                length: 10,
+                xmin: test_txn(1),
+                xmax: None,
+                prev_version: None,
+            })],
+        };
+
+        // Serialize header
+        let slot_dir = bincode::serialize(&versioned_page).unwrap();
+        let mut page_data = vec![0u8; PAGE_SIZE - 8];
+
+        // Write format version
+        page_data[0] = PAGE_FORMAT_VERSION;
+
+        // Write slot directory length
+        let slot_dir_len = slot_dir.len() as u32;
+        page_data[1..5].copy_from_slice(&slot_dir_len.to_le_bytes());
+
+        // Copy slot directory after header
+        page_data[5..5 + slot_dir.len()].copy_from_slice(&slot_dir);
+
+        let page = Page::from_data(0, page_data).unwrap();
+        heap.page_file.write_page(&page).unwrap();
+
+        // 2. Try to insert a new versioned tuple
+        // This should fail when extracting existing tuples
+        let tuple = tuple! { id: 1i64, name: "NewTuple" };
+        let result = heap.insert_tuple_versioned(&tuple, test_txn(2));
+
+        // 3. Assert failure
+        assert!(
+            result.is_err(),
+            "Insert versioned should fail on corrupted page"
+        );
+        match result {
+            Err(HeapError::Serialization(msg)) => {
+                assert!(
+                    msg.contains("Corrupted slot") || msg.contains("outside page data"),
+                    "Unexpected error message: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected Serialization error, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_heap_update_on_corrupted_page_fails() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+        let rel_type = create_test_relation_type();
+        let mut heap = HeapFile::create(path, rel_type).unwrap();
+
+        // 1. Insert a tuple to get a valid TupleId
+        let tuple = tuple! { id: 1i64, name: "Original" };
+        let tuple_id = heap.insert_tuple_versioned(&tuple, test_txn(1)).unwrap();
+
+        // 2. Corrupt the page (slot pointing outside)
+        // We need to read the page, construct a corrupted version, and write it back
+        {
+            let page = heap.page_file.read_page(tuple_id.page_id).unwrap();
+
+            // Deserialize (valid)
+            let _versioned_page: VersionedSlottedPage =
+                deserialize_versioned_page_for_test(page.data()).unwrap();
+
+            // Create corrupted version
+            let corrupted_page = VersionedSlottedPage {
+                magic: VERSIONED_PAGE_MAGIC,
+                slot_count: 1,
+                slots: vec![Some(VersionedSlotEntry {
+                    offset: (PAGE_SIZE + 100) as u32, // Invalid offset
+                    length: 10,
+                    xmin: test_txn(1),
+                    xmax: None,
+                    prev_version: None,
+                })],
+            };
+
+            // Serialize and write back
+            let slot_dir = bincode::serialize(&corrupted_page).unwrap();
+            let mut page_data = vec![0u8; PAGE_SIZE - 8];
+            page_data[0] = PAGE_FORMAT_VERSION;
+            let slot_dir_len = slot_dir.len() as u32;
+            page_data[1..5].copy_from_slice(&slot_dir_len.to_le_bytes());
+            page_data[5..5 + slot_dir.len()].copy_from_slice(&slot_dir);
+
+            let new_page = Page::from_data(tuple_id.page_id, page_data).unwrap();
+            heap.page_file.write_page(&new_page).unwrap();
+        }
+
+        // 3. Try to update the tuple
+        // This should fail when extracting existing tuples in update_tuple_versioned
+        let updated = tuple! { id: 1i64, name: "Updated" };
+        let result = heap.update_tuple_versioned(tuple_id, &updated, test_txn(2));
+
+        // 4. Assert failure
+        assert!(result.is_err(), "Update should fail on corrupted page");
+        match result {
+            Err(HeapError::Serialization(msg)) => {
+                assert!(
+                    msg.contains("Corrupted slot") || msg.contains("outside page data"),
+                    "Unexpected error message: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected Serialization error, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_heap_delete_on_corrupted_page_fails() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+        let rel_type = create_test_relation_type();
+        let mut heap = HeapFile::create(path, rel_type).unwrap();
+
+        // 1. Insert a tuple to get a valid TupleId
+        let tuple = tuple! { id: 1i64, name: "Original" };
+        let tuple_id = heap.insert_tuple_versioned(&tuple, test_txn(1)).unwrap();
+
+        // 2. Corrupt the page (slot pointing outside)
+        {
+            let corrupted_page = VersionedSlottedPage {
+                magic: VERSIONED_PAGE_MAGIC,
+                slot_count: 1,
+                slots: vec![Some(VersionedSlotEntry {
+                    offset: (PAGE_SIZE + 100) as u32, // Invalid offset
+                    length: 10,
+                    xmin: test_txn(1),
+                    xmax: None,
+                    prev_version: None,
+                })],
+            };
+
+            let slot_dir = bincode::serialize(&corrupted_page).unwrap();
+            let mut page_data = vec![0u8; PAGE_SIZE - 8];
+            page_data[0] = PAGE_FORMAT_VERSION;
+            let slot_dir_len = slot_dir.len() as u32;
+            page_data[1..5].copy_from_slice(&slot_dir_len.to_le_bytes());
+            page_data[5..5 + slot_dir.len()].copy_from_slice(&slot_dir);
+
+            let new_page = Page::from_data(tuple_id.page_id, page_data).unwrap();
+            heap.page_file.write_page(&new_page).unwrap();
+        }
+
+        // 3. Try to delete the tuple
+        let result = heap.delete_tuple_versioned(tuple_id, test_txn(2));
+
+        // 4. Assert failure
+        assert!(result.is_err(), "Delete should fail on corrupted page");
+        match result {
+            Err(HeapError::Serialization(msg)) => {
+                assert!(
+                    msg.contains("Corrupted slot") || msg.contains("outside page data"),
+                    "Unexpected error message: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected Serialization error, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_heap_gc_on_corrupted_page_fails() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+        let rel_type = create_test_relation_type();
+        let mut heap = HeapFile::create(path, rel_type).unwrap();
+
+        // 1. Create a corrupted versioned page
+        // Slot points to offset > PAGE_SIZE
+        let versioned_page = VersionedSlottedPage {
+            magic: VERSIONED_PAGE_MAGIC,
+            slot_count: 1,
+            slots: vec![Some(VersionedSlotEntry {
+                offset: (PAGE_SIZE + 100) as u32, // Invalid offset
+                length: 10,
+                xmin: test_txn(1),
+                xmax: None,
+                prev_version: None,
+            })],
+        };
+
+        // Serialize header
+        let slot_dir = bincode::serialize(&versioned_page).unwrap();
+        let mut page_data = vec![0u8; PAGE_SIZE - 8];
+
+        // Write format version
+        page_data[0] = PAGE_FORMAT_VERSION;
+
+        // Write slot directory length
+        let slot_dir_len = slot_dir.len() as u32;
+        page_data[1..5].copy_from_slice(&slot_dir_len.to_le_bytes());
+
+        // Copy slot directory after header
+        page_data[5..5 + slot_dir.len()].copy_from_slice(&slot_dir);
+
+        let page = Page::from_data(0, page_data).unwrap();
+        heap.page_file.write_page(&page).unwrap();
+
+        // 2. Run GC
+        let result = heap
+            .gc_remove_dead_versions(crate::wal::Lsn::new(100), &std::collections::HashSet::new());
+
+        // 3. Assert failure
+        assert!(result.is_err(), "GC should fail on corrupted page");
+        match result {
+            Err(HeapError::Serialization(msg)) => {
+                assert!(
+                    msg.contains("Corrupted slot") || msg.contains("outside page data"),
+                    "Unexpected error message: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected Serialization error, got {:?}", result),
+        }
+    }
 }


### PR DESCRIPTION
🛡️ Sentry: Prevent silent data loss on corrupted heap pages

**Target:** `HeapFile` in `relvar-storage/src/storage/heap.rs`
**Risk:** High. Silent data loss/corruption masking.
**Strategy:**
1.  Identified that `try_insert_into_page` and related methods were pushing `Vec::new()` when encountering invalid slot pointers, instead of erroring.
2.  Added a reproduction test `test_heap_insert_on_corrupted_page_fails` that manually corrupts a page and asserts `insert_tuple` fails.
3.  Refactored `try_insert_into_page`, `try_insert_into_page_versioned`, `try_insert_new_version`, `update_tuple_versioned`, `delete_tuple_versioned`, and `gc_remove_dead_versions` to return `HeapError::Serialization` on slot corruption.
4.  Verified that the regression test now passes (fails with error as expected) and no regressions were introduced.

**Verification:**
`cargo test -p relvar-storage`

---
*PR created automatically by Jules for task [12587880447396991573](https://jules.google.com/task/12587880447396991573) started by @madmax983*