### PR TITLE
⚡ Bolt: Avoid tuple cloning in update/delete

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2024-05-22 - Storage Engine Bottleneck
 **Learning:** `ConstraintManager` validation methods load entire relations into memory via `StorageEngine::load_relation` to perform foreign key checks. This creates `O(N)` memory usage and `O(N*M)` complexity for bulk operations.
 **Action:** Future architectural improvements should extend `StorageEngine` to support granular existence checks (`contains_tuple`, `find_tuple`) or iterator-based access to avoid full loads.
+
+## 2024-05-24 - Avoiding Clones in Update/Delete
+**Learning:** `Relation::insert` takes `Tuple` by value. Iterating over `Relation` using `IntoIterator` allows moving tuples from old to new relation during updates/deletes, saving O(N) clones.
+**Action:** When refactoring collection transformations, always check if the source collection can be consumed (`into_iter`) to avoid cloning elements.

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -493,7 +493,7 @@ impl<E: StorageEngine> Database<E> {
 
         // Filter out tuples to delete
         let (new_relation, delete_count) =
-            self.compute_relation_after_delete(&current_relation, predicate)?;
+            self.compute_relation_after_delete(current_relation, predicate)?;
 
         self.constraints.validate_referencing_foreign_keys(
             &mut self.engine,
@@ -572,7 +572,7 @@ impl<E: StorageEngine> Database<E> {
 
         // Apply updates
         let (new_relation, update_count) =
-            self.compute_relation_after_update(&current_relation, predicate, updater)?;
+            self.compute_relation_after_update(current_relation, predicate, updater)?;
 
         // Validate key constraints on new relation
         if let Some(key_constraints) = self.constraints.get_key_constraints(relation_name) {
@@ -711,7 +711,7 @@ impl<E: StorageEngine> Database<E> {
 
     fn compute_relation_after_delete<F>(
         &self,
-        current_relation: &Relation,
+        current_relation: Relation,
         predicate: F,
     ) -> Result<(Relation, usize), DatabaseError>
     where
@@ -720,11 +720,11 @@ impl<E: StorageEngine> Database<E> {
         let mut new_relation = Relation::new(current_relation.relation_type().clone());
         let mut delete_count = 0;
 
-        for tuple in current_relation.tuples() {
-            if predicate(tuple) {
+        for tuple in current_relation {
+            if predicate(&tuple) {
                 delete_count += 1;
             } else {
-                new_relation.insert(tuple.clone())?;
+                new_relation.insert(tuple)?;
             }
         }
 
@@ -733,7 +733,7 @@ impl<E: StorageEngine> Database<E> {
 
     fn compute_relation_after_update<F, U>(
         &self,
-        current_relation: &Relation,
+        current_relation: Relation,
         predicate: F,
         updater: U,
     ) -> Result<(Relation, usize), DatabaseError>
@@ -741,22 +741,24 @@ impl<E: StorageEngine> Database<E> {
         F: Fn(&Tuple) -> bool,
         U: Fn(&Tuple) -> Tuple,
     {
-        let mut new_relation = Relation::new(current_relation.relation_type().clone());
+        let relation_type = current_relation.relation_type().clone();
+        let expected_type = relation_type.tuple_type().clone();
+        let mut new_relation = Relation::new(relation_type);
         let mut update_count = 0;
 
-        for tuple in current_relation.tuples() {
-            if predicate(tuple) {
-                let updated_tuple = updater(tuple);
+        for tuple in current_relation {
+            if predicate(&tuple) {
+                let updated_tuple = updater(&tuple);
 
                 // Validate updated tuple
-                if !updated_tuple.conforms_to(current_relation.relation_type().tuple_type()) {
+                if !updated_tuple.conforms_to(&expected_type) {
                     return Err(DatabaseError::TupleMismatch);
                 }
 
                 new_relation.insert(updated_tuple)?;
                 update_count += 1;
             } else {
-                new_relation.insert(tuple.clone())?;
+                new_relation.insert(tuple)?;
             }
         }
 

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -156,6 +156,15 @@ impl std::hash::Hash for Relation {
     }
 }
 
+impl IntoIterator for Relation {
+    type Item = Tuple;
+    type IntoIter = std::collections::hash_set::IntoIter<Tuple>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.body.into_iter()
+    }
+}
+
 impl Relation {
     /// Creates a new empty relation with the given type.
     ///


### PR DESCRIPTION
💡 **What**: Implemented `IntoIterator` for `Relation` and updated database modification methods to consume the source relation.
🎯 **Why**: Update and Delete operations were cloning every tuple that wasn't modified/deleted, causing unnecessary heap allocations (O(N) clones).
📊 **Impact**: Removes N clones for delete/update operations where N is the number of preserved tuples.
🔬 **Measurement**: Verified via `cargo test` and manual code analysis. Correctness preserved.

---
*PR created automatically by Jules for task [2424780928965020268](https://jules.google.com/task/2424780928965020268) started by @madmax983*