### PR TITLE
⚡ Bolt: Optimize Foreign Key Constraint Checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+# Bolt's Journal ⚡
+
+## 2024-05-22 - Storage Engine Bottleneck
+**Learning:** `ConstraintManager` validation methods load entire relations into memory via `StorageEngine::load_relation` to perform foreign key checks. This creates `O(N)` memory usage and `O(N*M)` complexity for bulk operations.
+**Action:** Future architectural improvements should extend `StorageEngine` to support granular existence checks (`contains_tuple`, `find_tuple`) or iterator-based access to avoid full loads.

--- a/relvar-core/src/constraints/manager.rs
+++ b/relvar-core/src/constraints/manager.rs
@@ -135,24 +135,27 @@ impl ConstraintManager {
         for fk in constraints.foreign_keys() {
             let referenced_relation = engine.load_relation(fk.referenced_relation_name())?;
             // Build a HashSet of referenced keys for efficient O(1) lookups.
-            let referenced_keys: std::collections::HashSet<Vec<_>> = referenced_relation
+            // We store references to avoid cloning potentially large values.
+            let referenced_keys: std::collections::HashSet<Vec<&ScalarValue>> = referenced_relation
                 .tuples()
                 .map(|ref_tuple| {
                     fk.referenced_attributes()
                         .iter()
-                        .map(|attr| ref_tuple.get(attr).cloned().unwrap())
+                        .map(|attr| ref_tuple.get(attr).unwrap())
                         .collect()
                 })
                 .collect();
 
-            for tuple in relation.tuples() {
-                let fk_values: Vec<_> = fk
-                    .foreign_key_attributes()
-                    .iter()
-                    .map(|attr| tuple.get(attr).cloned().unwrap())
-                    .collect();
+            // Pre-allocate buffer for key construction to avoid repeated allocations
+            let mut fk_key_buffer = Vec::with_capacity(fk.foreign_key_attributes().len());
 
-                if !referenced_keys.contains(&fk_values) {
+            for tuple in relation.tuples() {
+                fk_key_buffer.clear();
+                for attr in fk.foreign_key_attributes() {
+                    fk_key_buffer.push(tuple.get(attr).unwrap());
+                }
+
+                if !referenced_keys.contains(&fk_key_buffer) {
                     return Err(ConstraintManagerError::ForeignKeyViolation(
                         "Existing tuple violates foreign key".to_string(),
                     ));
@@ -389,25 +392,31 @@ impl ConstraintManager {
                     let referencing_relation = engine.load_relation(ref_name)?;
 
                     // Build a HashSet of keys from the relation after deletion for efficient lookups.
-                    let existing_keys: std::collections::HashSet<Vec<_>> = relation_after_delete
-                        .tuples()
-                        .map(|t| {
-                            fk.referenced_attributes()
-                                .iter()
-                                .filter_map(|attr| t.get(attr).cloned())
-                                .collect()
-                        })
-                        .collect();
+                    // We store references to avoid cloning potentially large values (Strings, Blobs).
+                    let existing_keys: std::collections::HashSet<Vec<&ScalarValue>> =
+                        relation_after_delete
+                            .tuples()
+                            .map(|t| {
+                                fk.referenced_attributes()
+                                    .iter()
+                                    .filter_map(|attr| t.get(attr))
+                                    .collect()
+                            })
+                            .collect();
+
+                    // Pre-allocate buffer for key construction to avoid repeated allocations
+                    let mut ref_key_buffer = Vec::with_capacity(fk.foreign_key_attributes().len());
 
                     // Check if any referencing tuples would be orphaned by looking up in the HashSet.
                     for ref_tuple in referencing_relation.tuples() {
-                        let ref_key_values: Vec<ScalarValue> = fk
-                            .foreign_key_attributes()
-                            .iter()
-                            .filter_map(|attr| ref_tuple.get(attr).cloned())
-                            .collect();
+                        ref_key_buffer.clear();
+                        for attr in fk.foreign_key_attributes() {
+                            if let Some(val) = ref_tuple.get(attr) {
+                                ref_key_buffer.push(val);
+                            }
+                        }
 
-                        if !existing_keys.contains(&ref_key_values) {
+                        if !existing_keys.contains(&ref_key_buffer) {
                             return Err(ConstraintManagerError::ForeignKeyViolation(format!(
                                 "Deleting tuples would orphan referencing tuples in {}",
                                 ref_name

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -1346,6 +1346,163 @@ mod tests {
     }
 
     #[test]
+    fn test_set_foreign_key_constraints_with_existing_valid_data() {
+        use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+
+        let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
+
+        // Create parent and child relvars
+        let parent_type = RelationType::new(
+            TupleType::new()
+                .with_attribute("id", ScalarType::Int)
+                .with_attribute("name", ScalarType::String),
+        );
+        let child_type = RelationType::new(
+            TupleType::new()
+                .with_attribute("child_id", ScalarType::Int)
+                .with_attribute("parent_id", ScalarType::Int),
+        );
+
+        db.create_relvar("PARENT", parent_type).unwrap();
+        db.create_relvar("CHILD", child_type).unwrap();
+
+        // Set PK on parent
+        let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+        db.set_key_constraints("PARENT", KeyConstraints::new().with_primary_key(pk))
+            .unwrap();
+
+        // Insert data BEFORE setting FK
+        db.insert("PARENT", tuple! { id: 1i64, name: "Parent1" })
+            .unwrap();
+        db.insert("CHILD", tuple! { child_id: 100i64, parent_id: 1i64 })
+            .unwrap();
+
+        // Set FK constraints
+        let fk = ForeignKey::new(
+            vec!["parent_id".to_string()],
+            "PARENT".to_string(),
+            vec!["id".to_string()],
+        )
+        .unwrap();
+        let fk_constraints = ForeignKeyConstraints::new().with_foreign_key(fk);
+
+        // Should succeed as data is valid
+        db.set_foreign_key_constraints("CHILD", fk_constraints)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_set_foreign_key_constraints_with_existing_invalid_data() {
+        use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+
+        let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
+
+        // Create parent and child relvars
+        let parent_type = RelationType::new(
+            TupleType::new()
+                .with_attribute("id", ScalarType::Int)
+                .with_attribute("name", ScalarType::String),
+        );
+        let child_type = RelationType::new(
+            TupleType::new()
+                .with_attribute("child_id", ScalarType::Int)
+                .with_attribute("parent_id", ScalarType::Int),
+        );
+
+        db.create_relvar("PARENT", parent_type).unwrap();
+        db.create_relvar("CHILD", child_type).unwrap();
+
+        // Set PK on parent
+        let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+        db.set_key_constraints("PARENT", KeyConstraints::new().with_primary_key(pk))
+            .unwrap();
+
+        // Insert data BEFORE setting FK
+        db.insert("PARENT", tuple! { id: 1i64, name: "Parent1" })
+            .unwrap();
+        // Insert ORPHAN child
+        db.insert("CHILD", tuple! { child_id: 100i64, parent_id: 99i64 })
+            .unwrap();
+
+        // Set FK constraints
+        let fk = ForeignKey::new(
+            vec!["parent_id".to_string()],
+            "PARENT".to_string(),
+            vec!["id".to_string()],
+        )
+        .unwrap();
+        let fk_constraints = ForeignKeyConstraints::new().with_foreign_key(fk);
+
+        // Should fail
+        let result = db.set_foreign_key_constraints("CHILD", fk_constraints);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(DatabaseError::ForeignKeyViolation(_))));
+    }
+
+    #[test]
+    fn test_delete_referenced_parent_success() {
+        use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+
+        let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
+
+        let parent_type = RelationType::new(
+            TupleType::new()
+                .with_attribute("id", ScalarType::Int)
+                .with_attribute("name", ScalarType::String),
+        );
+        let child_type = RelationType::new(
+            TupleType::new()
+                .with_attribute("child_id", ScalarType::Int)
+                .with_attribute("parent_id", ScalarType::Int),
+        );
+
+        db.create_relvar("PARENT", parent_type).unwrap();
+        db.create_relvar("CHILD", child_type).unwrap();
+
+        let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+        db.set_key_constraints("PARENT", KeyConstraints::new().with_primary_key(pk))
+            .unwrap();
+
+        let fk = ForeignKey::new(
+            vec!["parent_id".to_string()],
+            "PARENT".to_string(),
+            vec!["id".to_string()],
+        )
+        .unwrap();
+        db.set_foreign_key_constraints("CHILD", ForeignKeyConstraints::new().with_foreign_key(fk))
+            .unwrap();
+
+        // Insert parents
+        db.insert("PARENT", tuple! { id: 1i64, name: "Parent1" })
+            .unwrap();
+        db.insert("PARENT", tuple! { id: 2i64, name: "Parent2" })
+            .unwrap();
+
+        // Insert child referencing Parent1
+        db.insert("CHILD", tuple! { child_id: 100i64, parent_id: 1i64 })
+            .unwrap();
+
+        // Delete Parent2 (not referenced) - should succeed
+        let count = db
+            .delete("PARENT", |t| t.get_typed::<i64>("id").unwrap() == 2)
+            .unwrap();
+        assert_eq!(count, 1);
+
+        // Verify Parent2 is gone
+        let result = db.query("PARENT").unwrap();
+        assert_eq!(result.cardinality(), 1);
+        assert_eq!(
+            result
+                .tuples()
+                .next()
+                .unwrap()
+                .get_typed::<String>("name")
+                .unwrap(),
+            "Parent1"
+        );
+    }
+
+    #[test]
     fn test_delete_returns_count() {
         let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
         db.create_relvar("TEST", test_rel_type()).unwrap();


### PR DESCRIPTION
Reduces heap allocations and memory copying during foreign key validation by using `Vec<&ScalarValue>` and buffer reuse.

---
*PR created automatically by Jules for task [13294570715547300805](https://jules.google.com/task/13294570715547300805) started by @madmax983*