### PR TITLE
Simplify abstractions: Flatten ConstraintManager, Exporter, and SchemaVisualizer

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -2,3 +2,18 @@
 **Bloat:** Single-implementation extension traits (`ExtendOps`, `GroupOps`, `SummarizeOps`) for `Relation`.
 **Cut:** Moved methods directly to `Relation` struct.
 **Saved:** ~3 traits, removed unnecessary imports, simplified API.
+
+## [Reduction]
+**Bloat:** `ConstraintManager` struct in `relvar-core` (Delegate pattern/Layer Lasagna).
+**Cut:** Flattened fields and methods directly into `Database` struct.
+**Saved:** ~200 lines of delegation boilerplate, 1 struct, removed unnecessary `&mut Engine` passing.
+
+## [Reduction]
+**Bloat:** `Exporter` struct in `relvar::experimental` (Wrapper struct/Method Object).
+**Cut:** Replaced with free functions (`to_csv`, `to_json`, etc.).
+**Saved:** 1 struct, simplified API usage.
+
+## [Reduction]
+**Bloat:** `SchemaVisualizer` struct in `relvar::visualizer` (Wrapper struct).
+**Cut:** Replaced with free function (`to_dot`).
+**Saved:** 1 struct, simplified API usage.

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -95,368 +95,6 @@ pub struct VirtualRelvarDefinition<E: StorageEngine> {
     pub evaluator: fn(&mut Database<E>) -> Result<Relation, DatabaseError>,
 }
 
-/// Manages integrity constraints for the database.
-///
-/// This struct handles storage and validation of:
-/// - Key constraints (Primary and Candidate keys)
-/// - Foreign key constraints
-/// - Type constraints
-/// - CHECK constraints
-#[derive(Debug, Default)]
-pub struct ConstraintManager {
-    /// Key constraints (primary and candidate) per relation.
-    key_constraints: HashMap<String, KeyConstraints>,
-    /// Foreign key constraints per relation.
-    foreign_key_constraints: HashMap<String, ForeignKeyConstraints>,
-    /// Type constraints per relation, per attribute.
-    type_constraints: HashMap<String, HashMap<String, AttributeConstraints>>,
-    /// CHECK constraints (tuple-level predicates) per relation.
-    check_constraints: HashMap<String, CheckConstraints>,
-}
-
-impl ConstraintManager {
-    /// Create a new constraint manager.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Remove all constraints associated with a relation.
-    pub fn remove_constraints_for_relation(&mut self, relation_name: &str) {
-        self.key_constraints.remove(relation_name);
-        self.foreign_key_constraints.remove(relation_name);
-        self.type_constraints.remove(relation_name);
-        self.check_constraints.remove(relation_name);
-    }
-
-    /// Set key constraints for a relation.
-    pub fn set_key_constraints<E: StorageEngine>(
-        &mut self,
-        engine: &mut E,
-        relation_name: &str,
-        constraints: KeyConstraints,
-    ) -> Result<(), DatabaseError> {
-        if !engine.relation_exists(relation_name) {
-            return Err(DatabaseError::RelationNotFound(relation_name.to_string()));
-        }
-
-        // Validate constraints against existing data
-        let relation = engine.load_relation(relation_name)?;
-        self.validate_key_constraints_bulk(&relation, &constraints)?;
-
-        self.key_constraints
-            .insert(relation_name.to_string(), constraints);
-        Ok(())
-    }
-
-    /// Set foreign key constraints for a relation.
-    pub fn set_foreign_key_constraints<E: StorageEngine>(
-        &mut self,
-        engine: &mut E,
-        relation_name: &str,
-        constraints: ForeignKeyConstraints,
-    ) -> Result<(), DatabaseError> {
-        if !engine.relation_exists(relation_name) {
-            return Err(DatabaseError::RelationNotFound(relation_name.to_string()));
-        }
-
-        // Validate constraints against existing data
-        let relation = engine.load_relation(relation_name)?;
-
-        for fk in constraints.foreign_keys() {
-            let referenced_relation = engine.load_relation(fk.referenced_relation_name())?;
-            // Build a HashSet of referenced keys for efficient O(1) lookups.
-            let referenced_keys: std::collections::HashSet<Vec<_>> = referenced_relation
-                .tuples()
-                .map(|ref_tuple| {
-                    fk.referenced_attributes()
-                        .iter()
-                        .map(|attr| ref_tuple.get(attr).cloned().unwrap())
-                        .collect()
-                })
-                .collect();
-
-            for tuple in relation.tuples() {
-                let fk_values: Vec<_> = fk
-                    .foreign_key_attributes()
-                    .iter()
-                    .map(|attr| tuple.get(attr).cloned().unwrap())
-                    .collect();
-
-                if !referenced_keys.contains(&fk_values) {
-                    return Err(DatabaseError::ForeignKeyViolation(
-                        "Existing tuple violates foreign key".to_string(),
-                    ));
-                }
-            }
-        }
-
-        self.foreign_key_constraints
-            .insert(relation_name.to_string(), constraints);
-        Ok(())
-    }
-
-    /// Set type constraints for an attribute.
-    pub fn set_type_constraints<E: StorageEngine>(
-        &mut self,
-        engine: &mut E,
-        relation_name: &str,
-        attribute_name: &str,
-        constraints: AttributeConstraints,
-    ) -> Result<(), DatabaseError> {
-        let metadata = engine.get_relation_metadata(relation_name)?;
-
-        if !metadata.relation_type.has_attribute(attribute_name) {
-            return Err(DatabaseError::AttributeNotFound(
-                attribute_name.to_string(),
-                relation_name.to_string(),
-            ));
-        }
-
-        // Validate constraints against existing data
-        let relation = engine.load_relation(relation_name)?;
-
-        for tuple in relation.tuples() {
-            if let Some(value) = tuple.get(attribute_name)
-                && !constraints
-                    .is_satisfied_by(value)
-                    .map_err(|e| DatabaseError::TypeConstraintViolation(e.to_string()))?
-            {
-                return Err(DatabaseError::TypeConstraintViolation(
-                    "Existing value violates constraint".to_string(),
-                ));
-            }
-        }
-
-        self.type_constraints
-            .entry(relation_name.to_string())
-            .or_default()
-            .insert(attribute_name.to_string(), constraints);
-        Ok(())
-    }
-
-    /// Set CHECK constraints for a relation.
-    pub fn set_check_constraints<E: StorageEngine>(
-        &mut self,
-        engine: &mut E,
-        relation_name: &str,
-        constraints: CheckConstraints,
-    ) -> Result<(), DatabaseError> {
-        if !engine.relation_exists(relation_name) {
-            return Err(DatabaseError::RelationNotFound(relation_name.to_string()));
-        }
-
-        // Validate constraints against existing data
-        let relation = engine.load_relation(relation_name)?;
-
-        for tuple in relation.tuples() {
-            constraints.are_all_satisfied_by(tuple)?;
-        }
-
-        self.check_constraints
-            .insert(relation_name.to_string(), constraints);
-        Ok(())
-    }
-
-    /// Validate that a tuple matches the relation's heading.
-    pub fn validate_tuple_type<E: StorageEngine>(
-        &self,
-        engine: &E,
-        relation_name: &str,
-        tuple: &Tuple,
-    ) -> Result<(), DatabaseError> {
-        let metadata = engine.get_relation_metadata(relation_name)?;
-        if !tuple.conforms_to(metadata.relation_type.tuple_type()) {
-            Err(DatabaseError::TupleMismatch)
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Validate that a tuple satisfies all type constraints.
-    pub fn validate_type_constraints(
-        &self,
-        relation_name: &str,
-        tuple: &Tuple,
-    ) -> Result<(), DatabaseError> {
-        if let Some(attr_constraints) = self.type_constraints.get(relation_name) {
-            for (attr_name, constraints) in attr_constraints {
-                if let Some(value) = tuple.get(attr_name)
-                    && !constraints
-                        .is_satisfied_by(value)
-                        .map_err(|e| DatabaseError::TypeConstraintViolation(e.to_string()))?
-                {
-                    return Err(DatabaseError::TypeConstraintViolation(format!(
-                        "Attribute {} violates constraint",
-                        attr_name
-                    )));
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Validate that a tuple satisfies all CHECK constraints.
-    pub fn validate_check_constraints(
-        &self,
-        relation_name: &str,
-        tuple: &Tuple,
-    ) -> Result<(), DatabaseError> {
-        if let Some(check_constraints) = self.check_constraints.get(relation_name) {
-            check_constraints.are_all_satisfied_by(tuple)?;
-        }
-        Ok(())
-    }
-
-    /// Validate key constraints for a single tuple against the current relation state.
-    pub fn validate_key_constraints_single_tuple(
-        &self,
-        relation_name: &str,
-        tuple: &Tuple,
-        current_relation: &Relation,
-    ) -> Result<(), DatabaseError> {
-        if let Some(key_constraints) = self.key_constraints.get(relation_name) {
-            if let Some(pk) = key_constraints.primary_key()
-                && pk
-                    .would_violate(current_relation, tuple)
-                    .map_err(|e| DatabaseError::TransactionError(e.to_string()))?
-            {
-                return Err(DatabaseError::PrimaryKeyViolation);
-            }
-
-            for ck in key_constraints.candidate_keys() {
-                if ck
-                    .would_violate(current_relation, tuple)
-                    .map_err(|e| DatabaseError::TransactionError(e.to_string()))?
-                {
-                    return Err(DatabaseError::CandidateKeyViolation);
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Validate foreign key constraints for a single tuple.
-    ///
-    /// Checks that values in the tuple exist in the referenced relations.
-    pub fn validate_foreign_keys_single_tuple<E: StorageEngine>(
-        &self,
-        engine: &mut E,
-        relation_name: &str,
-        tuple: &Tuple,
-    ) -> Result<(), DatabaseError> {
-        let fks_to_check = self
-            .foreign_key_constraints
-            .get(relation_name)
-            .map(|c| c.foreign_keys().to_vec())
-            .unwrap_or_default();
-
-        for fk in fks_to_check {
-            let referenced_relation = engine.load_relation(fk.referenced_relation_name())?;
-
-            if fk
-                .would_violate_on_insert(tuple, &referenced_relation)
-                .map_err(|e| DatabaseError::ForeignKeyViolation(e.to_string()))?
-            {
-                return Err(DatabaseError::ForeignKeyViolation(
-                    "Foreign key constraint violated".to_string(),
-                ));
-            }
-        }
-        Ok(())
-    }
-
-    /// Validate key constraints against a full relation.
-    pub fn validate_key_constraints_bulk(
-        &self,
-        relation: &Relation,
-        constraints: &KeyConstraints,
-    ) -> Result<(), DatabaseError> {
-        if let Some(pk) = constraints.primary_key()
-            && !pk
-                .is_satisfied_by(relation)
-                .map_err(|e| DatabaseError::TransactionError(e.to_string()))?
-        {
-            return Err(DatabaseError::PrimaryKeyViolation);
-        }
-
-        for ck in constraints.candidate_keys() {
-            if !ck
-                .is_satisfied_by(relation)
-                .map_err(|e| DatabaseError::TransactionError(e.to_string()))?
-            {
-                return Err(DatabaseError::CandidateKeyViolation);
-            }
-        }
-        Ok(())
-    }
-
-    /// Get the key constraints for a relation.
-    pub fn get_key_constraints(&self, relation_name: &str) -> Option<&KeyConstraints> {
-        self.key_constraints.get(relation_name)
-    }
-
-    /// Get the foreign key constraints for a relation.
-    pub fn get_foreign_key_constraints(
-        &self,
-        relation_name: &str,
-    ) -> Option<&ForeignKeyConstraints> {
-        self.foreign_key_constraints.get(relation_name)
-    }
-
-    /// Validate that deleting tuples won't violate foreign keys in other relations.
-    pub fn validate_referencing_foreign_keys<E: StorageEngine>(
-        &self,
-        engine: &mut E,
-        relation_name: &str,
-        relation_after_delete: &Relation,
-    ) -> Result<(), DatabaseError> {
-        // Collect referencing foreign keys to avoid borrowing issues
-        let referencing_fks: Vec<(String, crate::constraints::ForeignKey)> = self
-            .foreign_key_constraints
-            .iter()
-            .flat_map(|(ref_name, fk_constraints)| {
-                fk_constraints
-                    .foreign_keys()
-                    .iter()
-                    .filter(|fk| fk.referenced_relation_name() == relation_name)
-                    .map(move |fk| (ref_name.clone(), fk.clone()))
-            })
-            .collect();
-
-        for (ref_name, fk) in referencing_fks {
-            let referencing_relation = engine.load_relation(&ref_name)?;
-
-            // Build a HashSet of keys from the relation after deletion for efficient lookups.
-            let existing_keys: std::collections::HashSet<Vec<_>> = relation_after_delete
-                .tuples()
-                .map(|t| {
-                    fk.referenced_attributes()
-                        .iter()
-                        .filter_map(|attr| t.get(attr).cloned())
-                        .collect()
-                })
-                .collect();
-
-            // Check if any referencing tuples would be orphaned by looking up in the HashSet.
-            for ref_tuple in referencing_relation.tuples() {
-                let ref_key_values: Vec<ScalarValue> = fk
-                    .foreign_key_attributes()
-                    .iter()
-                    .filter_map(|attr| ref_tuple.get(attr).cloned())
-                    .collect();
-
-                if !existing_keys.contains(&ref_key_values) {
-                    return Err(DatabaseError::ForeignKeyViolation(format!(
-                        "Deleting tuples would orphan referencing tuples in {}",
-                        ref_name
-                    )));
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
 /// A relational database instance.
 ///
 /// Generic over the storage engine `E`, which handles persistence.
@@ -486,8 +124,14 @@ impl ConstraintManager {
 pub struct Database<E: StorageEngine> {
     /// Storage engine for persisting relations.
     engine: E,
-    /// Manages all integrity constraints.
-    constraints: ConstraintManager,
+    /// Key constraints (primary and candidate) per relation.
+    key_constraints: HashMap<String, KeyConstraints>,
+    /// Foreign key constraints per relation.
+    foreign_key_constraints: HashMap<String, ForeignKeyConstraints>,
+    /// Type constraints per relation, per attribute.
+    type_constraints: HashMap<String, HashMap<String, AttributeConstraints>>,
+    /// CHECK constraints (tuple-level predicates) per relation.
+    check_constraints: HashMap<String, CheckConstraints>,
     /// Whether a transaction is currently in progress.
     in_transaction: bool,
     /// Transaction savepoint.
@@ -501,7 +145,10 @@ impl<E: StorageEngine> Database<E> {
     pub fn new(engine: E) -> Self {
         Self {
             engine,
-            constraints: ConstraintManager::new(),
+            key_constraints: HashMap::new(),
+            foreign_key_constraints: HashMap::new(),
+            type_constraints: HashMap::new(),
+            check_constraints: HashMap::new(),
             in_transaction: false,
             transaction_snapshot: None,
             virtual_relvars: HashMap::new(),
@@ -533,7 +180,7 @@ impl<E: StorageEngine> Database<E> {
     /// Returns `DatabaseError::RelationNotFound` if the relation doesn't exist.
     pub fn drop_relvar(&mut self, name: &str) -> Result<(), DatabaseError> {
         // Remove associated constraints
-        self.constraints.remove_constraints_for_relation(name);
+        self.remove_constraints_for_relation(name);
 
         // Drop from engine
         self.engine.drop_relation(name)?;
@@ -552,9 +199,17 @@ impl<E: StorageEngine> Database<E> {
         names
     }
 
+    /// Remove all constraints associated with a relation.
+    fn remove_constraints_for_relation(&mut self, relation_name: &str) {
+        self.key_constraints.remove(relation_name);
+        self.foreign_key_constraints.remove(relation_name);
+        self.type_constraints.remove(relation_name);
+        self.check_constraints.remove(relation_name);
+    }
+
     /// Get the key constraints for a relation.
     pub fn get_key_constraints(&self, relation_name: &str) -> Option<&KeyConstraints> {
-        self.constraints.get_key_constraints(relation_name)
+        self.key_constraints.get(relation_name)
     }
 
     /// Get the foreign key constraints for a relation.
@@ -562,7 +217,7 @@ impl<E: StorageEngine> Database<E> {
         &self,
         relation_name: &str,
     ) -> Option<&ForeignKeyConstraints> {
-        self.constraints.get_foreign_key_constraints(relation_name)
+        self.foreign_key_constraints.get(relation_name)
     }
 
     /// Set key constraints for a relation.
@@ -591,8 +246,17 @@ impl<E: StorageEngine> Database<E> {
         relation_name: &str,
         constraints: KeyConstraints,
     ) -> Result<(), DatabaseError> {
-        self.constraints
-            .set_key_constraints(&mut self.engine, relation_name, constraints)
+        if !self.engine.relation_exists(relation_name) {
+            return Err(DatabaseError::RelationNotFound(relation_name.to_string()));
+        }
+
+        // Validate constraints against existing data
+        let relation = self.engine.load_relation(relation_name)?;
+        self.validate_key_constraints_bulk(&relation, &constraints)?;
+
+        self.key_constraints
+            .insert(relation_name.to_string(), constraints);
+        Ok(())
     }
 
     /// Set foreign key constraints for a relation.
@@ -633,8 +297,44 @@ impl<E: StorageEngine> Database<E> {
         relation_name: &str,
         constraints: ForeignKeyConstraints,
     ) -> Result<(), DatabaseError> {
-        self.constraints
-            .set_foreign_key_constraints(&mut self.engine, relation_name, constraints)
+        if !self.engine.relation_exists(relation_name) {
+            return Err(DatabaseError::RelationNotFound(relation_name.to_string()));
+        }
+
+        // Validate constraints against existing data
+        let relation = self.engine.load_relation(relation_name)?;
+
+        for fk in constraints.foreign_keys() {
+            let referenced_relation = self.engine.load_relation(fk.referenced_relation_name())?;
+            // Build a HashSet of referenced keys for efficient O(1) lookups.
+            let referenced_keys: std::collections::HashSet<Vec<_>> = referenced_relation
+                .tuples()
+                .map(|ref_tuple| {
+                    fk.referenced_attributes()
+                        .iter()
+                        .map(|attr| ref_tuple.get(attr).cloned().unwrap())
+                        .collect()
+                })
+                .collect();
+
+            for tuple in relation.tuples() {
+                let fk_values: Vec<_> = fk
+                    .foreign_key_attributes()
+                    .iter()
+                    .map(|attr| tuple.get(attr).cloned().unwrap())
+                    .collect();
+
+                if !referenced_keys.contains(&fk_values) {
+                    return Err(DatabaseError::ForeignKeyViolation(
+                        "Existing tuple violates foreign key".to_string(),
+                    ));
+                }
+            }
+        }
+
+        self.foreign_key_constraints
+            .insert(relation_name.to_string(), constraints);
+        Ok(())
     }
 
     /// Set type constraints for an attribute.
@@ -665,12 +365,35 @@ impl<E: StorageEngine> Database<E> {
         attribute_name: &str,
         constraints: AttributeConstraints,
     ) -> Result<(), DatabaseError> {
-        self.constraints.set_type_constraints(
-            &mut self.engine,
-            relation_name,
-            attribute_name,
-            constraints,
-        )
+        let metadata = self.engine.get_relation_metadata(relation_name)?;
+
+        if !metadata.relation_type.has_attribute(attribute_name) {
+            return Err(DatabaseError::AttributeNotFound(
+                attribute_name.to_string(),
+                relation_name.to_string(),
+            ));
+        }
+
+        // Validate constraints against existing data
+        let relation = self.engine.load_relation(relation_name)?;
+
+        for tuple in relation.tuples() {
+            if let Some(value) = tuple.get(attribute_name)
+                && !constraints
+                    .is_satisfied_by(value)
+                    .map_err(|e| DatabaseError::TypeConstraintViolation(e.to_string()))?
+            {
+                return Err(DatabaseError::TypeConstraintViolation(
+                    "Existing value violates constraint".to_string(),
+                ));
+            }
+        }
+
+        self.type_constraints
+            .entry(relation_name.to_string())
+            .or_default()
+            .insert(attribute_name.to_string(), constraints);
+        Ok(())
     }
 
     /// Set CHECK constraints for a relation.
@@ -679,8 +402,20 @@ impl<E: StorageEngine> Database<E> {
         relation_name: &str,
         constraints: CheckConstraints,
     ) -> Result<(), DatabaseError> {
-        self.constraints
-            .set_check_constraints(&mut self.engine, relation_name, constraints)
+        if !self.engine.relation_exists(relation_name) {
+            return Err(DatabaseError::RelationNotFound(relation_name.to_string()));
+        }
+
+        // Validate constraints against existing data
+        let relation = self.engine.load_relation(relation_name)?;
+
+        for tuple in relation.tuples() {
+            constraints.are_all_satisfied_by(tuple)?;
+        }
+
+        self.check_constraints
+            .insert(relation_name.to_string(), constraints);
+        Ok(())
     }
 
     /// Insert a tuple into a relation.
@@ -695,25 +430,14 @@ impl<E: StorageEngine> Database<E> {
         self.ensure_not_virtual(relation_name)?;
 
         // Pure checks and Type validations
-        self.constraints
-            .validate_tuple_type(&self.engine, relation_name, &tuple)?;
-        self.constraints
-            .validate_type_constraints(relation_name, &tuple)?;
-        self.constraints
-            .validate_check_constraints(relation_name, &tuple)?;
+        self.validate_tuple_type(relation_name, &tuple)?;
+        self.validate_type_constraints(relation_name, &tuple)?;
+        self.validate_check_constraints(relation_name, &tuple)?;
 
         // Load current relation to check key constraints
         let current_relation = self.query(relation_name)?;
-        self.constraints.validate_key_constraints_single_tuple(
-            relation_name,
-            &tuple,
-            &current_relation,
-        )?;
-        self.constraints.validate_foreign_keys_single_tuple(
-            &mut self.engine,
-            relation_name,
-            &tuple,
-        )?;
+        self.validate_key_constraints_single_tuple(relation_name, &tuple, &current_relation)?;
+        self.validate_foreign_keys_single_tuple(relation_name, &tuple)?;
 
         // Insert into engine
         self.engine.insert_tuple(relation_name, tuple)?;
@@ -759,11 +483,7 @@ impl<E: StorageEngine> Database<E> {
             }
         }
 
-        self.constraints.validate_referencing_foreign_keys(
-            &mut self.engine,
-            relation_name,
-            &new_relation,
-        )?;
+        self.validate_referencing_foreign_keys(relation_name, &new_relation)?;
 
         // Store the new relation
         self.engine.store_relation(relation_name, &new_relation)?;
@@ -809,9 +529,8 @@ impl<E: StorageEngine> Database<E> {
         }
 
         // Validate key constraints on new relation
-        if let Some(key_constraints) = self.constraints.get_key_constraints(relation_name) {
-            self.constraints
-                .validate_key_constraints_bulk(&new_relation, key_constraints)?;
+        if let Some(key_constraints) = self.get_key_constraints(relation_name) {
+            self.validate_key_constraints_bulk(&new_relation, key_constraints)?;
         }
 
         // Store the new relation
@@ -926,6 +645,185 @@ impl<E: StorageEngine> Database<E> {
         } else {
             Ok(())
         }
+    }
+
+    /// Validate that a tuple matches the relation's heading.
+    fn validate_tuple_type(&self, relation_name: &str, tuple: &Tuple) -> Result<(), DatabaseError> {
+        let metadata = self.engine.get_relation_metadata(relation_name)?;
+        if !tuple.conforms_to(metadata.relation_type.tuple_type()) {
+            Err(DatabaseError::TupleMismatch)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Validate that a tuple satisfies all type constraints.
+    fn validate_type_constraints(
+        &self,
+        relation_name: &str,
+        tuple: &Tuple,
+    ) -> Result<(), DatabaseError> {
+        if let Some(attr_constraints) = self.type_constraints.get(relation_name) {
+            for (attr_name, constraints) in attr_constraints {
+                if let Some(value) = tuple.get(attr_name)
+                    && !constraints
+                        .is_satisfied_by(value)
+                        .map_err(|e| DatabaseError::TypeConstraintViolation(e.to_string()))?
+                {
+                    return Err(DatabaseError::TypeConstraintViolation(format!(
+                        "Attribute {} violates constraint",
+                        attr_name
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate that a tuple satisfies all CHECK constraints.
+    fn validate_check_constraints(
+        &self,
+        relation_name: &str,
+        tuple: &Tuple,
+    ) -> Result<(), DatabaseError> {
+        if let Some(check_constraints) = self.check_constraints.get(relation_name) {
+            check_constraints.are_all_satisfied_by(tuple)?;
+        }
+        Ok(())
+    }
+
+    /// Validate key constraints for a single tuple against the current relation state.
+    fn validate_key_constraints_single_tuple(
+        &self,
+        relation_name: &str,
+        tuple: &Tuple,
+        current_relation: &Relation,
+    ) -> Result<(), DatabaseError> {
+        if let Some(key_constraints) = self.key_constraints.get(relation_name) {
+            if let Some(pk) = key_constraints.primary_key()
+                && pk
+                    .would_violate(current_relation, tuple)
+                    .map_err(|e| DatabaseError::TransactionError(e.to_string()))?
+            {
+                return Err(DatabaseError::PrimaryKeyViolation);
+            }
+
+            for ck in key_constraints.candidate_keys() {
+                if ck
+                    .would_violate(current_relation, tuple)
+                    .map_err(|e| DatabaseError::TransactionError(e.to_string()))?
+                {
+                    return Err(DatabaseError::CandidateKeyViolation);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate foreign key constraints for a single tuple.
+    ///
+    /// Checks that values in the tuple exist in the referenced relations.
+    fn validate_foreign_keys_single_tuple(
+        &mut self,
+        relation_name: &str,
+        tuple: &Tuple,
+    ) -> Result<(), DatabaseError> {
+        let fks_to_check = self
+            .foreign_key_constraints
+            .get(relation_name)
+            .map(|c| c.foreign_keys().to_vec())
+            .unwrap_or_default();
+
+        for fk in fks_to_check {
+            let referenced_relation = self.engine.load_relation(fk.referenced_relation_name())?;
+
+            if fk
+                .would_violate_on_insert(tuple, &referenced_relation)
+                .map_err(|e| DatabaseError::ForeignKeyViolation(e.to_string()))?
+            {
+                return Err(DatabaseError::ForeignKeyViolation(
+                    "Foreign key constraint violated".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate key constraints against a full relation.
+    fn validate_key_constraints_bulk(
+        &self,
+        relation: &Relation,
+        constraints: &KeyConstraints,
+    ) -> Result<(), DatabaseError> {
+        if let Some(pk) = constraints.primary_key()
+            && !pk
+                .is_satisfied_by(relation)
+                .map_err(|e| DatabaseError::TransactionError(e.to_string()))?
+        {
+            return Err(DatabaseError::PrimaryKeyViolation);
+        }
+
+        for ck in constraints.candidate_keys() {
+            if !ck
+                .is_satisfied_by(relation)
+                .map_err(|e| DatabaseError::TransactionError(e.to_string()))?
+            {
+                return Err(DatabaseError::CandidateKeyViolation);
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate that deleting tuples won't violate foreign keys in other relations.
+    fn validate_referencing_foreign_keys(
+        &mut self,
+        relation_name: &str,
+        relation_after_delete: &Relation,
+    ) -> Result<(), DatabaseError> {
+        // Collect referencing foreign keys to avoid borrowing issues
+        let referencing_fks: Vec<(String, crate::constraints::ForeignKey)> = self
+            .foreign_key_constraints
+            .iter()
+            .flat_map(|(ref_name, fk_constraints)| {
+                fk_constraints
+                    .foreign_keys()
+                    .iter()
+                    .filter(|fk| fk.referenced_relation_name() == relation_name)
+                    .map(move |fk| (ref_name.clone(), fk.clone()))
+            })
+            .collect();
+
+        for (ref_name, fk) in referencing_fks {
+            let referencing_relation = self.engine.load_relation(&ref_name)?;
+
+            // Build a HashSet of keys from the relation after deletion for efficient lookups.
+            let existing_keys: std::collections::HashSet<Vec<_>> = relation_after_delete
+                .tuples()
+                .map(|t| {
+                    fk.referenced_attributes()
+                        .iter()
+                        .filter_map(|attr| t.get(attr).cloned())
+                        .collect()
+                })
+                .collect();
+
+            // Check if any referencing tuples would be orphaned by looking up in the HashSet.
+            for ref_tuple in referencing_relation.tuples() {
+                let ref_key_values: Vec<ScalarValue> = fk
+                    .foreign_key_attributes()
+                    .iter()
+                    .filter_map(|attr| ref_tuple.get(attr).cloned())
+                    .collect();
+
+                if !existing_keys.contains(&ref_key_values) {
+                    return Err(DatabaseError::ForeignKeyViolation(format!(
+                        "Deleting tuples would orphan referencing tuples in {}",
+                        ref_name
+                    )));
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/relvar/src/experimental/exporter.rs
+++ b/relvar/src/experimental/exporter.rs
@@ -40,188 +40,175 @@ impl<'a> Ord for SortableTuple<'a> {
     }
 }
 
-/// Exporter provides methods to export a Relation to various formats.
-pub struct Exporter<'a> {
-    relation: &'a Relation,
-}
+/// Exports the relation to a CSV string.
+///
+/// # Arguments
+///
+/// * `relation` - The relation to export.
+/// * `delimiter` - The character to use as a delimiter (e.g., ',' or '\t').
+pub fn to_csv(relation: &Relation, delimiter: char) -> Result<String, ExporterError> {
+    let headers: Vec<&String> = relation
+        .relation_type()
+        .heading()
+        .attribute_names()
+        .collect();
+    let mut output = String::new();
 
-impl<'a> Exporter<'a> {
-    /// Creates a new Exporter for the given relation.
-    pub fn new(relation: &'a Relation) -> Self {
-        Self { relation }
+    // Write headers
+    for (i, header) in headers.iter().enumerate() {
+        if i > 0 {
+            output.push(delimiter);
+        }
+        output.push_str(header);
     }
+    output.push('\n');
 
-    /// Exports the relation to a CSV string.
-    ///
-    /// # Arguments
-    ///
-    /// * `delimiter` - The character to use as a delimiter (e.g., ',' or '\t').
-    pub fn to_csv(&self, delimiter: char) -> Result<String, ExporterError> {
-        let headers: Vec<&String> = self
-            .relation
-            .relation_type()
-            .heading()
-            .attribute_names()
-            .collect();
-        let mut output = String::new();
+    // Sort tuples
+    let mut tuples: Vec<SortableTuple> = relation.tuples().map(SortableTuple).collect();
+    tuples.sort();
 
-        // Write headers
+    // Write rows
+    for tuple in tuples {
         for (i, header) in headers.iter().enumerate() {
             if i > 0 {
                 output.push(delimiter);
             }
-            output.push_str(header);
+            if let Some(val) = tuple.0.get(header) {
+                output.push_str(&format_scalar_csv(val));
+            }
         }
         output.push('\n');
-
-        // Sort tuples
-        let mut tuples: Vec<SortableTuple> = self.relation.tuples().map(SortableTuple).collect();
-        tuples.sort();
-
-        // Write rows
-        for tuple in tuples {
-            for (i, header) in headers.iter().enumerate() {
-                if i > 0 {
-                    output.push(delimiter);
-                }
-                if let Some(val) = tuple.0.get(header) {
-                    output.push_str(&self.format_scalar_csv(val));
-                }
-            }
-            output.push('\n');
-        }
-
-        Ok(output)
     }
 
-    /// Exports the relation to a JSON string.
-    ///
-    /// The result is a JSON array of objects.
-    pub fn to_json(&self) -> Result<String, ExporterError> {
-        // Sort tuples first
-        let mut tuples: Vec<SortableTuple> = self.relation.tuples().map(SortableTuple).collect();
-        tuples.sort();
+    Ok(output)
+}
 
-        // Convert to a Vec of &Tuple for serialization
-        // Note: Tuple implements Serialize, so we can serialize the list directly
-        let sorted_tuples: Vec<&Tuple> = tuples.into_iter().map(|t| t.0).collect();
+/// Exports the relation to a JSON string.
+///
+/// The result is a JSON array of objects.
+pub fn to_json(relation: &Relation) -> Result<String, ExporterError> {
+    // Sort tuples first
+    let mut tuples: Vec<SortableTuple> = relation.tuples().map(SortableTuple).collect();
+    tuples.sort();
 
-        serde_json::to_string_pretty(&sorted_tuples).map_err(ExporterError::JsonError)
+    // Convert to a Vec of &Tuple for serialization
+    // Note: Tuple implements Serialize, so we can serialize the list directly
+    let sorted_tuples: Vec<&Tuple> = tuples.into_iter().map(|t| t.0).collect();
+
+    serde_json::to_string_pretty(&sorted_tuples).map_err(ExporterError::JsonError)
+}
+
+/// Exports the relation to an ASCII table.
+pub fn to_ascii_table(relation: &Relation) -> String {
+    let headers: Vec<&String> = relation
+        .relation_type()
+        .heading()
+        .attribute_names()
+        .collect();
+    if headers.is_empty() {
+        return String::from("(empty relation)");
     }
 
-    /// Exports the relation to an ASCII table.
-    pub fn to_ascii_table(&self) -> String {
-        let headers: Vec<&String> = self
-            .relation
-            .relation_type()
-            .heading()
-            .attribute_names()
-            .collect();
-        if headers.is_empty() {
-            return String::from("(empty relation)");
-        }
+    // Sort tuples
+    let mut tuples: Vec<SortableTuple> = relation.tuples().map(SortableTuple).collect();
+    tuples.sort();
 
-        // Sort tuples
-        let mut tuples: Vec<SortableTuple> = self.relation.tuples().map(SortableTuple).collect();
-        tuples.sort();
+    // Calculate column widths
+    let mut widths: Vec<usize> = headers.iter().map(|h| h.len()).collect();
 
-        // Calculate column widths
-        let mut widths: Vec<usize> = headers.iter().map(|h| h.len()).collect();
+    // Pass 1: Measure data widths
+    let rows: Vec<Vec<String>> = tuples
+        .iter()
+        .map(|t| {
+            headers
+                .iter()
+                .enumerate()
+                .map(|(i, h)| {
+                    let s = if let Some(val) = t.0.get(h) {
+                        format_scalar_table(val)
+                    } else {
+                        String::new()
+                    };
+                    if s.len() > widths[i] {
+                        widths[i] = s.len();
+                    }
+                    s
+                })
+                .collect()
+        })
+        .collect();
 
-        // Pass 1: Measure data widths
-        let rows: Vec<Vec<String>> = tuples
-            .iter()
-            .map(|t| {
-                headers
-                    .iter()
-                    .enumerate()
-                    .map(|(i, h)| {
-                        let s = if let Some(val) = t.0.get(h) {
-                            self.format_scalar_table(val)
-                        } else {
-                            String::new()
-                        };
-                        if s.len() > widths[i] {
-                            widths[i] = s.len();
-                        }
-                        s
-                    })
-                    .collect()
-            })
-            .collect();
+    let mut output = String::new();
 
-        let mut output = String::new();
-
-        // Helper to draw separator line
-        let draw_sep = |out: &mut String, widths: &[usize]| {
+    // Helper to draw separator line
+    let draw_sep = |out: &mut String, widths: &[usize]| {
+        out.push('+');
+        for w in widths {
+            out.push('-');
+            out.push_str(&"-".repeat(*w));
+            out.push('-');
             out.push('+');
-            for w in widths {
-                out.push('-');
-                out.push_str(&"-".repeat(*w));
-                out.push('-');
-                out.push('+');
-            }
-            out.push('\n');
-        };
+        }
+        out.push('\n');
+    };
 
-        // Top border
-        draw_sep(&mut output, &widths);
+    // Top border
+    draw_sep(&mut output, &widths);
 
-        // Header row
+    // Header row
+    output.push('|');
+    for (i, header) in headers.iter().enumerate() {
+        output.push(' ');
+        output.push_str(header);
+        output.push_str(&" ".repeat(widths[i] - header.len()));
+        output.push(' ');
         output.push('|');
-        for (i, header) in headers.iter().enumerate() {
+    }
+    output.push('\n');
+
+    // Header separator
+    draw_sep(&mut output, &widths);
+
+    // Data rows
+    for row in rows {
+        output.push('|');
+        for (i, cell) in row.iter().enumerate() {
             output.push(' ');
-            output.push_str(header);
-            output.push_str(&" ".repeat(widths[i] - header.len()));
+            output.push_str(cell);
+            output.push_str(&" ".repeat(widths[i] - cell.len()));
             output.push(' ');
             output.push('|');
         }
         output.push('\n');
-
-        // Header separator
-        draw_sep(&mut output, &widths);
-
-        // Data rows
-        for row in rows {
-            output.push('|');
-            for (i, cell) in row.iter().enumerate() {
-                output.push(' ');
-                output.push_str(cell);
-                output.push_str(&" ".repeat(widths[i] - cell.len()));
-                output.push(' ');
-                output.push('|');
-            }
-            output.push('\n');
-        }
-
-        // Bottom border
-        draw_sep(&mut output, &widths);
-
-        output
     }
 
-    fn format_scalar_csv(&self, val: &ScalarValue) -> String {
-        match val {
-            ScalarValue::Int(v) => v.to_string(),
-            ScalarValue::Float(v) => v.to_string(),
-            ScalarValue::String(v) => format!("\"{}\"", v.replace("\"", "\"\"")), // CSV escaping
-            ScalarValue::Bool(v) => v.to_string(),
-            ScalarValue::Bytes(v) => format!("{:?}", v),
-            ScalarValue::Relation(_) => "<Relation>".to_string(),
-            ScalarValue::UserDefined { .. } => "<UserDefined>".to_string(),
-        }
-    }
+    // Bottom border
+    draw_sep(&mut output, &widths);
 
-    fn format_scalar_table(&self, val: &ScalarValue) -> String {
-        match val {
-            ScalarValue::Int(v) => v.to_string(),
-            ScalarValue::Float(v) => format!("{:.2}", v), // Format floats nicer for table
-            ScalarValue::String(v) => v.clone(),
-            ScalarValue::Bool(v) => v.to_string(),
-            ScalarValue::Bytes(_) => "<Bytes>".to_string(),
-            ScalarValue::Relation(_) => "<Relation>".to_string(),
-            ScalarValue::UserDefined { .. } => "<UserDefined>".to_string(),
-        }
+    output
+}
+
+fn format_scalar_csv(val: &ScalarValue) -> String {
+    match val {
+        ScalarValue::Int(v) => v.to_string(),
+        ScalarValue::Float(v) => v.to_string(),
+        ScalarValue::String(v) => format!("\"{}\"", v.replace("\"", "\"\"")), // CSV escaping
+        ScalarValue::Bool(v) => v.to_string(),
+        ScalarValue::Bytes(v) => format!("{:?}", v),
+        ScalarValue::Relation(_) => "<Relation>".to_string(),
+        ScalarValue::UserDefined { .. } => "<UserDefined>".to_string(),
+    }
+}
+
+fn format_scalar_table(val: &ScalarValue) -> String {
+    match val {
+        ScalarValue::Int(v) => v.to_string(),
+        ScalarValue::Float(v) => format!("{:.2}", v), // Format floats nicer for table
+        ScalarValue::String(v) => v.clone(),
+        ScalarValue::Bool(v) => v.to_string(),
+        ScalarValue::Bytes(_) => "<Bytes>".to_string(),
+        ScalarValue::Relation(_) => "<Relation>".to_string(),
+        ScalarValue::UserDefined { .. } => "<UserDefined>".to_string(),
     }
 }
 
@@ -252,9 +239,8 @@ mod tests {
     #[test]
     fn test_to_csv() {
         let relation = create_test_relation();
-        let exporter = Exporter::new(&relation);
 
-        let csv = exporter.to_csv(',').unwrap();
+        let csv = to_csv(&relation, ',').unwrap();
 
         // Expected output (sorted by tuple content, so id 1 then id 2)
         // Headers sorted alphabetically: active, id, name
@@ -267,47 +253,20 @@ mod tests {
     #[test]
     fn test_to_json() {
         let relation = create_test_relation();
-        let exporter = Exporter::new(&relation);
 
-        let json = exporter.to_json().unwrap();
+        let json = to_json(&relation).unwrap();
         let val: serde_json::Value = serde_json::from_str(&json).unwrap();
 
         assert!(val.is_array());
         let arr = val.as_array().unwrap();
-        assert_eq!(arr.len(), 2);
-
-        // Since we sort, first element should be Alice (active=true comes after active=false? No, true > false usually?
-        // Wait, bool implementation of Ord: false (0) < true (1).
-        // Tuple comparison compares values in key order.
-        // Keys: active, id, name.
-        // Tuple 1: true, 1, Alice
-        // Tuple 2: false, 2, Bob
-        // Compare "active": true vs false. false < true.
-        // So Tuple 2 (Bob) comes BEFORE Tuple 1 (Alice).
-
-        let first = &arr[0];
-        let vals = first.get("values").unwrap(); // Tuple serialization structure: { tuple_type: ..., values: { ... } }
-        // Actually, let's see how Tuple serializes.
-        // It derives Serialize. It has fields tuple_type and values.
-        // So it serializes as an object.
-
-        let _name_val = vals.get("name").unwrap().as_object().unwrap();
-        // ScalarValue serializes as Enum. String variant: {"String": "Bob"}
-        // Let's check ScalarValue serialization test in scalar.rs
-        // ScalarValue::String("test") -> "test"?
-        // No, it's an enum. By default serde serializes enum as {"Variant": content}.
-        // But let's verify.
-
-        // For now, let's just check that it parses and has correct length.
         assert_eq!(arr.len(), 2);
     }
 
     #[test]
     fn test_to_ascii_table() {
         let relation = create_test_relation();
-        let exporter = Exporter::new(&relation);
 
-        let table = exporter.to_ascii_table();
+        let table = to_ascii_table(&relation);
 
         // Bob comes first (false < true)
         // active | id | name

--- a/relvar/src/visualizer.rs
+++ b/relvar/src/visualizer.rs
@@ -1,98 +1,86 @@
 //! Schema visualizer for Relvar databases.
 //!
-//! This module provides the [`SchemaVisualizer`] struct, which can generate
+//! This module provides the [`to_dot`] function, which can generate
 //! Graphviz DOT code representing the database schema, including relations
 //! and foreign key constraints.
 
 use relvar_core::database::Database;
 use relvar_core::storage_engine::StorageEngine;
 
-/// A tool for visualizing the database schema.
-pub struct SchemaVisualizer<'a, E: StorageEngine> {
-    db: &'a mut Database<E>,
-}
+/// Generate a Graphviz DOT string representation of the schema.
+pub fn to_dot<E: StorageEngine>(db: &mut Database<E>) -> String {
+    let mut dot = String::from("digraph DatabaseSchema {\n");
+    dot.push_str("    rankdir=LR;\n");
+    dot.push_str("    node [shape=none, fontname=\"Helvetica\", fontsize=10];\n");
+    dot.push_str("    edge [fontname=\"Helvetica\", fontsize=8];\n\n");
 
-impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
-    /// Create a new schema visualizer for the given database.
-    pub fn new(db: &'a mut Database<E>) -> Self {
-        Self { db }
-    }
+    let relvars = db.list_relvars();
 
-    /// Generate a Graphviz DOT string representation of the schema.
-    pub fn to_dot(&mut self) -> String {
-        let mut dot = String::from("digraph DatabaseSchema {\n");
-        dot.push_str("    rankdir=LR;\n");
-        dot.push_str("    node [shape=none, fontname=\"Helvetica\", fontsize=10];\n");
-        dot.push_str("    edge [fontname=\"Helvetica\", fontsize=8];\n\n");
+    // 1. Generate nodes (Tables)
+    for name in &relvars {
+        // Note: We use query() to get the relation structure.
+        // Since this is for visualization, we ignore potential errors (e.g. temporary locks)
+        // or if the relation somehow disappears.
+        if let Ok(relation) = db.query(name) {
+            let relation_type = relation.relation_type();
+            let tuple_type = relation_type.tuple_type();
 
-        let relvars = self.db.list_relvars();
-
-        // 1. Generate nodes (Tables)
-        for name in &relvars {
-            // Note: We use query() to get the relation structure.
-            // Since this is for visualization, we ignore potential errors (e.g. temporary locks)
-            // or if the relation somehow disappears.
-            if let Ok(relation) = self.db.query(name) {
-                let relation_type = relation.relation_type();
-                let tuple_type = relation_type.tuple_type();
-
-                // Determine primary key attributes
-                let pk_attrs = if let Some(key_constraints) = self.db.get_key_constraints(name) {
-                    if let Some(pk) = key_constraints.primary_key() {
-                        pk.attributes().to_vec()
-                    } else {
-                        Vec::new()
-                    }
+            // Determine primary key attributes
+            let pk_attrs = if let Some(key_constraints) = db.get_key_constraints(name) {
+                if let Some(pk) = key_constraints.primary_key() {
+                    pk.attributes().to_vec()
                 } else {
                     Vec::new()
+                }
+            } else {
+                Vec::new()
+            };
+
+            dot.push_str(&format!("    {} [label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\" cellpadding=\"4\">\n", name));
+            dot.push_str(&format!(
+                "        <tr><td bgcolor=\"lightgrey\" colspan=\"2\"><b>{}</b></td></tr>\n",
+                name
+            ));
+
+            // Sort attributes for consistent output
+            let mut attributes: Vec<_> = tuple_type.attributes().iter().collect();
+            attributes.sort_by(|a, b| a.0.cmp(b.0));
+
+            for (attr_name, scalar_type) in attributes {
+                let is_pk = pk_attrs.contains(attr_name);
+                let display_name = if is_pk {
+                    format!("<u>{}</u>", attr_name)
+                } else {
+                    attr_name.to_string()
                 };
 
-                dot.push_str(&format!("    {} [label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\" cellpadding=\"4\">\n", name));
                 dot.push_str(&format!(
-                    "        <tr><td bgcolor=\"lightgrey\" colspan=\"2\"><b>{}</b></td></tr>\n",
-                    name
+                    "        <tr><td align=\"left\">{}</td><td align=\"left\">{:?}</td></tr>\n",
+                    display_name, scalar_type
                 ));
-
-                // Sort attributes for consistent output
-                let mut attributes: Vec<_> = tuple_type.attributes().iter().collect();
-                attributes.sort_by(|a, b| a.0.cmp(b.0));
-
-                for (attr_name, scalar_type) in attributes {
-                    let is_pk = pk_attrs.contains(attr_name);
-                    let display_name = if is_pk {
-                        format!("<u>{}</u>", attr_name)
-                    } else {
-                        attr_name.to_string()
-                    };
-
-                    dot.push_str(&format!(
-                        "        <tr><td align=\"left\">{}</td><td align=\"left\">{:?}</td></tr>\n",
-                        display_name, scalar_type
-                    ));
-                }
-                dot.push_str("    </table>>];\n\n");
             }
+            dot.push_str("    </table>>];\n\n");
         }
-
-        // 2. Generate edges (Foreign Keys)
-        for name in &relvars {
-            if let Some(fk_constraints) = self.db.get_foreign_key_constraints(name) {
-                for fk in fk_constraints.foreign_keys() {
-                    let ref_table = fk.referenced_relation_name();
-                    let cols = fk.foreign_key_attributes().join(", ");
-                    // We label the edge with the columns involved
-
-                    dot.push_str(&format!(
-                        "    {} -> {} [label=\"({})\"];\n",
-                        name, ref_table, cols
-                    ));
-                }
-            }
-        }
-
-        dot.push_str("}\n");
-        dot
     }
+
+    // 2. Generate edges (Foreign Keys)
+    for name in &relvars {
+        if let Some(fk_constraints) = db.get_foreign_key_constraints(name) {
+            for fk in fk_constraints.foreign_keys() {
+                let ref_table = fk.referenced_relation_name();
+                let cols = fk.foreign_key_attributes().join(", ");
+                // We label the edge with the columns involved
+
+                dot.push_str(&format!(
+                    "    {} -> {} [label=\"({})\"];\n",
+                    name, ref_table, cols
+                ));
+            }
+        }
+    }
+
+    dot.push_str("}\n");
+    dot
 }
 
 #[cfg(test)]
@@ -137,8 +125,7 @@ mod tests {
             .unwrap();
 
         // Visualize
-        let mut visualizer = SchemaVisualizer::new(&mut db);
-        let dot = visualizer.to_dot();
+        let dot = to_dot(&mut db);
 
         println!("{}", dot);
 


### PR DESCRIPTION
This PR simplifies the codebase by applying "Razor" principles:

1.  **Merged `ConstraintManager` into `Database`**: The `ConstraintManager` struct in `relvar-core` was a "Delegate" pattern that added unnecessary indirection. It has been flattened directly into the `Database` struct. This reduced ~200 lines of boilerplate delegation and simplified method signatures.
2.  **Replaced `Exporter` struct with free functions**: The `Exporter` struct in `relvar::experimental` was a "Wrapper Struct" / "Method Object" that held no state other than a reference. It has been replaced with standalone functions `to_csv`, `to_json`, etc.
3.  **Replaced `SchemaVisualizer` struct with free function**: The `SchemaVisualizer` struct in `relvar::visualizer` was similarly unnecessary. It has been replaced with a standalone `to_dot` function.

All tests passed. Clippy is happy. The code is now simpler and flatter.


---
*PR created automatically by Jules for task [14455026420972166227](https://jules.google.com/task/14455026420972166227) started by @madmax983*