### PR TITLE
🎻 Bard: Enhance Relation and Scalar Type documentation

### DIFF
--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -190,6 +190,24 @@ impl ScalarType {
     /// TTM: The selector takes a value of the representation type and produces
     /// a value of this user-defined type.
     ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar_core::types::ScalarType;
+    /// use relvar_core::values::ScalarValue;
+    ///
+    /// // Define a user-defined type backed by Int
+    /// let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
+    ///
+    /// // Successful selection
+    /// let widget = widget_id_type.selector(ScalarValue::Int(42)).unwrap();
+    /// assert_eq!(widget.scalar_type().name(), "WidgetId");
+    ///
+    /// // Type mismatch error
+    /// let result = widget_id_type.selector(ScalarValue::String("not an int".into()));
+    /// assert!(result.is_err());
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns `Err` if the provided value's type doesn't match the expected

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -107,6 +107,24 @@ pub enum RelationError {
 /// let alice = tuple! { id: 1i64, name: "Alice" };
 /// assert!(relation.contains(&alice));
 /// ```
+///
+/// # Relational Algebra
+///
+/// The `Relation` struct implements the full suite of relational algebra operators
+/// as inherent methods. These methods transform relations into new relations
+/// according to TTM principles.
+///
+/// Available operators include:
+///
+/// - **Selection**: [`restrict`](Relation::restrict)
+/// - **Projection**: [`project`](Relation::project)
+/// - **Renaming**: [`rename`](Relation::rename)
+/// - **Set Operations**: [`union`](Relation::union), [`intersect`](Relation::intersect), [`difference`](Relation::difference)
+/// - **Joins**: [`join`](Relation::join) (natural), [`theta_join`](Relation::theta_join), [`semijoin`](Relation::semijoin)
+/// - **Advanced**: [`extend`](Relation::extend), [`summarize`](Relation::summarize), [`group`](Relation::group), [`ungroup`](Relation::ungroup)
+/// - **Division**: [`divide`](Relation::divide)
+///
+/// See the [`algebra`](crate::algebra) module for detailed documentation on each operator.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Relation {
     /// The relation type (heading) that defines the structure.

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -157,6 +157,24 @@ impl ScalarValue {
     /// TTM: The observer function extracts the representation from a
     /// user-defined type value.
     ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar_core::types::ScalarType;
+    /// use relvar_core::values::ScalarValue;
+    ///
+    /// let widget_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
+    /// let widget_val = widget_type.selector(ScalarValue::Int(42)).unwrap();
+    ///
+    /// // Observer extracts the Int(42)
+    /// let representation = widget_val.observer().unwrap();
+    /// assert_eq!(representation, ScalarValue::Int(42));
+    ///
+    /// // Built-in types have no observer
+    /// let raw_int = ScalarValue::Int(42);
+    /// assert!(raw_int.observer().is_err());
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns `Err` if called on a built-in type (only user-defined types


### PR DESCRIPTION
📖 Chapter: The `Relation` struct and User-Defined Types (`ScalarType`/`ScalarValue`).
🔦 Insight: Users could not easily find the relational algebra operators available on `Relation` because they are implemented as inherent methods in separate modules. Also, the critical POSSREP methods (`selector`/`observer`) for user-defined types lacked examples.
🧪 Example: Added 3 executable doctests and a cross-reference section.


---
*PR created automatically by Jules for task [13569684015551960042](https://jules.google.com/task/13569684015551960042) started by @madmax983*