### PR TITLE
🔒 Warden: Harden PageFile against integer overflows

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -13,3 +13,12 @@
 
 **Defense:**
 Added a pre-check `check_tuple_size_limit` using `bincode::serialized_size` on a dummy page to verify if the tuple can theoretically fit in an empty page. If it exceeds capacity, it returns `HeapError::TupleTooLarge` immediately.
+
+## 2024-05-25 - PageFile Integer Overflow
+**Threat:**
+1. `PageFile::read_page`, `write_page`, and `write_page_buffered` calculated file offsets as `page_id * PAGE_SIZE`, allowing integer overflow if `page_id` is large enough. This could lead to reading/writing from the wrong location or wrapping around to the beginning of the file.
+2. `PageFile::read_page` checked `data_len + 8 > buffer.len()` without overflow protection. A crafted page with `data_len` near `usize::MAX` could bypass this check, leading to buffer overflow or panic when slicing `buffer[8..8+data_len]`.
+
+**Defense:**
+1. Replaced `*` with `checked_mul` for offset calculations, returning `PageError::PageTooLarge` on overflow.
+2. Replaced `+` with `checked_add` for `data_len` check, returning `PageError::Serialization` on overflow.

--- a/relvar-storage/src/storage/page.rs
+++ b/relvar-storage/src/storage/page.rs
@@ -278,7 +278,9 @@ impl PageFile {
     /// Returns [`PageError::Io`] if the read fails.
     pub fn read_page(&mut self, page_id: PageId) -> Result<Page, PageError> {
         // Seek to the page offset
-        let offset = page_id * PAGE_SIZE as u64;
+        let offset = page_id
+            .checked_mul(PAGE_SIZE as u64)
+            .ok_or(PageError::PageTooLarge)?;
         self.file.seek(SeekFrom::Start(offset))?;
 
         // Read the page data
@@ -304,7 +306,11 @@ impl PageFile {
         let data_len = u64::from_le_bytes(buffer[0..8].try_into().unwrap()) as usize;
 
         // Check if declared length fits in the buffer
-        if data_len + 8 > buffer.len() {
+        let required_len = data_len
+            .checked_add(8)
+            .ok_or_else(|| PageError::Serialization("Page length overflow".to_string()))?;
+
+        if required_len > buffer.len() {
             return Err(PageError::Serialization(format!(
                 "Corrupted page: length prefix says {}, but only {} bytes available",
                 data_len,
@@ -330,7 +336,10 @@ impl PageFile {
     /// Returns [`PageError::Io`] if the write fails.
     pub fn write_page(&mut self, page: &Page) -> Result<(), PageError> {
         // Seek to the page offset
-        let offset = page.id() * PAGE_SIZE as u64;
+        let offset = page
+            .id()
+            .checked_mul(PAGE_SIZE as u64)
+            .ok_or(PageError::PageTooLarge)?;
         self.file.seek(SeekFrom::Start(offset))?;
 
         // Prepare buffer with length prefix and data
@@ -381,7 +390,10 @@ impl PageFile {
     /// Returns [`PageError::Io`] if the write fails.
     pub fn write_page_buffered(&mut self, page: &Page) -> Result<(), PageError> {
         // Seek to the page offset
-        let offset = page.id() * PAGE_SIZE as u64;
+        let offset = page
+            .id()
+            .checked_mul(PAGE_SIZE as u64)
+            .ok_or(PageError::PageTooLarge)?;
         self.file.seek(SeekFrom::Start(offset))?;
 
         // Prepare buffer with length prefix and data
@@ -686,6 +698,42 @@ mod tests {
                 assert!(msg.contains("Page too short"));
             }
             _ => panic!("Expected Serialization error"),
+        }
+    }
+
+    #[test]
+    fn test_page_file_data_len_overflow() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+
+        let mut page_file = PageFile::create(path).unwrap();
+
+        // manually write a page with data_len = u64::MAX
+        // This simulates a corrupted/malicious page
+        let bad_len: u64 = u64::MAX;
+        let mut buffer = Vec::new();
+        buffer.extend_from_slice(&bad_len.to_le_bytes());
+        buffer.resize(PAGE_SIZE, 0); // Fill rest with zeros
+
+        // Write manually to file
+        {
+            let mut file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+            use std::io::Write;
+            file.write_all(&buffer).unwrap();
+        }
+
+        // Now read it back - should error cleanly without panic
+        let result = page_file.read_page(0);
+        assert!(result.is_err());
+        match result {
+            Err(PageError::Serialization(msg)) => {
+                assert!(
+                    msg.contains("Page length overflow"),
+                    "Unexpected message: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected Serialization error with overflow message, got {:?}", result),
         }
     }
 }

--- a/relvar-storage/src/storage/page.rs
+++ b/relvar-storage/src/storage/page.rs
@@ -733,7 +733,10 @@ mod tests {
                     msg
                 );
             }
-            _ => panic!("Expected Serialization error with overflow message, got {:?}", result),
+            _ => panic!(
+                "Expected Serialization error with overflow message, got {:?}",
+                result
+            ),
         }
     }
 }


### PR DESCRIPTION
This PR hardens the `PageFile` implementation in `relvar-storage` against integer overflow vulnerabilities. 

1.  **Offset Calculation**: Changed `page_id * PAGE_SIZE` to `page_id.checked_mul(PAGE_SIZE)` to prevent wrapping around or accessing incorrect file offsets if `page_id` is huge. Returns `PageError::PageTooLarge` on overflow.
2.  **Data Length Check**: Changed `data_len + 8` to `data_len.checked_add(8)` to prevent bypass of the buffer size check if a corrupted page declares a length near `usize::MAX`. Returns `PageError::Serialization` on overflow.
3.  **Regression Test**: Added `test_page_file_data_len_overflow` to verify that `read_page` safely handles corrupted pages with invalid lengths.
4.  **Documentation**: Updated `.jules/warden.md` with the findings and defenses.

---
*PR created automatically by Jules for task [17793000674239618923](https://jules.google.com/task/17793000674239618923) started by @madmax983*