### PR TITLE
🗺️ Atlas: Unify DatabaseError and ConstraintManagerError

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -1,3 +1,7 @@
 ## 2025-05-24 - Extract ConstraintManager
 **Tangle:** `Database` struct in `relvar-core/src/database.rs` was becoming a "God Struct", mixing database orchestration with constraint enforcement logic. The file was nearly 2000 lines long.
 **Blueprint:** Extracted `ConstraintManager` and its error types into a dedicated `relvar-core/src/constraints/manager.rs` module. This improves cohesion by grouping constraint logic with constraint definitions and reduces coupling in the main database module.
+
+## 2025-05-24 - Unify Database Error Handling
+**Tangle:** `DatabaseError` duplicated `ConstraintManagerError` variants (violating DRY) and required manual synchronization.
+**Blueprint:** Nested `ConstraintManagerError` within `DatabaseError` via a `Constraint(#[from] ConstraintManagerError)` variant. This enforces hierarchy and removes code duplication.

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -63,7 +63,6 @@ pub enum DatabaseError {
     AttributeNotFound(String, String),
 }
 
-
 /// Definition of a virtual relvar (view).
 ///
 /// TTM: RM Prescription 10 - Virtual relvars (views) re-evaluate their

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -4,8 +4,8 @@
 //! for all database operations.
 
 use crate::constraints::{
-    AttributeConstraints, CheckConstraintError, CheckConstraints, ConstraintManager,
-    ConstraintManagerError, ForeignKeyConstraints, KeyConstraints,
+    AttributeConstraints, CheckConstraints, ConstraintManager, ConstraintManagerError,
+    ForeignKeyConstraints, KeyConstraints,
 };
 use crate::storage_engine::{StorageEngine, StorageError};
 use crate::types::RelationType;
@@ -38,25 +38,9 @@ pub enum DatabaseError {
     #[error("Tuple type does not match relation type")]
     TupleMismatch,
 
-    /// Primary key constraint violation.
-    #[error("Primary key violation")]
-    PrimaryKeyViolation,
-
-    /// Candidate key constraint violation.
-    #[error("Candidate key violation")]
-    CandidateKeyViolation,
-
-    /// Foreign key constraint violation.
-    #[error("Foreign key violation: {0}")]
-    ForeignKeyViolation(String),
-
-    /// Type constraint violation.
-    #[error("Type constraint violation: {0}")]
-    TypeConstraintViolation(String),
-
-    /// CHECK constraint violation.
-    #[error("CHECK constraint violation: {0}")]
-    CheckConstraintViolation(#[from] CheckConstraintError),
+    /// Constraint violation.
+    #[error("Constraint violation: {0}")]
+    Constraint(#[from] ConstraintManagerError),
 
     /// Transaction error.
     #[error("Transaction error: {0}")]
@@ -79,29 +63,6 @@ pub enum DatabaseError {
     AttributeNotFound(String, String),
 }
 
-impl From<ConstraintManagerError> for DatabaseError {
-    fn from(err: ConstraintManagerError) -> Self {
-        match err {
-            ConstraintManagerError::Storage(e) => DatabaseError::Storage(e),
-            ConstraintManagerError::Relation(e) => DatabaseError::Relation(e),
-            ConstraintManagerError::RelationNotFound(n) => DatabaseError::RelationNotFound(n),
-            ConstraintManagerError::AttributeNotFound(a, r) => {
-                DatabaseError::AttributeNotFound(a, r)
-            }
-            ConstraintManagerError::TupleMismatch => DatabaseError::TupleMismatch,
-            ConstraintManagerError::PrimaryKeyViolation => DatabaseError::PrimaryKeyViolation,
-            ConstraintManagerError::CandidateKeyViolation => DatabaseError::CandidateKeyViolation,
-            ConstraintManagerError::ForeignKeyViolation(s) => DatabaseError::ForeignKeyViolation(s),
-            ConstraintManagerError::TypeConstraintViolation(s) => {
-                DatabaseError::TypeConstraintViolation(s)
-            }
-            ConstraintManagerError::CheckConstraintViolation(e) => {
-                DatabaseError::CheckConstraintViolation(e)
-            }
-            ConstraintManagerError::TransactionError(s) => DatabaseError::TransactionError(s),
-        }
-    }
-}
 
 /// Definition of a virtual relvar (view).
 ///
@@ -458,7 +419,7 @@ impl<E: StorageEngine> Database<E> {
     /// Returns an error if:
     /// - The relation doesn't exist ([`DatabaseError::RelationNotFound`])
     /// - Deleting the tuples would violate a foreign key constraint in another relation
-    ///   ([`DatabaseError::ForeignKeyViolation`])
+    ///   ([`ConstraintManagerError::ForeignKeyViolation`])
     ///
     /// # Example
     ///
@@ -515,10 +476,10 @@ impl<E: StorageEngine> Database<E> {
     /// Returns an error if:
     /// - The relation doesn't exist ([`DatabaseError::RelationNotFound`])
     /// - The updated tuple doesn't match the relation type ([`DatabaseError::TupleMismatch`])
-    /// - A key constraint is violated ([`DatabaseError::PrimaryKeyViolation`], [`DatabaseError::CandidateKeyViolation`])
-    /// - A foreign key constraint is violated ([`DatabaseError::ForeignKeyViolation`])
-    /// - A type constraint is violated ([`DatabaseError::TypeConstraintViolation`])
-    /// - A CHECK constraint is violated ([`DatabaseError::CheckConstraintViolation`])
+    /// - A key constraint is violated ([`ConstraintManagerError::PrimaryKeyViolation`], [`ConstraintManagerError::CandidateKeyViolation`])
+    /// - A foreign key constraint is violated ([`ConstraintManagerError::ForeignKeyViolation`])
+    /// - A type constraint is violated ([`ConstraintManagerError::TypeConstraintViolation`])
+    /// - A CHECK constraint is violated ([`ConstraintManagerError::CheckConstraintViolation`])
     ///
     /// # Example
     ///
@@ -905,7 +866,12 @@ mod tests {
         // Duplicate primary key should fail
         let result = db.insert("TEST", tuple! { id: 1i64, name: "Bob" });
         assert!(result.is_err());
-        assert!(matches!(result, Err(DatabaseError::PrimaryKeyViolation)));
+        assert!(matches!(
+            result,
+            Err(DatabaseError::Constraint(
+                ConstraintManagerError::PrimaryKeyViolation
+            ))
+        ));
     }
 
     #[test]
@@ -927,7 +893,12 @@ mod tests {
         // Duplicate candidate key should fail
         let result = db.insert("TEST", tuple! { id: 2i64, name: "Alice" });
         assert!(result.is_err());
-        assert!(matches!(result, Err(DatabaseError::CandidateKeyViolation)));
+        assert!(matches!(
+            result,
+            Err(DatabaseError::Constraint(
+                ConstraintManagerError::CandidateKeyViolation
+            ))
+        ));
     }
 
     #[test]
@@ -978,7 +949,12 @@ mod tests {
         // Insert with invalid foreign key should fail
         let result = db.insert("EMP", tuple! { emp_id: 2i64, dept_id: 99i64 });
         assert!(result.is_err());
-        assert!(matches!(result, Err(DatabaseError::ForeignKeyViolation(_))));
+        assert!(matches!(
+            result,
+            Err(DatabaseError::Constraint(
+                ConstraintManagerError::ForeignKeyViolation(_)
+            ))
+        ));
     }
 
     #[test]
@@ -1009,7 +985,9 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result,
-            Err(DatabaseError::TypeConstraintViolation(_))
+            Err(DatabaseError::Constraint(
+                ConstraintManagerError::TypeConstraintViolation(_)
+            ))
         ));
 
         // Value above max should fail
@@ -1017,7 +995,9 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result,
-            Err(DatabaseError::TypeConstraintViolation(_))
+            Err(DatabaseError::Constraint(
+                ConstraintManagerError::TypeConstraintViolation(_)
+            ))
         ));
     }
 
@@ -1119,7 +1099,12 @@ mod tests {
         // Deleting parent should fail due to foreign key
         let result = db.delete("PARENT", |_| true);
         assert!(result.is_err());
-        assert!(matches!(result, Err(DatabaseError::ForeignKeyViolation(_))));
+        assert!(matches!(
+            result,
+            Err(DatabaseError::Constraint(
+                ConstraintManagerError::ForeignKeyViolation(_)
+            ))
+        ));
     }
 
     #[test]
@@ -1146,7 +1131,12 @@ mod tests {
             },
         );
         assert!(result.is_err());
-        assert!(matches!(result, Err(DatabaseError::PrimaryKeyViolation)));
+        assert!(matches!(
+            result,
+            Err(DatabaseError::Constraint(
+                ConstraintManagerError::PrimaryKeyViolation
+            ))
+        ));
     }
 
     #[test]
@@ -1516,7 +1506,12 @@ mod tests {
         // Should fail
         let result = db.set_foreign_key_constraints("CHILD", fk_constraints);
         assert!(result.is_err());
-        assert!(matches!(result, Err(DatabaseError::ForeignKeyViolation(_))));
+        assert!(matches!(
+            result,
+            Err(DatabaseError::Constraint(
+                ConstraintManagerError::ForeignKeyViolation(_)
+            ))
+        ));
     }
 
     #[test]
@@ -1673,7 +1668,12 @@ mod tests {
         );
 
         assert!(result.is_err());
-        assert!(matches!(result, Err(DatabaseError::CandidateKeyViolation)));
+        assert!(matches!(
+            result,
+            Err(DatabaseError::Constraint(
+                ConstraintManagerError::CandidateKeyViolation
+            ))
+        ));
     }
 
     #[test]
@@ -1731,7 +1731,9 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result,
-            Err(DatabaseError::CheckConstraintViolation(_))
+            Err(DatabaseError::Constraint(
+                ConstraintManagerError::CheckConstraintViolation(_)
+            ))
         ));
     }
 
@@ -1767,7 +1769,9 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result,
-            Err(DatabaseError::CheckConstraintViolation(_))
+            Err(DatabaseError::Constraint(
+                ConstraintManagerError::CheckConstraintViolation(_)
+            ))
         ));
     }
 

--- a/relvar-core/src/lib.rs
+++ b/relvar-core/src/lib.rs
@@ -27,9 +27,9 @@ pub use values::{Relation, ScalarValue, Tuple};
 // Re-export constraint types
 pub use constraints::{
     AttributeConstraints, CandidateKey, CheckConstraint, CheckConstraintError, CheckConstraints,
-    CheckPredicate, CmpOp, ConstraintExpression, ExpressionError, ForeignKey,
-    ForeignKeyConstraints, ForeignKeyError, KeyConstraintError, KeyConstraints, PrimaryKey,
-    TypeConstraint, TypeConstraintError, ValueOrRef,
+    CheckPredicate, CmpOp, ConstraintExpression, ConstraintManagerError, ExpressionError,
+    ForeignKey, ForeignKeyConstraints, ForeignKeyError, KeyConstraintError, KeyConstraints,
+    PrimaryKey, TypeConstraint, TypeConstraintError, ValueOrRef,
 };
 
 // Re-export storage engine types


### PR DESCRIPTION
This PR refactors `DatabaseError` in `relvar-core` to eliminate code duplication and enforce a cleaner error hierarchy. Previously, `DatabaseError` duplicated all variants of `ConstraintManagerError` and flattened them via a manual `From` implementation. The new design nests `ConstraintManagerError` within a `DatabaseError::Constraint` variant.

**Key Changes:**
1.  **`relvar-core/src/database.rs`**:
    *   Removed `PrimaryKeyViolation`, `CandidateKeyViolation`, `ForeignKeyViolation`, `TypeConstraintViolation`, and `CheckConstraintViolation`.
    *   Added `Constraint(#[from] ConstraintManagerError)`.
    *   Removed manual `impl From<ConstraintManagerError> for DatabaseError`.
    *   Updated all test assertions and doc comments to use the nested error structure.
2.  **`relvar-core/src/lib.rs`**:
    *   Added `ConstraintManagerError` to the public re-exports so users can match against specific constraint errors.

**Impact:**
*   **Breaking Change:** Consumers matching on `DatabaseError` variants for constraint violations will need to update their code to match `DatabaseError::Constraint(...)` instead.
*   **Behavior Change:** Infrastructure errors (like `StorageError`) occurring within `ConstraintManager` will now be reported as `DatabaseError::Constraint(ConstraintManagerError::Storage(...))` instead of being flattened to `DatabaseError::Storage(...)`. This correctly attributes the failure context to the constraint management subsystem.


---
*PR created automatically by Jules for task [18076111279519514471](https://jules.google.com/task/18076111279519514471) started by @madmax983*