### PR TITLE
shield: prevent panic/error in AVG aggregation on large sums

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -17,3 +17,7 @@
 ## 2026-05-21 - Silent Data Loss in Rename Collision
 **Learning:** `Relation::rename` handles attribute collisions (multiple attributes renamed to same target) by iterating map entries. Due to `BTreeMap` order, the lexicographically last attribute overwrites earlier ones without warning.
 **Action:** When testing renaming or mapping operations, always verify "collision" scenarios. Document the behavior explicitly in tests to prevent accidental regression if iteration order changes.
+
+## 2026-06-15 - Unnecessary Integer Overflow in Aggregation
+**Learning:** `Avg` aggregation was using `i64` accumulator, causing it to fail on large datasets where the sum exceeds `i64::MAX` even if the average is small.
+**Action:** Use `i128` (or larger type) accumulators for integer aggregations to prevent intermediate overflows.

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -1072,7 +1072,9 @@ mod overflow_tests {
         relation
             .insert(tuple! { id: 1i64, amount: i64::MAX })
             .unwrap();
-        relation.insert(tuple! { id: 2i64, amount: i64::MAX }).unwrap();
+        relation
+            .insert(tuple! { id: 2i64, amount: i64::MAX })
+            .unwrap();
 
         let result = relation.summarize(&[], &[Aggregation::avg("average", "amount")]);
 

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -284,7 +284,7 @@ impl Aggregation {
                 if tuples.is_empty() {
                     return Ok(ScalarValue::Float(0.0));
                 }
-                let mut sum = 0i64;
+                let mut sum = 0i128;
                 for tuple in tuples {
                     let value = tuple.get_typed::<i64>(attr_name).ok_or_else(|| {
                         SummarizeError::AggregationError(format!(
@@ -292,7 +292,7 @@ impl Aggregation {
                             attr_name
                         ))
                     })?;
-                    sum = sum.checked_add(value).ok_or_else(|| {
+                    sum = sum.checked_add(value as i128).ok_or_else(|| {
                         SummarizeError::AggregationError("Integer overflow in AVG".to_string())
                     })?;
                 }
@@ -1061,7 +1061,7 @@ mod overflow_tests {
     }
 
     #[test]
-    fn test_avg_overflow_returns_error() {
+    fn test_avg_handles_large_sums() {
         let heading = TupleType::new()
             .with_attribute("id".to_string(), ScalarType::Int)
             .with_attribute("amount".to_string(), ScalarType::Int);
@@ -1072,20 +1072,14 @@ mod overflow_tests {
         relation
             .insert(tuple! { id: 1i64, amount: i64::MAX })
             .unwrap();
-        relation.insert(tuple! { id: 2i64, amount: 1i64 }).unwrap();
+        relation.insert(tuple! { id: 2i64, amount: i64::MAX }).unwrap();
 
         let result = relation.summarize(&[], &[Aggregation::avg("average", "amount")]);
 
-        assert!(result.is_err(), "Expected overflow error, got Ok");
-        match result {
-            Err(SummarizeError::AggregationError(msg)) => {
-                assert!(
-                    msg.contains("overflow"),
-                    "Expected overflow message, got: {}",
-                    msg
-                );
-            }
-            _ => panic!("Expected AggregationError, got {:?}", result),
-        }
+        assert!(result.is_ok(), "Expected success on large sum average");
+        let result = result.unwrap();
+        let tuple = result.tuples().next().unwrap();
+        // Average of MAX and MAX is MAX
+        assert_eq!(tuple.get_typed::<f64>("average").unwrap(), i64::MAX as f64);
     }
 }


### PR DESCRIPTION
- **Target:** `AggregationFn::Avg` in `relvar-core/src/algebra/summarize.rs`.
- **Risk:** Unnecessary `Err` return when computing average of large integer values due to intermediate sum overflow.
- **Strategy:** Changed accumulator from `i64` to `i128`. Added `test_avg_handles_large_sums` to verify.
- **Verification:** `cargo test` confirms all tests pass, including the new edge case coverage.

---
*PR created automatically by Jules for task [4071125139785390008](https://jules.google.com/task/4071125139785390008) started by @madmax983*