### PR TITLE
🗺️ Atlas: Refactor SchemaVisualizer for efficiency and immutability

### DIFF
--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -214,6 +214,24 @@ impl<E: StorageEngine> Database<E> {
         names
     }
 
+    /// Get the relation type (heading) for a relvar.
+    ///
+    /// This method retrieves the metadata without loading the full relation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DatabaseError::RelationNotFound` if the relvar doesn't exist.
+    pub fn get_relvar_type(&self, name: &str) -> Result<RelationType, DatabaseError> {
+        // Check virtual relvars first
+        if let Some(def) = self.virtual_relvars.get(name) {
+            return Ok(def.relation_type.clone());
+        }
+
+        // Check base relvars
+        let metadata = self.engine.get_relation_metadata(name)?;
+        Ok(metadata.relation_type)
+    }
+
     /// Get the key constraints for a relation.
     pub fn get_key_constraints(&self, relation_name: &str) -> Option<&KeyConstraints> {
         self.constraints.get_key_constraints(relation_name)

--- a/relvar/src/visualizer.rs
+++ b/relvar/src/visualizer.rs
@@ -42,7 +42,7 @@
 //! db.set_foreign_key_constraints("EMP", ForeignKeyConstraints::new().with_foreign_key(fk)).unwrap();
 //!
 //! // Generate DOT
-//! let mut visualizer = SchemaVisualizer::new(&mut db);
+//! let visualizer = SchemaVisualizer::new(&db);
 //! let dot = visualizer.to_dot();
 //!
 //! assert!(dot.contains("digraph DatabaseSchema"));
@@ -54,12 +54,12 @@ use relvar_core::storage_engine::StorageEngine;
 
 /// A tool for visualizing the database schema.
 pub struct SchemaVisualizer<'a, E: StorageEngine> {
-    db: &'a mut Database<E>,
+    db: &'a Database<E>,
 }
 
 impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
     /// Create a new schema visualizer for the given database.
-    pub fn new(db: &'a mut Database<E>) -> Self {
+    pub fn new(db: &'a Database<E>) -> Self {
         Self { db }
     }
 
@@ -76,11 +76,11 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
     /// let mut db = Database::new(InMemoryEngine::new());
     /// // ... setup schema ...
     ///
-    /// let mut viz = SchemaVisualizer::new(&mut db);
+    /// let viz = SchemaVisualizer::new(&db);
     /// let dot_code = viz.to_dot();
     /// println!("{}", dot_code);
     /// ```
-    pub fn to_dot(&mut self) -> String {
+    pub fn to_dot(&self) -> String {
         let mut dot = String::from("digraph DatabaseSchema {\n");
         dot.push_str("    rankdir=LR;\n");
         dot.push_str("    node [shape=none, fontname=\"Helvetica\", fontsize=10];\n");
@@ -90,11 +90,9 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
 
         // 1. Generate nodes (Tables)
         for name in &relvars {
-            // Note: We use query() to get the relation structure.
-            // Since this is for visualization, we ignore potential errors (e.g. temporary locks)
-            // or if the relation somehow disappears.
-            if let Ok(relation) = self.db.query(name) {
-                let relation_type = relation.relation_type();
+            // Note: We use get_relvar_type() to get the relation structure.
+            // This avoids loading the full relation data.
+            if let Ok(relation_type) = self.db.get_relvar_type(name) {
                 let tuple_type = relation_type.tuple_type();
 
                 // Determine primary key attributes
@@ -198,7 +196,7 @@ mod tests {
             .unwrap();
 
         // Visualize
-        let mut visualizer = SchemaVisualizer::new(&mut db);
+        let visualizer = SchemaVisualizer::new(&db);
         let dot = visualizer.to_dot();
 
         println!("{}", dot);


### PR DESCRIPTION
This PR refactors the `SchemaVisualizer` to improve performance and API design.

**Changes:**
1.  **`relvar-core`**: Added `Database::get_relvar_type(&self, name: &str) -> Result<RelationType, DatabaseError>`. This method retrieves the relation type (heading) from the storage engine metadata or virtual relvar definition without loading the full relation (which involves scanning all tuples).
2.  **`relvar`**: Updated `SchemaVisualizer` to hold an immutable reference `&Database` instead of a mutable one. This is now possible because `get_relvar_type` only requires `&self`.
3.  **`relvar`**: Updated `SchemaVisualizer::to_dot` to use the new lightweight method.

**Benefits:**
-   **Performance**: Visualizing the schema no longer requires loading all data into memory.
-   **Usability**: The visualizer can now be used with a shared reference, allowing it to be used in contexts where mutable access is not available or desirable.
-   **Cleanliness**: Adheres to the principle of least privilege (only read access needed).

**Verification:**
-   `cargo check -p relvar-core` passed.
-   `cargo check -p relvar` passed.
-   `cargo test -p relvar` passed (including updated doctests).

---
*PR created automatically by Jules for task [5069074845788072416](https://jules.google.com/task/5069074845788072416) started by @madmax983*