### PR TITLE
⚒️ Forge: Refactor ConstraintManager duplication and Database validation logic

### DIFF
--- a/relvar-core/src/constraints/manager.rs
+++ b/relvar-core/src/constraints/manager.rs
@@ -136,15 +136,8 @@ impl ConstraintManager {
             let referenced_relation = engine.load_relation(fk.referenced_relation_name())?;
             // Build a HashSet of referenced keys for efficient O(1) lookups.
             // We store references to avoid cloning potentially large values.
-            let referenced_keys: std::collections::HashSet<Vec<&ScalarValue>> = referenced_relation
-                .tuples()
-                .map(|ref_tuple| {
-                    fk.referenced_attributes()
-                        .iter()
-                        .map(|attr| ref_tuple.get(attr).unwrap())
-                        .collect()
-                })
-                .collect();
+            let referenced_keys =
+                Self::extract_attribute_values(&referenced_relation, fk.referenced_attributes());
 
             // Pre-allocate buffer for key construction to avoid repeated allocations
             let mut fk_key_buffer = Vec::with_capacity(fk.foreign_key_attributes().len());
@@ -310,6 +303,21 @@ impl ConstraintManager {
         Ok(())
     }
 
+    /// Validate constraints that depend only on the tuple's content and foreign keys.
+    ///
+    /// This includes Type constraints, CHECK constraints, and Foreign Key constraints.
+    pub fn validate_tuple_content_constraints<E: StorageEngine>(
+        &self,
+        engine: &mut E,
+        relation_name: &str,
+        tuple: &Tuple,
+    ) -> Result<(), ConstraintManagerError> {
+        self.validate_type_constraints(relation_name, tuple)?;
+        self.validate_check_constraints(relation_name, tuple)?;
+        self.validate_foreign_keys_single_tuple(engine, relation_name, tuple)?;
+        Ok(())
+    }
+
     /// Validate foreign key constraints for a single tuple.
     ///
     /// Checks that values in the tuple exist in the referenced relations.
@@ -393,16 +401,10 @@ impl ConstraintManager {
 
                     // Build a HashSet of keys from the relation after deletion for efficient lookups.
                     // We store references to avoid cloning potentially large values (Strings, Blobs).
-                    let existing_keys: std::collections::HashSet<Vec<&ScalarValue>> =
-                        relation_after_delete
-                            .tuples()
-                            .map(|t| {
-                                fk.referenced_attributes()
-                                    .iter()
-                                    .filter_map(|attr| t.get(attr))
-                                    .collect()
-                            })
-                            .collect();
+                    let existing_keys = Self::extract_attribute_values(
+                        relation_after_delete,
+                        fk.referenced_attributes(),
+                    );
 
                     // Pre-allocate buffer for key construction to avoid repeated allocations
                     let mut ref_key_buffer = Vec::with_capacity(fk.foreign_key_attributes().len());
@@ -427,5 +429,25 @@ impl ConstraintManager {
             }
         }
         Ok(())
+    }
+
+    /// Helper to extract a set of attribute value combinations from a relation.
+    fn extract_attribute_values<'a>(
+        relation: &'a Relation,
+        attributes: &[String],
+    ) -> std::collections::HashSet<Vec<&'a ScalarValue>> {
+        relation
+            .tuples()
+            .map(|tuple| {
+                attributes
+                    .iter()
+                    .map(|attr| {
+                        tuple
+                            .get(attr)
+                            .expect("Attribute must exist in relation schema")
+                    })
+                    .collect()
+            })
+            .collect()
     }
 }

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -584,11 +584,7 @@ impl<E: StorageEngine> Database<E> {
         // NOTE: In a production system we'd only validate changed tuples, but for now
         // we validate everything to ensure total consistency.
         for tuple in new_relation.tuples() {
-            self.constraints
-                .validate_type_constraints(relation_name, tuple)?;
-            self.constraints
-                .validate_check_constraints(relation_name, tuple)?;
-            self.constraints.validate_foreign_keys_single_tuple(
+            self.constraints.validate_tuple_content_constraints(
                 &mut self.engine,
                 relation_name,
                 tuple,
@@ -769,10 +765,12 @@ impl<E: StorageEngine> Database<E> {
         // Pure checks and Type validations
         self.constraints
             .validate_tuple_type(&self.engine, relation_name, tuple)?;
-        self.constraints
-            .validate_type_constraints(relation_name, tuple)?;
-        self.constraints
-            .validate_check_constraints(relation_name, tuple)?;
+
+        self.constraints.validate_tuple_content_constraints(
+            &mut self.engine,
+            relation_name,
+            tuple,
+        )?;
 
         // Load current relation to check key constraints
         let current_relation = self.query(relation_name)?;
@@ -780,11 +778,6 @@ impl<E: StorageEngine> Database<E> {
             relation_name,
             tuple,
             &current_relation,
-        )?;
-        self.constraints.validate_foreign_keys_single_tuple(
-            &mut self.engine,
-            relation_name,
-            tuple,
         )?;
 
         Ok(())


### PR DESCRIPTION
🚮 Smell: 
- Duplicate logic for extracting keys from relations in `ConstraintManager` (`set_foreign_key_constraints` and `validate_referencing_foreign_keys`).
- Repetitive constraint validation calls (Type, Check, FK) in `Database::insert` and `Database::update`.
- Silent potential error masking using `filter_map` when extracting attributes for FK validation.

✨ Solution: 
- Extracted `extract_attribute_values` private helper method in `ConstraintManager`.
- Added `validate_tuple_content_constraints` public method in `ConstraintManager` to group tuple-level validations.
- Updated `Database` to use these helpers.
- Replaced `filter_map` with `expect` to crash on schema corruption (safer).

🧼 Benefit: 
- Reduces code duplication.
- Improves readability of `Database` operations.
- Enforces stricter schema validation.
- Unifies validation logic between `insert` and `update`.

🛡️ Verification: 
- `cargo check` passed.
- `cargo test` passed (all tests).
- No functional behavior change for valid inputs.

---
*PR created automatically by Jules for task [7163886922636688534](https://jules.google.com/task/7163886922636688534) started by @madmax983*