### PR TITLE
🗺️ Atlas: Extract ConstraintManager to dedicated module

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -1,0 +1,3 @@
+## 2025-05-24 - Extract ConstraintManager
+**Tangle:** `Database` struct in `relvar-core/src/database.rs` was becoming a "God Struct", mixing database orchestration with constraint enforcement logic. The file was nearly 2000 lines long.
+**Blueprint:** Extracted `ConstraintManager` and its error types into a dedicated `relvar-core/src/constraints/manager.rs` module. This improves cohesion by grouping constraint logic with constraint definitions and reduces coupling in the main database module.

--- a/relvar-core/src/constraints/manager.rs
+++ b/relvar-core/src/constraints/manager.rs
@@ -253,9 +253,9 @@ impl ConstraintManager {
         if let Some(attr_constraints) = self.type_constraints.get(relation_name) {
             for (attr_name, constraints) in attr_constraints {
                 if let Some(value) = tuple.get(attr_name)
-                    && !constraints
-                        .is_satisfied_by(value)
-                        .map_err(|e| ConstraintManagerError::TypeConstraintViolation(e.to_string()))?
+                    && !constraints.is_satisfied_by(value).map_err(|e| {
+                        ConstraintManagerError::TypeConstraintViolation(e.to_string())
+                    })?
                 {
                     return Err(ConstraintManagerError::TypeConstraintViolation(format!(
                         "Attribute {} violates constraint",

--- a/relvar-core/src/constraints/manager.rs
+++ b/relvar-core/src/constraints/manager.rs
@@ -1,0 +1,422 @@
+//! Manages constraints for relations.
+//!
+//! This module provides the [`ConstraintManager`], which is responsible for
+//! storing and validating all database constraints (keys, foreign keys, types, CHECKs).
+
+use crate::constraints::{
+    AttributeConstraints, CheckConstraintError, CheckConstraints, ForeignKeyConstraints,
+    KeyConstraints,
+};
+use crate::storage_engine::{StorageEngine, StorageError};
+use crate::values::relation::RelationError;
+use crate::values::{Relation, ScalarValue, Tuple};
+use std::collections::HashMap;
+use thiserror::Error;
+
+/// Errors that can occur during constraint management operations.
+#[derive(Debug, Error)]
+pub enum ConstraintManagerError {
+    /// A storage error occurred.
+    #[error("Storage error: {0}")]
+    Storage(#[from] StorageError),
+
+    /// An error occurred with a relation value.
+    #[error("Relation error: {0}")]
+    Relation(#[from] RelationError),
+
+    /// The specified relation does not exist.
+    #[error("Relation {0} not found")]
+    RelationNotFound(String),
+
+    /// The attribute does not exist.
+    #[error("Attribute {0} not found in relation {1}")]
+    AttributeNotFound(String, String),
+
+    /// The tuple's type does not match the relation's heading.
+    #[error("Tuple type does not match relation type")]
+    TupleMismatch,
+
+    /// Primary key constraint violation.
+    #[error("Primary key violation")]
+    PrimaryKeyViolation,
+
+    /// Candidate key constraint violation.
+    #[error("Candidate key violation")]
+    CandidateKeyViolation,
+
+    /// Foreign key constraint violation.
+    #[error("Foreign key violation: {0}")]
+    ForeignKeyViolation(String),
+
+    /// Type constraint violation.
+    #[error("Type constraint violation: {0}")]
+    TypeConstraintViolation(String),
+
+    /// CHECK constraint violation.
+    #[error("CHECK constraint violation: {0}")]
+    CheckConstraintViolation(#[from] CheckConstraintError),
+
+    /// Transaction error.
+    #[error("Transaction error: {0}")]
+    TransactionError(String),
+}
+
+/// Manages integrity constraints for the database.
+///
+/// This struct handles storage and validation of:
+/// - Key constraints (Primary and Candidate keys)
+/// - Foreign key constraints
+/// - Type constraints
+/// - CHECK constraints
+#[derive(Debug, Default)]
+pub struct ConstraintManager {
+    /// Key constraints (primary and candidate) per relation.
+    key_constraints: HashMap<String, KeyConstraints>,
+    /// Foreign key constraints per relation.
+    foreign_key_constraints: HashMap<String, ForeignKeyConstraints>,
+    /// Type constraints per relation, per attribute.
+    type_constraints: HashMap<String, HashMap<String, AttributeConstraints>>,
+    /// CHECK constraints (tuple-level predicates) per relation.
+    check_constraints: HashMap<String, CheckConstraints>,
+}
+
+impl ConstraintManager {
+    /// Create a new constraint manager.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Remove all constraints associated with a relation.
+    pub fn remove_constraints_for_relation(&mut self, relation_name: &str) {
+        self.key_constraints.remove(relation_name);
+        self.foreign_key_constraints.remove(relation_name);
+        self.type_constraints.remove(relation_name);
+        self.check_constraints.remove(relation_name);
+    }
+
+    /// Set key constraints for a relation.
+    pub fn set_key_constraints<E: StorageEngine>(
+        &mut self,
+        engine: &mut E,
+        relation_name: &str,
+        constraints: KeyConstraints,
+    ) -> Result<(), ConstraintManagerError> {
+        if !engine.relation_exists(relation_name) {
+            return Err(ConstraintManagerError::RelationNotFound(
+                relation_name.to_string(),
+            ));
+        }
+
+        // Validate constraints against existing data
+        let relation = engine.load_relation(relation_name)?;
+        self.validate_key_constraints_bulk(&relation, &constraints)?;
+
+        self.key_constraints
+            .insert(relation_name.to_string(), constraints);
+        Ok(())
+    }
+
+    /// Set foreign key constraints for a relation.
+    pub fn set_foreign_key_constraints<E: StorageEngine>(
+        &mut self,
+        engine: &mut E,
+        relation_name: &str,
+        constraints: ForeignKeyConstraints,
+    ) -> Result<(), ConstraintManagerError> {
+        if !engine.relation_exists(relation_name) {
+            return Err(ConstraintManagerError::RelationNotFound(
+                relation_name.to_string(),
+            ));
+        }
+
+        // Validate constraints against existing data
+        let relation = engine.load_relation(relation_name)?;
+
+        for fk in constraints.foreign_keys() {
+            let referenced_relation = engine.load_relation(fk.referenced_relation_name())?;
+            // Build a HashSet of referenced keys for efficient O(1) lookups.
+            let referenced_keys: std::collections::HashSet<Vec<_>> = referenced_relation
+                .tuples()
+                .map(|ref_tuple| {
+                    fk.referenced_attributes()
+                        .iter()
+                        .map(|attr| ref_tuple.get(attr).cloned().unwrap())
+                        .collect()
+                })
+                .collect();
+
+            for tuple in relation.tuples() {
+                let fk_values: Vec<_> = fk
+                    .foreign_key_attributes()
+                    .iter()
+                    .map(|attr| tuple.get(attr).cloned().unwrap())
+                    .collect();
+
+                if !referenced_keys.contains(&fk_values) {
+                    return Err(ConstraintManagerError::ForeignKeyViolation(
+                        "Existing tuple violates foreign key".to_string(),
+                    ));
+                }
+            }
+        }
+
+        self.foreign_key_constraints
+            .insert(relation_name.to_string(), constraints);
+        Ok(())
+    }
+
+    /// Set type constraints for an attribute.
+    pub fn set_type_constraints<E: StorageEngine>(
+        &mut self,
+        engine: &mut E,
+        relation_name: &str,
+        attribute_name: &str,
+        constraints: AttributeConstraints,
+    ) -> Result<(), ConstraintManagerError> {
+        let metadata = engine.get_relation_metadata(relation_name)?;
+
+        if !metadata.relation_type.has_attribute(attribute_name) {
+            return Err(ConstraintManagerError::AttributeNotFound(
+                attribute_name.to_string(),
+                relation_name.to_string(),
+            ));
+        }
+
+        // Validate constraints against existing data
+        let relation = engine.load_relation(relation_name)?;
+
+        for tuple in relation.tuples() {
+            if let Some(value) = tuple.get(attribute_name)
+                && !constraints
+                    .is_satisfied_by(value)
+                    .map_err(|e| ConstraintManagerError::TypeConstraintViolation(e.to_string()))?
+            {
+                return Err(ConstraintManagerError::TypeConstraintViolation(
+                    "Existing value violates constraint".to_string(),
+                ));
+            }
+        }
+
+        self.type_constraints
+            .entry(relation_name.to_string())
+            .or_default()
+            .insert(attribute_name.to_string(), constraints);
+        Ok(())
+    }
+
+    /// Set CHECK constraints for a relation.
+    pub fn set_check_constraints<E: StorageEngine>(
+        &mut self,
+        engine: &mut E,
+        relation_name: &str,
+        constraints: CheckConstraints,
+    ) -> Result<(), ConstraintManagerError> {
+        if !engine.relation_exists(relation_name) {
+            return Err(ConstraintManagerError::RelationNotFound(
+                relation_name.to_string(),
+            ));
+        }
+
+        // Validate constraints against existing data
+        let relation = engine.load_relation(relation_name)?;
+
+        for tuple in relation.tuples() {
+            constraints.are_all_satisfied_by(tuple)?;
+        }
+
+        self.check_constraints
+            .insert(relation_name.to_string(), constraints);
+        Ok(())
+    }
+
+    /// Validate that a tuple matches the relation's heading.
+    pub fn validate_tuple_type<E: StorageEngine>(
+        &self,
+        engine: &E,
+        relation_name: &str,
+        tuple: &Tuple,
+    ) -> Result<(), ConstraintManagerError> {
+        let metadata = engine.get_relation_metadata(relation_name)?;
+        if !tuple.conforms_to(metadata.relation_type.tuple_type()) {
+            Err(ConstraintManagerError::TupleMismatch)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Validate that a tuple satisfies all type constraints.
+    pub fn validate_type_constraints(
+        &self,
+        relation_name: &str,
+        tuple: &Tuple,
+    ) -> Result<(), ConstraintManagerError> {
+        if let Some(attr_constraints) = self.type_constraints.get(relation_name) {
+            for (attr_name, constraints) in attr_constraints {
+                if let Some(value) = tuple.get(attr_name)
+                    && !constraints
+                        .is_satisfied_by(value)
+                        .map_err(|e| ConstraintManagerError::TypeConstraintViolation(e.to_string()))?
+                {
+                    return Err(ConstraintManagerError::TypeConstraintViolation(format!(
+                        "Attribute {} violates constraint",
+                        attr_name
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate that a tuple satisfies all CHECK constraints.
+    pub fn validate_check_constraints(
+        &self,
+        relation_name: &str,
+        tuple: &Tuple,
+    ) -> Result<(), ConstraintManagerError> {
+        if let Some(check_constraints) = self.check_constraints.get(relation_name) {
+            check_constraints.are_all_satisfied_by(tuple)?;
+        }
+        Ok(())
+    }
+
+    /// Validate key constraints for a single tuple against the current relation state.
+    pub fn validate_key_constraints_single_tuple(
+        &self,
+        relation_name: &str,
+        tuple: &Tuple,
+        current_relation: &Relation,
+    ) -> Result<(), ConstraintManagerError> {
+        if let Some(key_constraints) = self.key_constraints.get(relation_name) {
+            if let Some(pk) = key_constraints.primary_key()
+                && pk
+                    .would_violate(current_relation, tuple)
+                    .map_err(|e| ConstraintManagerError::TransactionError(e.to_string()))?
+            {
+                return Err(ConstraintManagerError::PrimaryKeyViolation);
+            }
+
+            for ck in key_constraints.candidate_keys() {
+                if ck
+                    .would_violate(current_relation, tuple)
+                    .map_err(|e| ConstraintManagerError::TransactionError(e.to_string()))?
+                {
+                    return Err(ConstraintManagerError::CandidateKeyViolation);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate foreign key constraints for a single tuple.
+    ///
+    /// Checks that values in the tuple exist in the referenced relations.
+    pub fn validate_foreign_keys_single_tuple<E: StorageEngine>(
+        &self,
+        engine: &mut E,
+        relation_name: &str,
+        tuple: &Tuple,
+    ) -> Result<(), ConstraintManagerError> {
+        let fks_to_check = self
+            .foreign_key_constraints
+            .get(relation_name)
+            .map(|c| c.foreign_keys())
+            .unwrap_or_default();
+
+        for fk in fks_to_check {
+            let referenced_relation = engine.load_relation(fk.referenced_relation_name())?;
+
+            if fk
+                .would_violate_on_insert(tuple, &referenced_relation)
+                .map_err(|e| ConstraintManagerError::ForeignKeyViolation(e.to_string()))?
+            {
+                return Err(ConstraintManagerError::ForeignKeyViolation(
+                    "Foreign key constraint violated".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate key constraints against a full relation.
+    pub fn validate_key_constraints_bulk(
+        &self,
+        relation: &Relation,
+        constraints: &KeyConstraints,
+    ) -> Result<(), ConstraintManagerError> {
+        if let Some(pk) = constraints.primary_key()
+            && !pk
+                .is_satisfied_by(relation)
+                .map_err(|e| ConstraintManagerError::TransactionError(e.to_string()))?
+        {
+            return Err(ConstraintManagerError::PrimaryKeyViolation);
+        }
+
+        for ck in constraints.candidate_keys() {
+            if !ck
+                .is_satisfied_by(relation)
+                .map_err(|e| ConstraintManagerError::TransactionError(e.to_string()))?
+            {
+                return Err(ConstraintManagerError::CandidateKeyViolation);
+            }
+        }
+        Ok(())
+    }
+
+    /// Get the key constraints for a relation.
+    pub fn get_key_constraints(&self, relation_name: &str) -> Option<&KeyConstraints> {
+        self.key_constraints.get(relation_name)
+    }
+
+    /// Get the foreign key constraints for a relation.
+    pub fn get_foreign_key_constraints(
+        &self,
+        relation_name: &str,
+    ) -> Option<&ForeignKeyConstraints> {
+        self.foreign_key_constraints.get(relation_name)
+    }
+
+    /// Validate that deleting tuples won't violate foreign keys in other relations.
+    pub fn validate_referencing_foreign_keys<E: StorageEngine>(
+        &self,
+        engine: &mut E,
+        relation_name: &str,
+        relation_after_delete: &Relation,
+    ) -> Result<(), ConstraintManagerError> {
+        // Iterate over constraints without collecting/cloning
+        for (ref_name, fk_constraints) in &self.foreign_key_constraints {
+            for fk in fk_constraints.foreign_keys() {
+                if fk.referenced_relation_name() == relation_name {
+                    let referencing_relation = engine.load_relation(ref_name)?;
+
+                    // Build a HashSet of keys from the relation after deletion for efficient lookups.
+                    let existing_keys: std::collections::HashSet<Vec<_>> = relation_after_delete
+                        .tuples()
+                        .map(|t| {
+                            fk.referenced_attributes()
+                                .iter()
+                                .filter_map(|attr| t.get(attr).cloned())
+                                .collect()
+                        })
+                        .collect();
+
+                    // Check if any referencing tuples would be orphaned by looking up in the HashSet.
+                    for ref_tuple in referencing_relation.tuples() {
+                        let ref_key_values: Vec<ScalarValue> = fk
+                            .foreign_key_attributes()
+                            .iter()
+                            .filter_map(|attr| ref_tuple.get(attr).cloned())
+                            .collect();
+
+                        if !existing_keys.contains(&ref_key_values) {
+                            return Err(ConstraintManagerError::ForeignKeyViolation(format!(
+                                "Deleting tuples would orphan referencing tuples in {}",
+                                ref_name
+                            )));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/relvar-core/src/constraints/mod.rs
+++ b/relvar-core/src/constraints/mod.rs
@@ -38,10 +38,12 @@ pub mod check;
 pub mod expression;
 pub mod foreign_key;
 pub mod key;
+pub mod manager;
 pub mod type_constraint;
 
 pub use check::{CheckConstraint, CheckConstraintError, CheckConstraints, CheckPredicate};
 pub use expression::{CmpOp, ConstraintExpression, ExpressionError, ValueOrRef};
 pub use foreign_key::{ForeignKey, ForeignKeyConstraints, ForeignKeyError};
 pub use key::{CandidateKey, KeyConstraintError, KeyConstraints, PrimaryKey};
+pub use manager::{ConstraintManager, ConstraintManagerError};
 pub use type_constraint::{AttributeConstraints, TypeConstraint, TypeConstraintError};

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -4,13 +4,13 @@
 //! for all database operations.
 
 use crate::constraints::{
-    AttributeConstraints, CheckConstraintError, CheckConstraints, ForeignKeyConstraints,
-    KeyConstraints,
+    AttributeConstraints, CheckConstraintError, CheckConstraints, ConstraintManager,
+    ConstraintManagerError, ForeignKeyConstraints, KeyConstraints,
 };
 use crate::storage_engine::{StorageEngine, StorageError};
 use crate::types::RelationType;
 use crate::values::relation::RelationError;
-use crate::values::{Relation, ScalarValue, Tuple};
+use crate::values::{Relation, Tuple};
 
 use std::collections::HashMap;
 use thiserror::Error;
@@ -79,6 +79,32 @@ pub enum DatabaseError {
     AttributeNotFound(String, String),
 }
 
+impl From<ConstraintManagerError> for DatabaseError {
+    fn from(err: ConstraintManagerError) -> Self {
+        match err {
+            ConstraintManagerError::Storage(e) => DatabaseError::Storage(e),
+            ConstraintManagerError::Relation(e) => DatabaseError::Relation(e),
+            ConstraintManagerError::RelationNotFound(n) => DatabaseError::RelationNotFound(n),
+            ConstraintManagerError::AttributeNotFound(a, r) => {
+                DatabaseError::AttributeNotFound(a, r)
+            }
+            ConstraintManagerError::TupleMismatch => DatabaseError::TupleMismatch,
+            ConstraintManagerError::PrimaryKeyViolation => DatabaseError::PrimaryKeyViolation,
+            ConstraintManagerError::CandidateKeyViolation => DatabaseError::CandidateKeyViolation,
+            ConstraintManagerError::ForeignKeyViolation(s) => {
+                DatabaseError::ForeignKeyViolation(s)
+            }
+            ConstraintManagerError::TypeConstraintViolation(s) => {
+                DatabaseError::TypeConstraintViolation(s)
+            }
+            ConstraintManagerError::CheckConstraintViolation(e) => {
+                DatabaseError::CheckConstraintViolation(e)
+            }
+            ConstraintManagerError::TransactionError(s) => DatabaseError::TransactionError(s),
+        }
+    }
+}
+
 /// Definition of a virtual relvar (view).
 ///
 /// TTM: RM Prescription 10 - Virtual relvars (views) re-evaluate their
@@ -93,360 +119,6 @@ pub struct VirtualRelvarDefinition<E: StorageEngine> {
     ///
     /// Takes a mutable reference to the database and returns the computed relation.
     pub evaluator: fn(&mut Database<E>) -> Result<Relation, DatabaseError>,
-}
-
-/// Manages integrity constraints for the database.
-///
-/// This struct handles storage and validation of:
-/// - Key constraints (Primary and Candidate keys)
-/// - Foreign key constraints
-/// - Type constraints
-/// - CHECK constraints
-#[derive(Debug, Default)]
-pub struct ConstraintManager {
-    /// Key constraints (primary and candidate) per relation.
-    key_constraints: HashMap<String, KeyConstraints>,
-    /// Foreign key constraints per relation.
-    foreign_key_constraints: HashMap<String, ForeignKeyConstraints>,
-    /// Type constraints per relation, per attribute.
-    type_constraints: HashMap<String, HashMap<String, AttributeConstraints>>,
-    /// CHECK constraints (tuple-level predicates) per relation.
-    check_constraints: HashMap<String, CheckConstraints>,
-}
-
-impl ConstraintManager {
-    /// Create a new constraint manager.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Remove all constraints associated with a relation.
-    pub fn remove_constraints_for_relation(&mut self, relation_name: &str) {
-        self.key_constraints.remove(relation_name);
-        self.foreign_key_constraints.remove(relation_name);
-        self.type_constraints.remove(relation_name);
-        self.check_constraints.remove(relation_name);
-    }
-
-    /// Set key constraints for a relation.
-    pub fn set_key_constraints<E: StorageEngine>(
-        &mut self,
-        engine: &mut E,
-        relation_name: &str,
-        constraints: KeyConstraints,
-    ) -> Result<(), DatabaseError> {
-        if !engine.relation_exists(relation_name) {
-            return Err(DatabaseError::RelationNotFound(relation_name.to_string()));
-        }
-
-        // Validate constraints against existing data
-        let relation = engine.load_relation(relation_name)?;
-        self.validate_key_constraints_bulk(&relation, &constraints)?;
-
-        self.key_constraints
-            .insert(relation_name.to_string(), constraints);
-        Ok(())
-    }
-
-    /// Set foreign key constraints for a relation.
-    pub fn set_foreign_key_constraints<E: StorageEngine>(
-        &mut self,
-        engine: &mut E,
-        relation_name: &str,
-        constraints: ForeignKeyConstraints,
-    ) -> Result<(), DatabaseError> {
-        if !engine.relation_exists(relation_name) {
-            return Err(DatabaseError::RelationNotFound(relation_name.to_string()));
-        }
-
-        // Validate constraints against existing data
-        let relation = engine.load_relation(relation_name)?;
-
-        for fk in constraints.foreign_keys() {
-            let referenced_relation = engine.load_relation(fk.referenced_relation_name())?;
-            // Build a HashSet of referenced keys for efficient O(1) lookups.
-            let referenced_keys: std::collections::HashSet<Vec<_>> = referenced_relation
-                .tuples()
-                .map(|ref_tuple| {
-                    fk.referenced_attributes()
-                        .iter()
-                        .map(|attr| ref_tuple.get(attr).cloned().unwrap())
-                        .collect()
-                })
-                .collect();
-
-            for tuple in relation.tuples() {
-                let fk_values: Vec<_> = fk
-                    .foreign_key_attributes()
-                    .iter()
-                    .map(|attr| tuple.get(attr).cloned().unwrap())
-                    .collect();
-
-                if !referenced_keys.contains(&fk_values) {
-                    return Err(DatabaseError::ForeignKeyViolation(
-                        "Existing tuple violates foreign key".to_string(),
-                    ));
-                }
-            }
-        }
-
-        self.foreign_key_constraints
-            .insert(relation_name.to_string(), constraints);
-        Ok(())
-    }
-
-    /// Set type constraints for an attribute.
-    pub fn set_type_constraints<E: StorageEngine>(
-        &mut self,
-        engine: &mut E,
-        relation_name: &str,
-        attribute_name: &str,
-        constraints: AttributeConstraints,
-    ) -> Result<(), DatabaseError> {
-        let metadata = engine.get_relation_metadata(relation_name)?;
-
-        if !metadata.relation_type.has_attribute(attribute_name) {
-            return Err(DatabaseError::AttributeNotFound(
-                attribute_name.to_string(),
-                relation_name.to_string(),
-            ));
-        }
-
-        // Validate constraints against existing data
-        let relation = engine.load_relation(relation_name)?;
-
-        for tuple in relation.tuples() {
-            if let Some(value) = tuple.get(attribute_name)
-                && !constraints
-                    .is_satisfied_by(value)
-                    .map_err(|e| DatabaseError::TypeConstraintViolation(e.to_string()))?
-            {
-                return Err(DatabaseError::TypeConstraintViolation(
-                    "Existing value violates constraint".to_string(),
-                ));
-            }
-        }
-
-        self.type_constraints
-            .entry(relation_name.to_string())
-            .or_default()
-            .insert(attribute_name.to_string(), constraints);
-        Ok(())
-    }
-
-    /// Set CHECK constraints for a relation.
-    pub fn set_check_constraints<E: StorageEngine>(
-        &mut self,
-        engine: &mut E,
-        relation_name: &str,
-        constraints: CheckConstraints,
-    ) -> Result<(), DatabaseError> {
-        if !engine.relation_exists(relation_name) {
-            return Err(DatabaseError::RelationNotFound(relation_name.to_string()));
-        }
-
-        // Validate constraints against existing data
-        let relation = engine.load_relation(relation_name)?;
-
-        for tuple in relation.tuples() {
-            constraints.are_all_satisfied_by(tuple)?;
-        }
-
-        self.check_constraints
-            .insert(relation_name.to_string(), constraints);
-        Ok(())
-    }
-
-    /// Validate that a tuple matches the relation's heading.
-    pub fn validate_tuple_type<E: StorageEngine>(
-        &self,
-        engine: &E,
-        relation_name: &str,
-        tuple: &Tuple,
-    ) -> Result<(), DatabaseError> {
-        let metadata = engine.get_relation_metadata(relation_name)?;
-        if !tuple.conforms_to(metadata.relation_type.tuple_type()) {
-            Err(DatabaseError::TupleMismatch)
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Validate that a tuple satisfies all type constraints.
-    pub fn validate_type_constraints(
-        &self,
-        relation_name: &str,
-        tuple: &Tuple,
-    ) -> Result<(), DatabaseError> {
-        if let Some(attr_constraints) = self.type_constraints.get(relation_name) {
-            for (attr_name, constraints) in attr_constraints {
-                if let Some(value) = tuple.get(attr_name)
-                    && !constraints
-                        .is_satisfied_by(value)
-                        .map_err(|e| DatabaseError::TypeConstraintViolation(e.to_string()))?
-                {
-                    return Err(DatabaseError::TypeConstraintViolation(format!(
-                        "Attribute {} violates constraint",
-                        attr_name
-                    )));
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Validate that a tuple satisfies all CHECK constraints.
-    pub fn validate_check_constraints(
-        &self,
-        relation_name: &str,
-        tuple: &Tuple,
-    ) -> Result<(), DatabaseError> {
-        if let Some(check_constraints) = self.check_constraints.get(relation_name) {
-            check_constraints.are_all_satisfied_by(tuple)?;
-        }
-        Ok(())
-    }
-
-    /// Validate key constraints for a single tuple against the current relation state.
-    pub fn validate_key_constraints_single_tuple(
-        &self,
-        relation_name: &str,
-        tuple: &Tuple,
-        current_relation: &Relation,
-    ) -> Result<(), DatabaseError> {
-        if let Some(key_constraints) = self.key_constraints.get(relation_name) {
-            if let Some(pk) = key_constraints.primary_key()
-                && pk
-                    .would_violate(current_relation, tuple)
-                    .map_err(|e| DatabaseError::TransactionError(e.to_string()))?
-            {
-                return Err(DatabaseError::PrimaryKeyViolation);
-            }
-
-            for ck in key_constraints.candidate_keys() {
-                if ck
-                    .would_violate(current_relation, tuple)
-                    .map_err(|e| DatabaseError::TransactionError(e.to_string()))?
-                {
-                    return Err(DatabaseError::CandidateKeyViolation);
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Validate foreign key constraints for a single tuple.
-    ///
-    /// Checks that values in the tuple exist in the referenced relations.
-    pub fn validate_foreign_keys_single_tuple<E: StorageEngine>(
-        &self,
-        engine: &mut E,
-        relation_name: &str,
-        tuple: &Tuple,
-    ) -> Result<(), DatabaseError> {
-        let fks_to_check = self
-            .foreign_key_constraints
-            .get(relation_name)
-            .map(|c| c.foreign_keys())
-            .unwrap_or_default();
-
-        for fk in fks_to_check {
-            let referenced_relation = engine.load_relation(fk.referenced_relation_name())?;
-
-            if fk
-                .would_violate_on_insert(tuple, &referenced_relation)
-                .map_err(|e| DatabaseError::ForeignKeyViolation(e.to_string()))?
-            {
-                return Err(DatabaseError::ForeignKeyViolation(
-                    "Foreign key constraint violated".to_string(),
-                ));
-            }
-        }
-        Ok(())
-    }
-
-    /// Validate key constraints against a full relation.
-    pub fn validate_key_constraints_bulk(
-        &self,
-        relation: &Relation,
-        constraints: &KeyConstraints,
-    ) -> Result<(), DatabaseError> {
-        if let Some(pk) = constraints.primary_key()
-            && !pk
-                .is_satisfied_by(relation)
-                .map_err(|e| DatabaseError::TransactionError(e.to_string()))?
-        {
-            return Err(DatabaseError::PrimaryKeyViolation);
-        }
-
-        for ck in constraints.candidate_keys() {
-            if !ck
-                .is_satisfied_by(relation)
-                .map_err(|e| DatabaseError::TransactionError(e.to_string()))?
-            {
-                return Err(DatabaseError::CandidateKeyViolation);
-            }
-        }
-        Ok(())
-    }
-
-    /// Get the key constraints for a relation.
-    pub fn get_key_constraints(&self, relation_name: &str) -> Option<&KeyConstraints> {
-        self.key_constraints.get(relation_name)
-    }
-
-    /// Get the foreign key constraints for a relation.
-    pub fn get_foreign_key_constraints(
-        &self,
-        relation_name: &str,
-    ) -> Option<&ForeignKeyConstraints> {
-        self.foreign_key_constraints.get(relation_name)
-    }
-
-    /// Validate that deleting tuples won't violate foreign keys in other relations.
-    pub fn validate_referencing_foreign_keys<E: StorageEngine>(
-        &self,
-        engine: &mut E,
-        relation_name: &str,
-        relation_after_delete: &Relation,
-    ) -> Result<(), DatabaseError> {
-        // Iterate over constraints without collecting/cloning
-        for (ref_name, fk_constraints) in &self.foreign_key_constraints {
-            for fk in fk_constraints.foreign_keys() {
-                if fk.referenced_relation_name() == relation_name {
-                    let referencing_relation = engine.load_relation(ref_name)?;
-
-                    // Build a HashSet of keys from the relation after deletion for efficient lookups.
-                    let existing_keys: std::collections::HashSet<Vec<_>> = relation_after_delete
-                        .tuples()
-                        .map(|t| {
-                            fk.referenced_attributes()
-                                .iter()
-                                .filter_map(|attr| t.get(attr).cloned())
-                                .collect()
-                        })
-                        .collect();
-
-                    // Check if any referencing tuples would be orphaned by looking up in the HashSet.
-                    for ref_tuple in referencing_relation.tuples() {
-                        let ref_key_values: Vec<ScalarValue> = fk
-                            .foreign_key_attributes()
-                            .iter()
-                            .filter_map(|attr| ref_tuple.get(attr).cloned())
-                            .collect();
-
-                        if !existing_keys.contains(&ref_key_values) {
-                            return Err(DatabaseError::ForeignKeyViolation(format!(
-                                "Deleting tuples would orphan referencing tuples in {}",
-                                ref_name
-                            )));
-                        }
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
 }
 
 /// A relational database instance.
@@ -583,8 +255,9 @@ impl<E: StorageEngine> Database<E> {
         relation_name: &str,
         constraints: KeyConstraints,
     ) -> Result<(), DatabaseError> {
-        self.constraints
-            .set_key_constraints(&mut self.engine, relation_name, constraints)
+        Ok(self
+            .constraints
+            .set_key_constraints(&mut self.engine, relation_name, constraints)?)
     }
 
     /// Set foreign key constraints for a relation.
@@ -625,8 +298,9 @@ impl<E: StorageEngine> Database<E> {
         relation_name: &str,
         constraints: ForeignKeyConstraints,
     ) -> Result<(), DatabaseError> {
-        self.constraints
-            .set_foreign_key_constraints(&mut self.engine, relation_name, constraints)
+        Ok(self
+            .constraints
+            .set_foreign_key_constraints(&mut self.engine, relation_name, constraints)?)
     }
 
     /// Set type constraints for an attribute.
@@ -657,12 +331,12 @@ impl<E: StorageEngine> Database<E> {
         attribute_name: &str,
         constraints: AttributeConstraints,
     ) -> Result<(), DatabaseError> {
-        self.constraints.set_type_constraints(
+        Ok(self.constraints.set_type_constraints(
             &mut self.engine,
             relation_name,
             attribute_name,
             constraints,
-        )
+        )?)
     }
 
     /// Set CHECK constraints for a relation.
@@ -701,8 +375,9 @@ impl<E: StorageEngine> Database<E> {
         relation_name: &str,
         constraints: CheckConstraints,
     ) -> Result<(), DatabaseError> {
-        self.constraints
-            .set_check_constraints(&mut self.engine, relation_name, constraints)
+        Ok(self
+            .constraints
+            .set_check_constraints(&mut self.engine, relation_name, constraints)?)
     }
 
     /// Insert a tuple into a relation.
@@ -1037,6 +712,7 @@ mod tests {
     use crate::storage_engine::InMemoryEngine;
     use crate::tuple;
     use crate::types::{ScalarType, TupleType};
+    use crate::values::ScalarValue;
 
     fn test_rel_type() -> RelationType {
         RelationType::new(

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -91,9 +91,7 @@ impl From<ConstraintManagerError> for DatabaseError {
             ConstraintManagerError::TupleMismatch => DatabaseError::TupleMismatch,
             ConstraintManagerError::PrimaryKeyViolation => DatabaseError::PrimaryKeyViolation,
             ConstraintManagerError::CandidateKeyViolation => DatabaseError::CandidateKeyViolation,
-            ConstraintManagerError::ForeignKeyViolation(s) => {
-                DatabaseError::ForeignKeyViolation(s)
-            }
+            ConstraintManagerError::ForeignKeyViolation(s) => DatabaseError::ForeignKeyViolation(s),
             ConstraintManagerError::TypeConstraintViolation(s) => {
                 DatabaseError::TypeConstraintViolation(s)
             }
@@ -298,9 +296,11 @@ impl<E: StorageEngine> Database<E> {
         relation_name: &str,
         constraints: ForeignKeyConstraints,
     ) -> Result<(), DatabaseError> {
-        Ok(self
-            .constraints
-            .set_foreign_key_constraints(&mut self.engine, relation_name, constraints)?)
+        Ok(self.constraints.set_foreign_key_constraints(
+            &mut self.engine,
+            relation_name,
+            constraints,
+        )?)
     }
 
     /// Set type constraints for an attribute.


### PR DESCRIPTION
Extracted `ConstraintManager` from `database.rs` to `constraints/manager.rs` to improve cohesion and reduce coupling.
- Created `relvar-core/src/constraints/manager.rs`.
- Defined `ConstraintManagerError`.
- Updated `relvar-core/src/database.rs` to delegate to the new module.
- Updated `DatabaseError` to wrap `ConstraintManagerError`.

---
*PR created automatically by Jules for task [6626136616602108982](https://jules.google.com/task/6626136616602108982) started by @madmax983*