### PR TITLE
🔒 Warden: Fix HeapFile header corruption and DoS vector

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -45,3 +45,11 @@ Added a pre-check `check_tuple_size_limit` using `bincode::serialized_size` on a
 2. Implemented `escape_html` to sanitize strings used in HTML-like labels (replacing `<, >, &, ", '` with entities).
 3. Implemented `escape_dot_string_content` for string literals in labels.
 4. Updated `to_dot` to use these helpers for all user-controlled data.
+
+## 2026-02-04 - HeapFile Header Corruption and DoS
+**Threat:**
+1. `HeapFile::try_insert_into_page` and related methods underestimated the page header size by manually calculating it (`size_of::<u32> + N * size`) instead of using `bincode`'s actual serialization size. `bincode` adds overhead (tags, varint lengths) not accounted for. This caused the header to grow into the tuple data area, leading to silent data corruption (overlap).
+2. The discrepancy between `check_tuple_size_limit` (correctly using bincode) and `try_insert_into_page` (underestimating) could hypothetically lead to infinite loops if `check` passed but `insert` failed with `PageFull` repeatedly on new pages (though in this specific case it caused corruption instead of `PageFull`).
+
+**Defense:**
+Modified insertion logic to clone the page structure, insert a dummy entry into the target slot, and use `bincode::serialized_size` to calculate the exact header requirements before committing the write.

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -317,7 +317,8 @@ impl HeapFile {
         });
 
         let header_size = bincode::serialized_size(&temp_page)
-            .map_err(|e| HeapError::Serialization(e.to_string()))? as usize;
+            .map_err(|e| HeapError::Serialization(e.to_string()))?
+            as usize;
 
         // Add new tuple to the list
         existing_tuples.insert(slot_number as usize, tuple_data.to_vec());
@@ -698,8 +699,8 @@ impl HeapFile {
         });
 
         // Serialize the slot directory to get actual size
-        let slot_dir = bincode::serialize(&temp_page)
-            .map_err(|e| HeapError::Serialization(e.to_string()))?;
+        let slot_dir =
+            bincode::serialize(&temp_page).map_err(|e| HeapError::Serialization(e.to_string()))?;
         let header_size = FORMAT_HEADER_SIZE + slot_dir.len();
 
         // existing_tuples already includes tuple_data, so we just sum existing_tuples
@@ -1087,8 +1088,8 @@ impl HeapFile {
         });
 
         // Serialize the slot directory to get actual size
-        let slot_dir = bincode::serialize(&temp_page)
-            .map_err(|e| HeapError::Serialization(e.to_string()))?;
+        let slot_dir =
+            bincode::serialize(&temp_page).map_err(|e| HeapError::Serialization(e.to_string()))?;
         let header_size = FORMAT_HEADER_SIZE + slot_dir.len();
 
         let total_tuple_data_size: usize =
@@ -3439,20 +3440,25 @@ mod tests {
             // Also verify that the last inserted tuple is valid
             let sp = res.unwrap();
             if let Some(Some(last_slot)) = sp.slots.last() {
-                 // Check for overlap
-                 let slot_dir = bincode::serialize(&sp).unwrap();
-                 // Slot dir is at offset 0.
-                 // Tuple is at last_slot.offset.
-                 // If tuple start < slot_dir end, we have overlap.
-                 if last_slot.offset < slot_dir.len() as u32 {
-                     println!("Overlap detected at insert {}! Offset: {}, Header: {}", i, last_slot.offset, slot_dir.len());
-                     panic!("Overlap detected!");
-                 }
+                // Check for overlap
+                let slot_dir = bincode::serialize(&sp).unwrap();
+                // Slot dir is at offset 0.
+                // Tuple is at last_slot.offset.
+                // If tuple start < slot_dir end, we have overlap.
+                if last_slot.offset < slot_dir.len() as u32 {
+                    println!(
+                        "Overlap detected at insert {}! Offset: {}, Header: {}",
+                        i,
+                        last_slot.offset,
+                        slot_dir.len()
+                    );
+                    panic!("Overlap detected!");
+                }
             }
 
             if page.id() > 0 {
-                 println!("Page split happened at insert {}", i);
-                 break;
+                println!("Page split happened at insert {}", i);
+                break;
             }
         }
     }

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -295,12 +295,6 @@ impl HeapFile {
             sp
         };
 
-        // Calculate required space (account for 8-byte length prefix in page format)
-        const USABLE_PAGE_SIZE: usize = PAGE_SIZE - 8;
-        let slot_entry_size = std::mem::size_of::<SlotEntry>();
-        let header_size =
-            std::mem::size_of::<u32>() + (slotted_page.slots.len() + 1) * slot_entry_size;
-
         // Find free slot or add new one
         let slot_number = if let Some(pos) = slotted_page.slots.iter().position(|s| s.is_none()) {
             pos as u32
@@ -310,6 +304,20 @@ impl HeapFile {
             slotted_page.slot_count += 1;
             new_slot
         };
+
+        // Calculate required space (account for 8-byte length prefix in page format)
+        const USABLE_PAGE_SIZE: usize = PAGE_SIZE - 8;
+
+        // Calculate exact header size using bincode (to account for Vec length and Option overhead)
+        // We must assume the target slot is occupied (Some) to reserve enough space
+        let mut temp_page = slotted_page.clone();
+        temp_page.slots[slot_number as usize] = Some(SlotEntry {
+            offset: 0,
+            length: 0,
+        });
+
+        let header_size = bincode::serialized_size(&temp_page)
+            .map_err(|e| HeapError::Serialization(e.to_string()))? as usize;
 
         // Add new tuple to the list
         existing_tuples.insert(slot_number as usize, tuple_data.to_vec());
@@ -678,8 +686,19 @@ impl HeapFile {
         const USABLE_PAGE_SIZE: usize = PAGE_SIZE - 8;
         const FORMAT_HEADER_SIZE: usize = 5; // 1 byte version + 4 bytes length
 
+        // We must assume the target slot is occupied (Some) to reserve enough space
+        // because we will fill it with metadata later
+        let mut temp_page = versioned_page.clone();
+        temp_page.slots[slot_number as usize] = Some(VersionedSlotEntry {
+            offset: 0,
+            length: 0,
+            xmin: txn_id,
+            xmax: None,
+            prev_version: None,
+        });
+
         // Serialize the slot directory to get actual size
-        let slot_dir = bincode::serialize(&versioned_page)
+        let slot_dir = bincode::serialize(&temp_page)
             .map_err(|e| HeapError::Serialization(e.to_string()))?;
         let header_size = FORMAT_HEADER_SIZE + slot_dir.len();
 
@@ -1043,12 +1062,32 @@ impl HeapFile {
             vp
         };
 
+        // Find free slot or add new one
+        let slot_number = if let Some(pos) = versioned_page.slots.iter().position(|s| s.is_none()) {
+            pos as u32
+        } else {
+            let new_slot = versioned_page.slots.len() as u32;
+            versioned_page.slots.push(None);
+            versioned_page.slot_count += 1;
+            new_slot
+        };
+
         // Calculate required space using ACTUAL serialized size
         const USABLE_PAGE_SIZE: usize = PAGE_SIZE - 8;
         const FORMAT_HEADER_SIZE: usize = 5; // 1 byte version + 4 bytes length
 
+        // We must assume the target slot is occupied (Some) to reserve enough space
+        let mut temp_page = versioned_page.clone();
+        temp_page.slots[slot_number as usize] = Some(VersionedSlotEntry {
+            offset: 0,
+            length: 0,
+            xmin: txn_id,
+            xmax: None,
+            prev_version: Some(prev_version),
+        });
+
         // Serialize the slot directory to get actual size
-        let slot_dir = bincode::serialize(&versioned_page)
+        let slot_dir = bincode::serialize(&temp_page)
             .map_err(|e| HeapError::Serialization(e.to_string()))?;
         let header_size = FORMAT_HEADER_SIZE + slot_dir.len();
 
@@ -1059,16 +1098,6 @@ impl HeapFile {
         if required_space > USABLE_PAGE_SIZE {
             return Err(HeapError::PageFull);
         }
-
-        // Find free slot or add new one
-        let slot_number = if let Some(pos) = versioned_page.slots.iter().position(|s| s.is_none()) {
-            pos as u32
-        } else {
-            let new_slot = versioned_page.slots.len() as u32;
-            versioned_page.slots.push(None);
-            versioned_page.slot_count += 1;
-            new_slot
-        };
 
         // Add new tuple to the list
         existing_tuples.insert(slot_number as usize, tuple_data.to_vec());
@@ -3376,6 +3405,55 @@ mod tests {
                 assert_eq!(msg, "Versioned page too short to contain header");
             }
             _ => panic!("Expected specific Serialization error, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_heap_header_corruption() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+
+        // Create a relation type
+        let heading = TupleType::new().with_attribute("id", ScalarType::Int);
+        let rel_type = RelationType::new(heading);
+
+        let mut heap = HeapFile::create(path, rel_type).unwrap();
+
+        // We want to insert many small tuples to increase N (number of slots).
+        // Discrepancy D = N bytes.
+        // We want to fill the page such that we are just on the edge.
+
+        for i in 0..1000 {
+            let t = tuple! { id: i as i64 };
+            heap.insert_tuple(&t).unwrap();
+
+            // Read page 0
+            let page = heap.page_file.read_page(0).unwrap();
+            // Try to deserialize
+            let res = heap.deserialize_slotted_page(&page);
+            if res.is_err() {
+                println!("Corruption detected at insert {}!", i);
+                panic!("Corruption detected: {:?}", res.err());
+            }
+
+            // Also verify that the last inserted tuple is valid
+            let sp = res.unwrap();
+            if let Some(Some(last_slot)) = sp.slots.last() {
+                 // Check for overlap
+                 let slot_dir = bincode::serialize(&sp).unwrap();
+                 // Slot dir is at offset 0.
+                 // Tuple is at last_slot.offset.
+                 // If tuple start < slot_dir end, we have overlap.
+                 if last_slot.offset < slot_dir.len() as u32 {
+                     println!("Overlap detected at insert {}! Offset: {}, Header: {}", i, last_slot.offset, slot_dir.len());
+                     panic!("Overlap detected!");
+                 }
+            }
+
+            if page.id() > 0 {
+                 println!("Page split happened at insert {}", i);
+                 break;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes a critical data corruption vulnerability in the `HeapFile` storage engine.

### The Vulnerability
The `HeapFile` implementation manually estimated the size of the page header (slot directory) using `size_of::<u32> + N * size_of::<SlotEntry>`. However, `bincode` serialization adds overhead (e.g., `Option` tags, variable-length integer encoding for `Vec` lengths) that was not accounted for.

As the number of slots increased (e.g., many small tuples), the actual serialized header size would exceed the estimated size. Since tuples are written growing backwards from the end of the page, the growing header would eventually overlap with the tuple data, causing silent data corruption.

### The Fix
The insertion logic in `insert_tuple` (and MVCC variants) has been updated to:
1. Clone the page structure.
2. Insert a dummy `Some` entry into the target slot (to account for the full size of a populated slot).
3. Use `bincode::serialized_size` to calculate the *exact* space required by the header.
4. Verify this exact size against available space.

This ensures that we never commit a write that would cause the header and tuple data to overlap.

### Verification
A new regression test `storage::heap::tests::test_heap_header_corruption` was added.
- Before fix: Panicked with "Corruption detected" or "Overlap detected".
- After fix: Passes successfully.

All existing tests in `relvar-storage` also pass.

---
*PR created automatically by Jules for task [4062092713865814690](https://jules.google.com/task/4062092713865814690) started by @madmax983*