### PR TITLE
🛡️ Sentry: Add TTM edge case tests for Project and Join operators

### DIFF
--- a/relvar-core/src/algebra/join.rs
+++ b/relvar-core/src/algebra/join.rs
@@ -509,4 +509,41 @@ mod tests {
             1
         );
     }
+
+    /// Verifies behavior when colliding attributes have DIFFERENT types.
+    ///
+    /// Even if types mismatch, the second attribute is dropped, and the result
+    /// retains the type and value of the first attribute. This ensures no
+    /// type confusion or panic occurs during tuple construction.
+    #[test]
+    fn test_theta_join_colliding_attributes_different_types() {
+        // Relation 1: id=1 (Int)
+        let heading1 = TupleType::new().with_attribute("id", ScalarType::Int);
+        let mut rel1 = Relation::new(RelationType::new(heading1));
+        rel1.insert(tuple! { id: 1i64 }).unwrap();
+
+        // Relation 2: id="2" (String) - Same name, different type
+        let heading2 = TupleType::new().with_attribute("id", ScalarType::String);
+        let mut rel2 = Relation::new(RelationType::new(heading2));
+        rel2.insert(tuple! { id: "2" }).unwrap();
+
+        // Theta join
+        let result = rel1.theta_join(&rel2, |_, _| true);
+
+        // Result should have 'id' as Int (from rel1)
+        assert_eq!(result.degree(), 1);
+        let tuple = result.tuples().next().unwrap();
+
+        // Should be able to get as Int
+        assert_eq!(tuple.get_typed::<i64>("id").unwrap(), 1);
+
+        // Should NOT be able to get as String
+        assert!(tuple.get_typed::<String>("id").is_none());
+
+        // Verify type in heading
+        assert_eq!(
+            result.relation_type().heading().get_attribute_type("id"),
+            Some(&ScalarType::Int)
+        );
+    }
 }

--- a/relvar-core/src/algebra/project.rs
+++ b/relvar-core/src/algebra/project.rs
@@ -219,4 +219,66 @@ mod tests {
         assert_eq!(result.degree(), 1);
         assert_eq!(result.cardinality(), 2);
     }
+
+    /// Verifies TTM behavior for TABLE_DEE (empty heading, 1 tuple)
+    ///
+    /// When projecting a non-empty relation onto an empty set of attributes,
+    /// the result should be a relation with degree 0 and cardinality 1.
+    /// This is equivalent to TABLE_DEE (Boolean TRUE).
+    #[test]
+    fn test_project_empty_attributes_creates_table_dee() {
+        let heading = TupleType::new()
+            .with_attribute("emp_id", ScalarType::Int)
+            .with_attribute("name", ScalarType::String);
+
+        let rel_type = RelationType::new(heading);
+        let mut relation = Relation::new(rel_type);
+
+        relation
+            .insert(tuple! { emp_id: 1i64, name: "Alice" })
+            .unwrap();
+        relation
+            .insert(tuple! { emp_id: 2i64, name: "Bob" })
+            .unwrap();
+
+        // Project onto empty set of attributes
+        let result = relation.project(&[]);
+
+        // Should have degree 0 (no attributes)
+        assert_eq!(result.degree(), 0);
+
+        // Should have cardinality 1 (one empty tuple)
+        // Since {Alice} becomes {} and {Bob} becomes {}, they are duplicates
+        // and reduced to a single {}.
+        assert_eq!(result.cardinality(), 1);
+
+        // Verify the single tuple is empty
+        let tuple = result.tuples().next().unwrap();
+        assert_eq!(tuple.degree(), 0);
+    }
+
+    /// Verifies TTM behavior for TABLE_DUM (empty heading, 0 tuples)
+    ///
+    /// When projecting an empty relation onto an empty set of attributes,
+    /// the result should be a relation with degree 0 and cardinality 0.
+    /// This is equivalent to TABLE_DUM (Boolean FALSE).
+    #[test]
+    fn test_project_empty_attributes_on_empty_relation_creates_table_dum() {
+        let heading = TupleType::new()
+            .with_attribute("emp_id", ScalarType::Int)
+            .with_attribute("name", ScalarType::String);
+
+        let rel_type = RelationType::new(heading);
+        let relation = Relation::new(rel_type);
+
+        // Project onto empty set of attributes
+        let result = relation.project(&[]);
+
+        // Should have degree 0
+        assert_eq!(result.degree(), 0);
+
+        // Should have cardinality 0
+        assert_eq!(result.cardinality(), 0);
+        assert!(result.is_empty());
+    }
 }


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target: `relvar-core/src/algebra/project.rs` and `relvar-core/src/algebra/join.rs`
💣 Risk:
  - `project`: Incorrect handling of empty attribute sets could lead to invalid relations (e.g., empty relation instead of TABLE_DEE), violating relational algebra closure.
  - `theta_join`: Colliding attributes with different types could cause type confusion or panics during tuple construction if the wrong attribute is retained or if values are mixed up.
🧪 Strategy:
  - Added unit tests for TABLE_DEE and TABLE_DUM generation via projection.
  - Added a unit test for `theta_join` with colliding attributes of different types (Int vs String).
🔬 Verification:
  - Run `cargo test algebra::project::tests::test_project_empty_attributes`
  - Run `cargo test algebra::join::tests::test_theta_join_colliding_attributes_different_types`


---
*PR created automatically by Jules for task [1868306843203681898](https://jules.google.com/task/1868306843203681898) started by @madmax983*