### PR TITLE
🔒 Warden: Fix virtual relvar recursion and verify heap deserialization

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -53,3 +53,11 @@ Added a pre-check `check_tuple_size_limit` using `bincode::serialized_size` on a
 
 **Defense:**
 Modified insertion logic to clone the page structure, insert a dummy entry into the target slot, and use `bincode::serialized_size` to calculate the exact header requirements before committing the write.
+
+## 2024-05-23 - [Recursion Limit Exceeded in Virtual Relvars]
+**Threat:** Infinite recursion in virtual relvar definitions (views) could cause a stack overflow and crash the database process (Denial of Service).
+**Defense:** Added recursion detection in `Database::query` by tracking currently evaluating virtual relvars in a stack. Returns `DatabaseError::RecursionLimitExceeded` if a cycle is detected.
+
+## 2024-05-23 - [Potential Allocation Bomb in Heap File Deserialization]
+**Threat:** Maliciously crafted heap pages with large vector lengths could cause massive memory allocation attempts during deserialization (DoS).
+**Defense:** Verified that `bincode` 1.3.3 correctly handles slice inputs by checking `len * min_size`, preventing allocation if data is insufficient. Added regression test `relvar-storage/tests/security_exploit.rs`.

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -474,11 +474,10 @@ impl<E: StorageEngine> Database<E> {
 
         // Check if this is a virtual relvar
         // We need to extract the evaluator to avoid borrowing self immutably while calling it mutably
-        let evaluator = if let Some(virtual_relvar) = self.virtual_relvars.get(relation_name) {
-            Some(virtual_relvar.evaluator)
-        } else {
-            None
-        };
+        let evaluator = self
+            .virtual_relvars
+            .get(relation_name)
+            .map(|virtual_relvar| virtual_relvar.evaluator);
 
         if let Some(evaluator) = evaluator {
             self.evaluating_relvars.push(relation_name.to_string());

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -13,6 +13,7 @@ use crate::values::relation::RelationError;
 use crate::values::{Relation, Tuple};
 
 use std::collections::HashMap;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use thiserror::Error;
 
 /// Errors that can occur during database operations.
@@ -61,6 +62,10 @@ pub enum DatabaseError {
     /// The attribute does not exist.
     #[error("Attribute {0} not found in relation {1}")]
     AttributeNotFound(String, String),
+
+    /// Recursion limit exceeded for virtual relvar.
+    #[error("Recursion limit exceeded for virtual relvar {0}")]
+    RecursionLimitExceeded(String),
 }
 
 /// Definition of a virtual relvar (view).
@@ -116,6 +121,8 @@ pub struct Database<E: StorageEngine> {
     transaction_snapshot: Option<E::Snapshot>,
     /// Virtual relvars defined by expressions.
     virtual_relvars: HashMap<String, VirtualRelvarDefinition<E>>,
+    /// Stack of currently evaluating virtual relvars to detect recursion.
+    evaluating_relvars: Vec<String>,
 }
 
 impl<E: StorageEngine> Database<E> {
@@ -127,6 +134,7 @@ impl<E: StorageEngine> Database<E> {
             in_transaction: false,
             transaction_snapshot: None,
             virtual_relvars: HashMap::new(),
+            evaluating_relvars: Vec::new(),
         }
     }
 
@@ -457,9 +465,36 @@ impl<E: StorageEngine> Database<E> {
     ///
     /// Returns `DatabaseError::RelationNotFound` if the relation doesn't exist.
     pub fn query(&mut self, relation_name: &str) -> Result<Relation, DatabaseError> {
+        // Check for recursion
+        if self.evaluating_relvars.contains(&relation_name.to_string()) {
+            return Err(DatabaseError::RecursionLimitExceeded(
+                relation_name.to_string(),
+            ));
+        }
+
         // Check if this is a virtual relvar
-        if let Some(virtual_relvar) = self.virtual_relvars.get(relation_name) {
-            return (virtual_relvar.evaluator)(self);
+        // We need to extract the evaluator to avoid borrowing self immutably while calling it mutably
+        let evaluator = if let Some(virtual_relvar) = self.virtual_relvars.get(relation_name) {
+            Some(virtual_relvar.evaluator)
+        } else {
+            None
+        };
+
+        if let Some(evaluator) = evaluator {
+            self.evaluating_relvars.push(relation_name.to_string());
+
+            // Use catch_unwind to ensure we pop from the stack even if the evaluator panics.
+            // We use AssertUnwindSafe because we want to maintain the evaluating_relvars invariant
+            // even if other parts of the Database are left in an inconsistent state by a panic.
+            let result = catch_unwind(AssertUnwindSafe(|| evaluator(self)));
+
+            let popped = self.evaluating_relvars.pop();
+            debug_assert_eq!(popped.as_deref(), Some(relation_name));
+
+            match result {
+                Ok(r) => return r,
+                Err(payload) => std::panic::resume_unwind(payload),
+            }
         }
 
         // Otherwise, load from engine

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -13,7 +13,7 @@ use crate::values::relation::RelationError;
 use crate::values::{Relation, Tuple};
 
 use std::collections::HashMap;
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use thiserror::Error;
 
 /// Errors that can occur during database operations.

--- a/relvar-core/tests/virtual_recursion.rs
+++ b/relvar-core/tests/virtual_recursion.rs
@@ -1,0 +1,35 @@
+use relvar_core::database::Database;
+use relvar_core::storage_engine::InMemoryEngine;
+use relvar_core::types::{RelationType, TupleType};
+use relvar_core::database::DatabaseError;
+
+#[test]
+fn test_virtual_relvar_infinite_recursion() {
+    let mut db = Database::new(InMemoryEngine::new());
+
+    // Define virtual relvar "A" that queries "B"
+    db.define_virtual_relvar(
+        "A",
+        RelationType::new(TupleType::new()),
+        |db| db.query("B")
+    ).unwrap();
+
+    // Define virtual relvar "B" that queries "A"
+    db.define_virtual_relvar(
+        "B",
+        RelationType::new(TupleType::new()),
+        |db| db.query("A")
+    ).unwrap();
+
+    // This should return RecursionLimitExceeded instead of crashing
+    let result = db.query("A");
+    assert!(result.is_err());
+
+    match result {
+        Err(DatabaseError::RecursionLimitExceeded(name)) => {
+            // "A" calls "B", "B" calls "A". Recursion detected at "A" (second time) or "B" depending on impl
+            assert!(name == "A" || name == "B");
+        }
+        _ => panic!("Expected RecursionLimitExceeded, got {:?}", result),
+    }
+}

--- a/relvar-core/tests/virtual_recursion.rs
+++ b/relvar-core/tests/virtual_recursion.rs
@@ -1,25 +1,19 @@
 use relvar_core::database::Database;
+use relvar_core::database::DatabaseError;
 use relvar_core::storage_engine::InMemoryEngine;
 use relvar_core::types::{RelationType, TupleType};
-use relvar_core::database::DatabaseError;
 
 #[test]
 fn test_virtual_relvar_infinite_recursion() {
     let mut db = Database::new(InMemoryEngine::new());
 
     // Define virtual relvar "A" that queries "B"
-    db.define_virtual_relvar(
-        "A",
-        RelationType::new(TupleType::new()),
-        |db| db.query("B")
-    ).unwrap();
+    db.define_virtual_relvar("A", RelationType::new(TupleType::new()), |db| db.query("B"))
+        .unwrap();
 
     // Define virtual relvar "B" that queries "A"
-    db.define_virtual_relvar(
-        "B",
-        RelationType::new(TupleType::new()),
-        |db| db.query("A")
-    ).unwrap();
+    db.define_virtual_relvar("B", RelationType::new(TupleType::new()), |db| db.query("A"))
+        .unwrap();
 
     // This should return RecursionLimitExceeded instead of crashing
     let result = db.query("A");

--- a/relvar-storage/tests/security_exploit.rs
+++ b/relvar-storage/tests/security_exploit.rs
@@ -1,0 +1,60 @@
+use relvar_core::{tuple, types::{RelationType, ScalarType, TupleType}};
+use relvar_storage::storage::{HeapFile, PAGE_SIZE};
+use std::io::{Read, Write, Seek, SeekFrom};
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_exploit_allocation_bomb() {
+    let temp_file = NamedTempFile::new().unwrap();
+    let path = temp_file.path();
+
+    // Create a valid heap file first
+    let heading = TupleType::new().with_attribute("id", ScalarType::Int);
+    let rel_type = RelationType::new(heading);
+    {
+        let mut heap = HeapFile::create(path, rel_type.clone()).unwrap();
+        heap.insert_tuple(&tuple! { id: 1i64 }).unwrap();
+    }
+
+    // Now corrupt the page to have a huge slot count
+    // The page format is [slot_count: u32][slots...]
+    // We'll write u32::MAX as slot_count
+
+    // Read the page
+    let mut file = std::fs::OpenOptions::new().read(true).write(true).open(path).unwrap();
+    let mut buffer = vec![0u8; PAGE_SIZE];
+    file.seek(SeekFrom::Start(0)).unwrap();
+    file.read_exact(&mut buffer).unwrap();
+
+    // Skip the 8-byte length prefix (page header)
+    // The actual data starts at offset 8
+
+    // SlottedPage starts with slot_count (u32)
+    // We want to overwrite this with a huge value
+    // But wait, SlottedPage is serialized with bincode.
+    // Struct: { slot_count: u32, slots: Vec<Option<SlotEntry>> }
+    // Serialization: [slot_count][slots_len (u64)][slots data...]
+
+    // So we need to overwrite the `slots_len` (u64) which comes after `slot_count` (u32).
+    // offset 8 (page len) + 4 (slot_count) = 12.
+
+    let huge_len: u64 = 1_000_000_000; // 1 billion slots
+    let len_bytes = huge_len.to_le_bytes();
+
+    // Write at offset 12
+    buffer[12..20].copy_from_slice(&len_bytes);
+
+    // Write back to file
+    file.seek(SeekFrom::Start(0)).unwrap();
+    file.write_all(&buffer).unwrap();
+
+    // Now try to open and scan
+    let mut heap = HeapFile::open(path, rel_type).unwrap();
+
+    // This should fail gracefully, NOT panic or OOM
+    let result = heap.scan();
+
+    assert!(result.is_err(), "Scan should fail on corrupted page");
+
+    // If it panics (OOM), the test runner will catch it and fail the test
+}

--- a/relvar-storage/tests/security_exploit.rs
+++ b/relvar-storage/tests/security_exploit.rs
@@ -1,6 +1,9 @@
-use relvar_core::{tuple, types::{RelationType, ScalarType, TupleType}};
+use relvar_core::{
+    tuple,
+    types::{RelationType, ScalarType, TupleType},
+};
 use relvar_storage::storage::{HeapFile, PAGE_SIZE};
-use std::io::{Read, Write, Seek, SeekFrom};
+use std::io::{Read, Seek, SeekFrom, Write};
 use tempfile::NamedTempFile;
 
 #[test]
@@ -21,7 +24,11 @@ fn test_exploit_allocation_bomb() {
     // We'll write u32::MAX as slot_count
 
     // Read the page
-    let mut file = std::fs::OpenOptions::new().read(true).write(true).open(path).unwrap();
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .unwrap();
     let mut buffer = vec![0u8; PAGE_SIZE];
     file.seek(SeekFrom::Start(0)).unwrap();
     file.read_exact(&mut buffer).unwrap();


### PR DESCRIPTION
This PR addresses two potential Denial of Service (DoS) vulnerabilities:

1.  **Infinite Recursion in Virtual Relvars:**
    Virtual relvars (views) could define recursive dependencies (e.g., A calls B, B calls A), leading to a stack overflow crash.
    *   **Fix:** Added `evaluating_relvars` stack to `Database` to track currently evaluating views. If a cycle is detected, `DatabaseError::RecursionLimitExceeded` is returned.
    *   **Panic Safety:** The evaluation is wrapped in `std::panic::catch_unwind` to ensure the recursion stack is correctly popped even if the evaluator panics, preventing the `Database` instance from being permanently locked in a "recursion detected" state for that relvar.

2.  **Heap File Allocation Bomb:**
    A malicious heap page could declare a massive vector length, potentially causing OOM.
    *   **Verification:** Added a regression test verifying that `bincode` (v1.3.3) correctly validates input size against declared length for `Vec` deserialization, returning an error instead of allocating. No code change was needed in `relvar-storage` as the library already handles this safely for slice inputs.

**Tests:**
- `relvar-core/tests/virtual_recursion.rs`: Verifies recursion is caught and returns error.
- `relvar-storage/tests/security_exploit.rs`: Verifies massive allocation attempts fail gracefully.

---
*PR created automatically by Jules for task [2685442962747451948](https://jules.google.com/task/2685442962747451948) started by @madmax983*