### PR TITLE
Simplify constraint system and remove dynamic predicates

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -22,3 +22,18 @@
 **Bloat:** `relvar/src/experimental/exporter.rs` - `Exporter` struct was a "Factory Factory" / unnecessary wrapper around `Relation` just to call methods.
 **Cut:** Refactored into free functions (`to_csv`, `to_json`, `to_ascii_table`).
 **Saved:** Simplified API (no need to instantiate `Exporter`), reduced boilerplate.
+
+## [Reduction]
+**Bloat:** `CheckPredicate::Dynamic` and `TypeConstraint::Custom` (closure-based validation)
+**Cut:** Removed dynamic predicates; enforced strictly declarative, serializable constraints.
+**Saved:** Removed "Zombie Code" path that couldn't be persisted, simplified `CheckConstraint` struct.
+
+## [Reduction]
+**Bloat:** `ConstraintExpression` variants (`Eq`, `Ne`, `Lt`, `Le`, `Gt`, `Ge`, `AttrCmp`, `Between`)
+**Cut:** Consolidated into a single `Cmp` variant and removed `Between` (syntactic sugar).
+**Saved:** Reduced 8 variants to 1, significantly simplifying evaluation logic and DRY.
+
+## [Reduction]
+**Bloat:** `TypeConstraint::PositiveInt` and `NonNegativeInt`
+**Cut:** Replaced with `Range`.
+**Saved:** Removed redundant enum variants.

--- a/relvar-core/src/constraints/check.rs
+++ b/relvar-core/src/constraints/check.rs
@@ -13,19 +13,20 @@
 //! # Example
 //!
 //! ```
-//! use relvar_core::constraints::check::{CheckConstraint, CheckPredicate};
-//! use relvar_core::constraints::expression::{ConstraintExpression, ValueOrRef};
+//! use relvar_core::constraints::check::CheckConstraint;
+//! use relvar_core::constraints::expression::{ConstraintExpression, CmpOp, ValueOrRef};
 //! use relvar_core::values::ScalarValue;
 //! use relvar_core::tuple;
 //!
 //! // Create a CHECK constraint using an expression
-//! let constraint = CheckConstraint::from_expression(
+//! let constraint = CheckConstraint::new(
 //!     "positive_salary",
 //!     "Salary must be positive",
-//!     ConstraintExpression::Gt(
-//!         "salary".to_string(),
-//!         ValueOrRef::Value(ScalarValue::Int(0)),
-//!     ),
+//!     ConstraintExpression::Cmp {
+//!         left: "salary".to_string(),
+//!         op: CmpOp::Gt,
+//!         right: ValueOrRef::Value(ScalarValue::Int(0)),
+//!     },
 //! );
 //!
 //! let valid_tuple = tuple! { salary: 50000i64 };
@@ -37,6 +38,7 @@
 
 use crate::constraints::expression::ConstraintExpression;
 use crate::values::Tuple;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Errors that can occur during CHECK constraint evaluation.
@@ -56,123 +58,58 @@ pub enum CheckConstraintError {
     EvaluationError(String),
 }
 
-/// Predicate type for CHECK constraints.
-///
-/// Supports both closure-based (flexible, not serializable) and
-/// expression-based (serializable, persistent) predicates.
-pub enum CheckPredicate {
-    /// Closure-based predicate (not serializable).
-    ///
-    /// Use for complex business logic that can't be expressed in the DSL.
-    /// Must be re-registered on database restart.
-    Dynamic(Box<dyn Fn(&Tuple) -> bool + Send + Sync>),
-
-    /// Expression-based predicate (serializable).
-    ///
-    /// Can be persisted to storage and loaded on restart.
-    Expression(Box<ConstraintExpression>),
-}
-
-impl std::fmt::Debug for CheckPredicate {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CheckPredicate::Dynamic(_) => write!(f, "Dynamic(<closure>)"),
-            CheckPredicate::Expression(expr) => write!(f, "Expression({:?})", expr),
-        }
-    }
-}
-
 /// A CHECK constraint that must be satisfied by every tuple in a relvar.
 ///
 /// CHECK constraints are tuple-level constraints that enforce business rules
 /// on individual tuples. They are checked on INSERT and UPDATE operations.
 ///
-/// # Example
-///
-/// ```
-/// use relvar_core::constraints::check::CheckConstraint;
-/// use relvar_core::tuple;
-///
-/// let constraint = CheckConstraint::from_closure(
-///     "positive_salary",
-///     "Salary must be positive",
-///     |tuple| {
-///         tuple.get("salary")
-///             .map(|v| matches!(v, relvar_core::values::ScalarValue::Int(n) if *n > 0))
-///             .unwrap_or(false)
-///     }
-/// );
-///
-/// let valid = tuple! { name: "Alice", salary: 50000i64 };
-/// assert!(constraint.is_satisfied_by(&valid).unwrap());
-/// ```
-#[derive(Debug)]
+/// Constraints are defined using declarative expressions ([`ConstraintExpression`]),
+/// ensuring they can be serialized and persisted in the system catalog.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckConstraint {
     /// Constraint name (unique identifier).
     name: String,
-    /// The predicate to evaluate.
-    predicate: CheckPredicate,
+    /// The expression to evaluate.
+    expression: ConstraintExpression,
     /// Human-readable description.
     description: String,
 }
 
 impl CheckConstraint {
-    /// Creates a CHECK constraint from a closure.
+    /// Creates a new CHECK constraint from an expression.
     ///
     /// # Example
     ///
     /// ```
     /// use relvar_core::constraints::check::CheckConstraint;
+    /// use relvar_core::constraints::expression::{ConstraintExpression, CmpOp, ValueOrRef};
     /// use relvar_core::values::ScalarValue;
     ///
-    /// let constraint = CheckConstraint::from_closure(
-    ///     "positive_balance",
-    ///     "Balance must be non-negative",
-    ///     |tuple| {
-    ///         tuple.get("balance")
-    ///             .map(|v| matches!(v, ScalarValue::Int(n) if *n >= 0))
-    ///             .unwrap_or(false)
-    ///     }
-    /// );
-    /// ```
-    pub fn from_closure<F>(name: impl Into<String>, description: impl Into<String>, f: F) -> Self
-    where
-        F: Fn(&Tuple) -> bool + Send + Sync + 'static,
-    {
-        Self {
-            name: name.into(),
-            predicate: CheckPredicate::Dynamic(Box::new(f)),
-            description: description.into(),
-        }
-    }
-
-    /// Creates a CHECK constraint from an expression.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use relvar_core::constraints::check::CheckConstraint;
-    /// use relvar_core::constraints::expression::{ConstraintExpression, ValueOrRef};
-    /// use relvar_core::values::ScalarValue;
-    ///
-    /// let constraint = CheckConstraint::from_expression(
+    /// let constraint = CheckConstraint::new(
     ///     "valid_age",
     ///     "Age must be between 0 and 150",
-    ///     ConstraintExpression::Between(
-    ///         "age".to_string(),
-    ///         ScalarValue::Int(0),
-    ///         ScalarValue::Int(150),
+    ///     ConstraintExpression::And(
+    ///         Box::new(ConstraintExpression::Cmp {
+    ///             left: "age".to_string(),
+    ///             op: CmpOp::Ge,
+    ///             right: ValueOrRef::Value(ScalarValue::Int(0)),
+    ///         }),
+    ///         Box::new(ConstraintExpression::Cmp {
+    ///             left: "age".to_string(),
+    ///             op: CmpOp::Le,
+    ///             right: ValueOrRef::Value(ScalarValue::Int(150)),
+    ///         }),
     ///     ),
     /// );
     /// ```
-    pub fn from_expression(
+    pub fn new(
         name: impl Into<String>,
         description: impl Into<String>,
-        expr: ConstraintExpression,
+        expression: ConstraintExpression,
     ) -> Self {
         Self {
             name: name.into(),
-            predicate: CheckPredicate::Expression(Box::new(expr)),
+            expression,
             description: description.into(),
         }
     }
@@ -187,23 +124,20 @@ impl CheckConstraint {
         &self.description
     }
 
-    /// Returns true if this constraint is serializable (expression-based).
-    pub fn is_serializable(&self) -> bool {
-        matches!(self.predicate, CheckPredicate::Expression(_))
+    /// Returns the constraint expression.
+    pub fn expression(&self) -> &ConstraintExpression {
+        &self.expression
     }
 
     /// Checks if this constraint is satisfied by the given tuple.
     ///
     /// # Errors
     ///
-    /// Returns `Err` if the constraint evaluation fails.
+    /// Returns `Err` if the constraint evaluation fails (e.g. type mismatch).
     pub fn is_satisfied_by(&self, tuple: &Tuple) -> Result<bool, CheckConstraintError> {
-        match &self.predicate {
-            CheckPredicate::Dynamic(f) => Ok(f(tuple)),
-            CheckPredicate::Expression(expr) => (**expr)
-                .evaluate(tuple)
-                .map_err(|e| CheckConstraintError::EvaluationError(e.to_string())),
-        }
+        self.expression
+            .evaluate(tuple)
+            .map_err(|e| CheckConstraintError::EvaluationError(e.to_string()))
     }
 }
 
@@ -211,7 +145,7 @@ impl CheckConstraint {
 ///
 /// This manages multiple CHECK constraints and provides methods to check
 /// if all constraints are satisfied by a tuple.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct CheckConstraints {
     constraints: Vec<CheckConstraint>,
 }
@@ -236,7 +170,7 @@ impl CheckConstraints {
     ///
     /// # Errors
     ///
-    /// Returns `Err` with the first violated constraint.
+    /// Returns `Err` with the first violated constraint or evaluation error.
     pub fn are_all_satisfied_by(&self, tuple: &Tuple) -> Result<bool, CheckConstraintError> {
         for constraint in &self.constraints {
             if !constraint.is_satisfied_by(tuple)? {
@@ -249,73 +183,45 @@ impl CheckConstraints {
         Ok(true)
     }
 
-    /// Returns only the serializable (expression-based) constraints.
-    ///
-    /// Useful for persistence - closure-based constraints cannot be serialized.
-    pub fn serializable_constraints(&self) -> Vec<&CheckConstraint> {
-        self.constraints
-            .iter()
-            .filter(|c| c.is_serializable())
-            .collect()
+    /// Returns all constraints.
+    pub fn constraints(&self) -> &[CheckConstraint] {
+        &self.constraints
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::constraints::expression::{ConstraintExpression, ValueOrRef};
+    use crate::constraints::expression::{CmpOp, ConstraintExpression, ValueOrRef};
     use crate::tuple;
     use crate::values::ScalarValue;
 
     #[test]
-    fn test_check_constraint_from_closure() {
-        let constraint =
-            CheckConstraint::from_closure("positive_salary", "Salary must be positive", |tuple| {
-                tuple
-                    .get("salary")
-                    .map(|v| matches!(v, ScalarValue::Int(n) if *n > 0))
-                    .unwrap_or(false)
-            });
-
-        assert_eq!(constraint.name(), "positive_salary");
-        assert!(!constraint.is_serializable());
-    }
-
-    #[test]
-    fn test_check_constraint_from_expression() {
-        let constraint = CheckConstraint::from_expression(
+    fn test_check_constraint_creation() {
+        let constraint = CheckConstraint::new(
             "positive_salary",
             "Salary must be positive",
-            ConstraintExpression::Gt("salary".to_string(), ValueOrRef::Value(ScalarValue::Int(0))),
+            ConstraintExpression::Cmp {
+                left: "salary".to_string(),
+                op: CmpOp::Gt,
+                right: ValueOrRef::Value(ScalarValue::Int(0)),
+            },
         );
 
         assert_eq!(constraint.name(), "positive_salary");
-        assert!(constraint.is_serializable());
+        assert_eq!(constraint.description(), "Salary must be positive");
     }
 
     #[test]
-    fn test_check_constraint_dynamic_satisfied() {
-        let constraint =
-            CheckConstraint::from_closure("positive_salary", "Salary must be positive", |tuple| {
-                tuple
-                    .get("salary")
-                    .map(|v| matches!(v, ScalarValue::Int(n) if *n > 0))
-                    .unwrap_or(false)
-            });
-
-        let good_tuple = tuple! { name: "Alice", salary: 50000i64 };
-        assert!(constraint.is_satisfied_by(&good_tuple).unwrap());
-
-        let bad_tuple = tuple! { name: "Bob", salary: -100i64 };
-        assert!(!constraint.is_satisfied_by(&bad_tuple).unwrap());
-    }
-
-    #[test]
-    fn test_check_constraint_expression_satisfied() {
-        let constraint = CheckConstraint::from_expression(
+    fn test_check_constraint_satisfied() {
+        let constraint = CheckConstraint::new(
             "positive_salary",
             "Salary must be positive",
-            ConstraintExpression::Gt("salary".to_string(), ValueOrRef::Value(ScalarValue::Int(0))),
+            ConstraintExpression::Cmp {
+                left: "salary".to_string(),
+                op: CmpOp::Gt,
+                right: ValueOrRef::Value(ScalarValue::Int(0)),
+            },
         );
 
         let good_tuple = tuple! { salary: 50000i64 };
@@ -328,11 +234,23 @@ mod tests {
     #[test]
     fn test_check_constraints_all_satisfied() {
         let constraints = CheckConstraints::new()
-            .with_constraint(CheckConstraint::from_closure("c1", "d1", |_| true))
-            .with_constraint(CheckConstraint::from_expression(
+            .with_constraint(CheckConstraint::new(
+                "c1",
+                "x > 0",
+                ConstraintExpression::Cmp {
+                    left: "x".to_string(),
+                    op: CmpOp::Gt,
+                    right: ValueOrRef::Value(ScalarValue::Int(0)),
+                },
+            ))
+            .with_constraint(CheckConstraint::new(
                 "c2",
-                "d2",
-                ConstraintExpression::Gt("x".to_string(), ValueOrRef::Value(ScalarValue::Int(0))),
+                "x < 100",
+                ConstraintExpression::Cmp {
+                    left: "x".to_string(),
+                    op: CmpOp::Lt,
+                    right: ValueOrRef::Value(ScalarValue::Int(100)),
+                },
             ));
 
         let tuple = tuple! { x: 10i64 };
@@ -341,29 +259,48 @@ mod tests {
 
     #[test]
     fn test_check_constraints_violation_returns_error() {
-        let constraints = CheckConstraints::new().with_constraint(CheckConstraint::from_closure(
+        let constraints = CheckConstraints::new().with_constraint(CheckConstraint::new(
             "must_fail",
             "always fails",
-            |_| false,
+            ConstraintExpression::Cmp {
+                left: "id".to_string(),
+                op: CmpOp::Lt,
+                right: ValueOrRef::Value(ScalarValue::Int(0)),
+            },
         ));
 
         let tuple = tuple! { id: 1i64 };
         let result = constraints.are_all_satisfied_by(&tuple);
         assert!(result.is_err());
+        match result {
+            Err(CheckConstraintError::Violation {
+                constraint_name, ..
+            }) => {
+                assert_eq!(constraint_name, "must_fail");
+            }
+            _ => panic!("Expected Violation error"),
+        }
     }
 
     #[test]
-    fn test_check_constraints_serializable_only() {
-        let constraints = CheckConstraints::new()
-            .with_constraint(CheckConstraint::from_closure("c1", "d1", |_| true))
-            .with_constraint(CheckConstraint::from_expression(
-                "c2",
-                "d2",
-                ConstraintExpression::Gt("x".to_string(), ValueOrRef::Value(ScalarValue::Int(0))),
-            ));
+    fn test_serialization() {
+        let constraint = CheckConstraint::new(
+            "test_const",
+            "desc",
+            ConstraintExpression::Cmp {
+                left: "a".to_string(),
+                op: CmpOp::Eq,
+                right: ValueOrRef::Value(ScalarValue::Int(1)),
+            },
+        );
 
-        let serializable = constraints.serializable_constraints();
-        assert_eq!(serializable.len(), 1);
-        assert_eq!(serializable[0].name(), "c2");
+        let serialized = serde_json::to_string(&constraint).unwrap();
+        let deserialized: CheckConstraint = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(constraint.name(), deserialized.name());
+        assert_eq!(constraint.description(), deserialized.description());
+
+        let tuple = tuple! { a: 1i64 };
+        assert!(deserialized.is_satisfied_by(&tuple).unwrap());
     }
 }

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -11,15 +11,16 @@
 //! # Example
 //!
 //! ```
-//! use relvar_core::constraints::expression::{ConstraintExpression, ValueOrRef};
+//! use relvar_core::constraints::expression::{ConstraintExpression, CmpOp, ValueOrRef};
 //! use relvar_core::values::ScalarValue;
 //! use relvar_core::tuple;
 //!
 //! // Create a constraint: salary > 0
-//! let expr = ConstraintExpression::Gt(
-//!     "salary".to_string(),
-//!     ValueOrRef::Value(ScalarValue::Int(0)),
-//! );
+//! let expr = ConstraintExpression::Cmp {
+//!     left: "salary".to_string(),
+//!     op: CmpOp::Gt,
+//!     right: ValueOrRef::Value(ScalarValue::Int(0)),
+//! };
 //!
 //! let valid_tuple = tuple! { salary: 50000i64 };
 //! assert!(expr.evaluate(&valid_tuple).unwrap());
@@ -58,7 +59,7 @@ pub enum ValueOrRef {
 }
 
 /// Comparison operators for constraint expressions.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum CmpOp {
     /// Equal (=)
     Eq,
@@ -82,26 +83,21 @@ pub enum CmpOp {
 ///
 /// # Supported Operations
 ///
-/// - **Comparisons**: Eq, Ne, Lt, Le, Gt, Ge
+/// - **Comparisons**: Eq, Ne, Lt, Le, Gt, Ge via `Cmp`
 /// - **Logical**: And, Or, Not
-/// - **Attribute comparison**: Compare two attributes
-/// - **Range**: Between
 /// - **Set membership**: In
 /// - **Pattern matching**: Like
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum ConstraintExpression {
-    /// Equality comparison: attribute = value
-    Eq(String, ValueOrRef),
-    /// Inequality comparison: attribute ≠ value
-    Ne(String, ValueOrRef),
-    /// Less than: attribute < value
-    Lt(String, ValueOrRef),
-    /// Less than or equal: attribute ≤ value
-    Le(String, ValueOrRef),
-    /// Greater than: attribute > value
-    Gt(String, ValueOrRef),
-    /// Greater than or equal: attribute ≥ value
-    Ge(String, ValueOrRef),
+    /// Comparison: left_attr op right_value_or_ref
+    Cmp {
+        /// Left attribute name
+        left: String,
+        /// Comparison operator
+        op: CmpOp,
+        /// Right operand (value or attribute reference)
+        right: ValueOrRef,
+    },
 
     /// Logical AND: both expressions must be true
     And(Box<ConstraintExpression>, Box<ConstraintExpression>),
@@ -109,19 +105,6 @@ pub enum ConstraintExpression {
     Or(Box<ConstraintExpression>, Box<ConstraintExpression>),
     /// Logical NOT: inverts the expression
     Not(Box<ConstraintExpression>),
-
-    /// Attribute-to-attribute comparison: left_attr op right_attr
-    AttrCmp {
-        /// Left attribute name
-        left: String,
-        /// Comparison operator
-        op: CmpOp,
-        /// Right attribute name
-        right: String,
-    },
-
-    /// Range check: value BETWEEN min AND max (inclusive)
-    Between(String, ScalarValue, ScalarValue),
 
     /// Set membership: attribute IN (value1, value2, ...)
     In(String, Vec<ScalarValue>),
@@ -147,43 +130,31 @@ impl ConstraintExpression {
     /// # Example
     ///
     /// ```
-    /// use relvar_core::constraints::expression::{ConstraintExpression, ValueOrRef};
+    /// use relvar_core::constraints::expression::{ConstraintExpression, CmpOp, ValueOrRef};
     /// use relvar_core::values::ScalarValue;
     /// use relvar_core::tuple;
     ///
-    /// let expr = ConstraintExpression::Gt(
-    ///     "age".to_string(),
-    ///     ValueOrRef::Value(ScalarValue::Int(0)),
-    /// );
+    /// let expr = ConstraintExpression::Cmp {
+    ///     left: "age".to_string(),
+    ///     op: CmpOp::Gt,
+    ///     right: ValueOrRef::Value(ScalarValue::Int(0)),
+    /// };
     ///
     /// let tuple = tuple! { age: 30i64 };
     /// assert!(expr.evaluate(&tuple).unwrap());
     /// ```
     pub fn evaluate(&self, tuple: &Tuple) -> Result<bool, ExpressionError> {
         match self {
-            ConstraintExpression::Eq(attr, value_or_ref) => {
-                let (left, right) = Self::get_comparison_operands(tuple, attr, value_or_ref)?;
-                Ok(left == right)
-            }
-            ConstraintExpression::Ne(attr, value_or_ref) => {
-                let (left, right) = Self::get_comparison_operands(tuple, attr, value_or_ref)?;
-                Ok(left != right)
-            }
-            ConstraintExpression::Lt(attr, value_or_ref) => {
-                let (left, right) = Self::get_comparison_operands(tuple, attr, value_or_ref)?;
-                Ok(left < right)
-            }
-            ConstraintExpression::Le(attr, value_or_ref) => {
-                let (left, right) = Self::get_comparison_operands(tuple, attr, value_or_ref)?;
-                Ok(left <= right)
-            }
-            ConstraintExpression::Gt(attr, value_or_ref) => {
-                let (left, right) = Self::get_comparison_operands(tuple, attr, value_or_ref)?;
-                Ok(left > right)
-            }
-            ConstraintExpression::Ge(attr, value_or_ref) => {
-                let (left, right) = Self::get_comparison_operands(tuple, attr, value_or_ref)?;
-                Ok(left >= right)
+            ConstraintExpression::Cmp { left, op, right } => {
+                let (left_val, right_val) = Self::get_comparison_operands(tuple, left, right)?;
+                match op {
+                    CmpOp::Eq => Ok(left_val == right_val),
+                    CmpOp::Ne => Ok(left_val != right_val),
+                    CmpOp::Lt => Ok(left_val < right_val),
+                    CmpOp::Le => Ok(left_val <= right_val),
+                    CmpOp::Gt => Ok(left_val > right_val),
+                    CmpOp::Ge => Ok(left_val >= right_val),
+                }
             }
             ConstraintExpression::And(left, right) => {
                 Ok(left.evaluate(tuple)? && right.evaluate(tuple)?)
@@ -192,37 +163,6 @@ impl ConstraintExpression {
                 Ok(left.evaluate(tuple)? || right.evaluate(tuple)?)
             }
             ConstraintExpression::Not(expr) => Ok(!expr.evaluate(tuple)?),
-            ConstraintExpression::AttrCmp { left, op, right } => {
-                let left_value = tuple
-                    .get(left)
-                    .ok_or_else(|| ExpressionError::AttributeNotFound(left.clone()))?;
-                let right_value = tuple
-                    .get(right)
-                    .ok_or_else(|| ExpressionError::AttributeNotFound(right.clone()))?;
-
-                // Validate types are compatible for comparison
-                if std::mem::discriminant(left_value) != std::mem::discriminant(right_value) {
-                    return Err(ExpressionError::TypeMismatch(
-                        format!("{:?}", left_value.scalar_type()),
-                        format!("{:?}", right_value.scalar_type()),
-                    ));
-                }
-
-                match op {
-                    CmpOp::Eq => Ok(left_value == right_value),
-                    CmpOp::Ne => Ok(left_value != right_value),
-                    CmpOp::Lt => Ok(left_value < right_value),
-                    CmpOp::Le => Ok(left_value <= right_value),
-                    CmpOp::Gt => Ok(left_value > right_value),
-                    CmpOp::Ge => Ok(left_value >= right_value),
-                }
-            }
-            ConstraintExpression::Between(attr, min, max) => {
-                let tuple_value = tuple
-                    .get(attr)
-                    .ok_or_else(|| ExpressionError::AttributeNotFound(attr.clone()))?;
-                Ok(tuple_value >= min && tuple_value <= max)
-            }
             ConstraintExpression::In(attr, values) => {
                 let tuple_value = tuple
                     .get(attr)
@@ -361,10 +301,11 @@ mod tests {
 
     #[test]
     fn test_constraint_expression_eq() {
-        let expr = ConstraintExpression::Eq(
-            "salary".to_string(),
-            ValueOrRef::Value(ScalarValue::Int(50000)),
-        );
+        let expr = ConstraintExpression::Cmp {
+            left: "salary".to_string(),
+            op: CmpOp::Eq,
+            right: ValueOrRef::Value(ScalarValue::Int(50000)),
+        };
 
         let tuple = tuple! { salary: 50000i64 };
         assert!(expr.evaluate(&tuple).unwrap());
@@ -375,10 +316,11 @@ mod tests {
 
     #[test]
     fn test_constraint_expression_ne() {
-        let expr = ConstraintExpression::Ne(
-            "status".to_string(),
-            ValueOrRef::Value(ScalarValue::String("inactive".to_string())),
-        );
+        let expr = ConstraintExpression::Cmp {
+            left: "status".to_string(),
+            op: CmpOp::Ne,
+            right: ValueOrRef::Value(ScalarValue::String("inactive".to_string())),
+        };
 
         let tuple = tuple! { status: "active" };
         assert!(expr.evaluate(&tuple).unwrap());
@@ -389,8 +331,11 @@ mod tests {
 
     #[test]
     fn test_constraint_expression_lt() {
-        let expr =
-            ConstraintExpression::Lt("age".to_string(), ValueOrRef::Value(ScalarValue::Int(65)));
+        let expr = ConstraintExpression::Cmp {
+            left: "age".to_string(),
+            op: CmpOp::Lt,
+            right: ValueOrRef::Value(ScalarValue::Int(65)),
+        };
 
         let tuple = tuple! { age: 30i64 };
         assert!(expr.evaluate(&tuple).unwrap());
@@ -404,10 +349,11 @@ mod tests {
 
     #[test]
     fn test_constraint_expression_le() {
-        let expr = ConstraintExpression::Le(
-            "score".to_string(),
-            ValueOrRef::Value(ScalarValue::Int(100)),
-        );
+        let expr = ConstraintExpression::Cmp {
+            left: "score".to_string(),
+            op: CmpOp::Le,
+            right: ValueOrRef::Value(ScalarValue::Int(100)),
+        };
 
         let tuple = tuple! { score: 95i64 };
         assert!(expr.evaluate(&tuple).unwrap());
@@ -421,8 +367,11 @@ mod tests {
 
     #[test]
     fn test_constraint_expression_gt() {
-        let expr =
-            ConstraintExpression::Gt("salary".to_string(), ValueOrRef::Value(ScalarValue::Int(0)));
+        let expr = ConstraintExpression::Cmp {
+            left: "salary".to_string(),
+            op: CmpOp::Gt,
+            right: ValueOrRef::Value(ScalarValue::Int(0)),
+        };
 
         let tuple = tuple! { salary: 50000i64 };
         assert!(expr.evaluate(&tuple).unwrap());
@@ -436,10 +385,11 @@ mod tests {
 
     #[test]
     fn test_constraint_expression_ge() {
-        let expr = ConstraintExpression::Ge(
-            "balance".to_string(),
-            ValueOrRef::Value(ScalarValue::Int(0)),
-        );
+        let expr = ConstraintExpression::Cmp {
+            left: "balance".to_string(),
+            op: CmpOp::Ge,
+            right: ValueOrRef::Value(ScalarValue::Int(0)),
+        };
 
         let tuple = tuple! { balance: 100i64 };
         assert!(expr.evaluate(&tuple).unwrap());
@@ -454,14 +404,16 @@ mod tests {
     #[test]
     fn test_constraint_expression_and() {
         let expr = ConstraintExpression::And(
-            Box::new(ConstraintExpression::Gt(
-                "age".to_string(),
-                ValueOrRef::Value(ScalarValue::Int(0)),
-            )),
-            Box::new(ConstraintExpression::Lt(
-                "age".to_string(),
-                ValueOrRef::Value(ScalarValue::Int(150)),
-            )),
+            Box::new(ConstraintExpression::Cmp {
+                left: "age".to_string(),
+                op: CmpOp::Gt,
+                right: ValueOrRef::Value(ScalarValue::Int(0)),
+            }),
+            Box::new(ConstraintExpression::Cmp {
+                left: "age".to_string(),
+                op: CmpOp::Lt,
+                right: ValueOrRef::Value(ScalarValue::Int(150)),
+            }),
         );
 
         let valid = tuple! { age: 30i64 };
@@ -477,14 +429,16 @@ mod tests {
     #[test]
     fn test_constraint_expression_or() {
         let expr = ConstraintExpression::Or(
-            Box::new(ConstraintExpression::Eq(
-                "status".to_string(),
-                ValueOrRef::Value(ScalarValue::String("active".to_string())),
-            )),
-            Box::new(ConstraintExpression::Eq(
-                "status".to_string(),
-                ValueOrRef::Value(ScalarValue::String("pending".to_string())),
-            )),
+            Box::new(ConstraintExpression::Cmp {
+                left: "status".to_string(),
+                op: CmpOp::Eq,
+                right: ValueOrRef::Value(ScalarValue::String("active".to_string())),
+            }),
+            Box::new(ConstraintExpression::Cmp {
+                left: "status".to_string(),
+                op: CmpOp::Eq,
+                right: ValueOrRef::Value(ScalarValue::String("pending".to_string())),
+            }),
         );
 
         let active = tuple! { status: "active" };
@@ -499,10 +453,11 @@ mod tests {
 
     #[test]
     fn test_constraint_expression_not() {
-        let expr = ConstraintExpression::Not(Box::new(ConstraintExpression::Eq(
-            "deleted".to_string(),
-            ValueOrRef::Value(ScalarValue::Bool(true)),
-        )));
+        let expr = ConstraintExpression::Not(Box::new(ConstraintExpression::Cmp {
+            left: "deleted".to_string(),
+            op: CmpOp::Eq,
+            right: ValueOrRef::Value(ScalarValue::Bool(true)),
+        }));
 
         let not_deleted = tuple! { deleted: false };
         assert!(expr.evaluate(&not_deleted).unwrap());
@@ -513,10 +468,10 @@ mod tests {
 
     #[test]
     fn test_attr_comparison_ge() {
-        let expr = ConstraintExpression::AttrCmp {
+        let expr = ConstraintExpression::Cmp {
             left: "end_date".to_string(),
             op: CmpOp::Ge,
-            right: "start_date".to_string(),
+            right: ValueOrRef::Attribute("start_date".to_string()),
         };
 
         let valid = tuple! { start_date: 100i64, end_date: 200i64 };
@@ -531,10 +486,10 @@ mod tests {
 
     #[test]
     fn test_attr_comparison_eq() {
-        let expr = ConstraintExpression::AttrCmp {
+        let expr = ConstraintExpression::Cmp {
             left: "password".to_string(),
             op: CmpOp::Eq,
-            right: "password_confirmation".to_string(),
+            right: ValueOrRef::Attribute("password_confirmation".to_string()),
         };
 
         let valid = tuple! { password: "secret123", password_confirmation: "secret123" };
@@ -546,10 +501,10 @@ mod tests {
 
     #[test]
     fn test_attr_comparison_lt() {
-        let expr = ConstraintExpression::AttrCmp {
+        let expr = ConstraintExpression::Cmp {
             left: "min_value".to_string(),
             op: CmpOp::Lt,
-            right: "max_value".to_string(),
+            right: ValueOrRef::Attribute("max_value".to_string()),
         };
 
         let valid = tuple! { min_value: 10i64, max_value: 100i64 };
@@ -563,11 +518,19 @@ mod tests {
     }
 
     #[test]
-    fn test_between_inclusive() {
-        let expr = ConstraintExpression::Between(
-            "age".to_string(),
-            ScalarValue::Int(18),
-            ScalarValue::Int(65),
+    fn test_between_inclusive_replacement() {
+        // Between replacement: And(Ge(min), Le(max))
+        let expr = ConstraintExpression::And(
+            Box::new(ConstraintExpression::Cmp {
+                left: "age".to_string(),
+                op: CmpOp::Ge,
+                right: ValueOrRef::Value(ScalarValue::Int(18)),
+            }),
+            Box::new(ConstraintExpression::Cmp {
+                left: "age".to_string(),
+                op: CmpOp::Le,
+                right: ValueOrRef::Value(ScalarValue::Int(65)),
+            }),
         );
 
         let valid_low = tuple! { age: 18i64 };
@@ -627,8 +590,11 @@ mod tests {
 
     #[test]
     fn test_expression_serialization_simple() {
-        let expr =
-            ConstraintExpression::Gt("age".to_string(), ValueOrRef::Value(ScalarValue::Int(0)));
+        let expr = ConstraintExpression::Cmp {
+            left: "age".to_string(),
+            op: CmpOp::Gt,
+            right: ValueOrRef::Value(ScalarValue::Int(0)),
+        };
 
         let json = serde_json::to_string(&expr).unwrap();
         let restored: ConstraintExpression = serde_json::from_str(&json).unwrap();
@@ -642,14 +608,16 @@ mod tests {
     #[test]
     fn test_expression_serialization_complex() {
         let expr = ConstraintExpression::And(
-            Box::new(ConstraintExpression::Gt(
-                "age".to_string(),
-                ValueOrRef::Value(ScalarValue::Int(0)),
-            )),
-            Box::new(ConstraintExpression::Lt(
-                "age".to_string(),
-                ValueOrRef::Value(ScalarValue::Int(150)),
-            )),
+            Box::new(ConstraintExpression::Cmp {
+                left: "age".to_string(),
+                op: CmpOp::Gt,
+                right: ValueOrRef::Value(ScalarValue::Int(0)),
+            }),
+            Box::new(ConstraintExpression::Cmp {
+                left: "age".to_string(),
+                op: CmpOp::Lt,
+                right: ValueOrRef::Value(ScalarValue::Int(150)),
+            }),
         );
 
         let json = serde_json::to_string(&expr).unwrap();
@@ -666,24 +634,11 @@ mod tests {
 
     #[test]
     fn test_expression_serialization_attr_cmp() {
-        let expr = ConstraintExpression::AttrCmp {
+        let expr = ConstraintExpression::Cmp {
             left: "end_date".to_string(),
             op: CmpOp::Ge,
-            right: "start_date".to_string(),
+            right: ValueOrRef::Attribute("start_date".to_string()),
         };
-
-        let json = serde_json::to_string(&expr).unwrap();
-        let restored: ConstraintExpression = serde_json::from_str(&json).unwrap();
-        assert_eq!(expr, restored);
-    }
-
-    #[test]
-    fn test_expression_serialization_between() {
-        let expr = ConstraintExpression::Between(
-            "score".to_string(),
-            ScalarValue::Int(0),
-            ScalarValue::Int(100),
-        );
 
         let json = serde_json::to_string(&expr).unwrap();
         let restored: ConstraintExpression = serde_json::from_str(&json).unwrap();
@@ -693,10 +648,11 @@ mod tests {
     #[test]
     fn test_type_mismatch_in_comparison() {
         // Comparing Int with String should fail with TypeMismatch
-        let expr = ConstraintExpression::Gt(
-            "age".to_string(),
-            ValueOrRef::Value(ScalarValue::String("not_a_number".to_string())),
-        );
+        let expr = ConstraintExpression::Cmp {
+            left: "age".to_string(),
+            op: CmpOp::Gt,
+            right: ValueOrRef::Value(ScalarValue::String("not_a_number".to_string())),
+        };
 
         let tuple = tuple! { age: 30i64 };
         let result = expr.evaluate(&tuple);
@@ -706,8 +662,11 @@ mod tests {
 
     #[test]
     fn test_type_mismatch_in_lt() {
-        let expr =
-            ConstraintExpression::Lt("name".to_string(), ValueOrRef::Value(ScalarValue::Int(42)));
+        let expr = ConstraintExpression::Cmp {
+            left: "name".to_string(),
+            op: CmpOp::Lt,
+            right: ValueOrRef::Value(ScalarValue::Int(42)),
+        };
 
         let tuple = tuple! { name: "Alice" };
         let result = expr.evaluate(&tuple);
@@ -717,10 +676,10 @@ mod tests {
 
     #[test]
     fn test_type_mismatch_attr_to_attr() {
-        let expr = ConstraintExpression::AttrCmp {
+        let expr = ConstraintExpression::Cmp {
             left: "age".to_string(),
             op: CmpOp::Lt,
-            right: "name".to_string(),
+            right: ValueOrRef::Attribute("name".to_string()),
         };
 
         let tuple = tuple! { age: 30i64, name: "Alice" };

--- a/relvar-core/src/constraints/mod.rs
+++ b/relvar-core/src/constraints/mod.rs
@@ -41,7 +41,7 @@ pub mod key;
 pub mod manager;
 pub mod type_constraint;
 
-pub use check::{CheckConstraint, CheckConstraintError, CheckConstraints, CheckPredicate};
+pub use check::{CheckConstraint, CheckConstraintError, CheckConstraints};
 pub use expression::{CmpOp, ConstraintExpression, ExpressionError, ValueOrRef};
 pub use foreign_key::{ForeignKey, ForeignKeyConstraints, ForeignKeyError};
 pub use key::{CandidateKey, KeyConstraintError, KeyConstraints, PrimaryKey};

--- a/relvar-core/src/constraints/type_constraint.rs
+++ b/relvar-core/src/constraints/type_constraint.rs
@@ -2,16 +2,13 @@
 //!
 //! Type constraints define additional rules beyond basic type checking that
 //! values must satisfy. These include range limits, enumerated values,
-//! string length requirements, and custom validation functions.
+//! and string length requirements.
 //!
 //! # Constraint Types
 //!
 //! - [`TypeConstraint::Range`] - Value must be within min/max bounds
 //! - [`TypeConstraint::Enum`] - Value must be one of specified options
 //! - [`TypeConstraint::StringLength`] - String length must be within bounds
-//! - [`TypeConstraint::PositiveInt`] - Integer must be > 0
-//! - [`TypeConstraint::NonNegativeInt`] - Integer must be >= 0
-//! - [`TypeConstraint::Custom`] - User-defined validation function
 //!
 //! # Example
 //!
@@ -55,8 +52,7 @@ pub enum TypeConstraintError {
 /// A constraint that restricts the valid values for a scalar type.
 ///
 /// Type constraints add domain restrictions beyond the basic type system.
-/// They can enforce ranges, enumerated values, string lengths, or custom
-/// validation logic.
+/// They can enforce ranges, enumerated values, or string lengths.
 ///
 /// # Example
 ///
@@ -79,7 +75,7 @@ pub enum TypeConstraintError {
 ///     ],
 /// };
 /// ```
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TypeConstraint {
     /// Value must be within an inclusive range.
     ///
@@ -104,85 +100,6 @@ pub enum TypeConstraint {
         /// Maximum string length (inclusive).
         max: usize,
     },
-
-    /// Integer must be strictly positive (> 0).
-    PositiveInt,
-
-    /// Integer must be non-negative (>= 0).
-    NonNegativeInt,
-
-    /// Custom validation function.
-    ///
-    /// The validator function is not serializable. After deserialization,
-    /// the validator will be `None` and validation will pass by default.
-    Custom {
-        /// The validation function (optional for deserialization support).
-        #[serde(skip)]
-        #[allow(clippy::type_complexity)]
-        validator: Option<Box<dyn Fn(&ScalarValue) -> bool + Send + Sync>>,
-        /// Human-readable description of the constraint.
-        description: String,
-    },
-}
-
-// Manual Clone implementation since Custom variant contains a function
-impl Clone for TypeConstraint {
-    fn clone(&self) -> Self {
-        match self {
-            TypeConstraint::Range { min, max } => TypeConstraint::Range {
-                min: min.clone(),
-                max: max.clone(),
-            },
-            TypeConstraint::Enum { allowed_values } => TypeConstraint::Enum {
-                allowed_values: allowed_values.clone(),
-            },
-            TypeConstraint::StringLength { min, max } => TypeConstraint::StringLength {
-                min: *min,
-                max: *max,
-            },
-            TypeConstraint::PositiveInt => TypeConstraint::PositiveInt,
-            TypeConstraint::NonNegativeInt => TypeConstraint::NonNegativeInt,
-            TypeConstraint::Custom {
-                validator: _,
-                description,
-            } => TypeConstraint::Custom {
-                validator: None, // Can't clone functions
-                description: description.clone(),
-            },
-        }
-    }
-}
-
-// Manual Debug implementation since Custom variant contains a function
-impl std::fmt::Debug for TypeConstraint {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TypeConstraint::Range { min, max } => f
-                .debug_struct("Range")
-                .field("min", min)
-                .field("max", max)
-                .finish(),
-            TypeConstraint::Enum { allowed_values } => f
-                .debug_struct("Enum")
-                .field("allowed_values", allowed_values)
-                .finish(),
-            TypeConstraint::StringLength { min, max } => f
-                .debug_struct("StringLength")
-                .field("min", min)
-                .field("max", max)
-                .finish(),
-            TypeConstraint::PositiveInt => f.debug_tuple("PositiveInt").finish(),
-            TypeConstraint::NonNegativeInt => f.debug_tuple("NonNegativeInt").finish(),
-            TypeConstraint::Custom {
-                validator,
-                description,
-            } => f
-                .debug_struct("Custom")
-                .field("validator", &validator.is_some())
-                .field("description", description)
-                .finish(),
-        }
-    }
 }
 
 impl TypeConstraint {
@@ -224,36 +141,6 @@ impl TypeConstraint {
                         expected: "String".to_string(),
                         actual: value.scalar_type().name(),
                     })
-                }
-            }
-            TypeConstraint::PositiveInt => {
-                if let ScalarValue::Int(n) = value {
-                    Ok(*n > 0)
-                } else {
-                    Err(TypeConstraintError::TypeMismatch {
-                        expected: "Int".to_string(),
-                        actual: value.scalar_type().name(),
-                    })
-                }
-            }
-            TypeConstraint::NonNegativeInt => {
-                if let ScalarValue::Int(n) = value {
-                    Ok(*n >= 0)
-                } else {
-                    Err(TypeConstraintError::TypeMismatch {
-                        expected: "Int".to_string(),
-                        actual: value.scalar_type().name(),
-                    })
-                }
-            }
-            TypeConstraint::Custom {
-                validator,
-                description: _,
-            } => {
-                if let Some(f) = validator {
-                    Ok(f(value))
-                } else {
-                    Ok(true) // Skip validation if no function (e.g., after deserialization)
                 }
             }
         }
@@ -412,8 +299,12 @@ mod tests {
     }
 
     #[test]
-    fn test_positive_int_constraint() {
-        let constraint = TypeConstraint::PositiveInt;
+    fn test_positive_int_replacement() {
+        // Replacement for PositiveInt: Range { min: 1, max: MAX }
+        let constraint = TypeConstraint::Range {
+            min: ScalarValue::Int(1),
+            max: ScalarValue::Int(i64::MAX),
+        };
 
         assert!(constraint.is_satisfied_by(&ScalarValue::Int(1)).unwrap());
         assert!(constraint.is_satisfied_by(&ScalarValue::Int(100)).unwrap());
@@ -422,8 +313,12 @@ mod tests {
     }
 
     #[test]
-    fn test_non_negative_int_constraint() {
-        let constraint = TypeConstraint::NonNegativeInt;
+    fn test_non_negative_int_replacement() {
+        // Replacement for NonNegativeInt: Range { min: 0, max: MAX }
+        let constraint = TypeConstraint::Range {
+            min: ScalarValue::Int(0),
+            max: ScalarValue::Int(i64::MAX),
+        };
 
         assert!(constraint.is_satisfied_by(&ScalarValue::Int(0)).unwrap());
         assert!(constraint.is_satisfied_by(&ScalarValue::Int(1)).unwrap());
@@ -438,7 +333,11 @@ mod tests {
                 min: ScalarValue::Int(0),
                 max: ScalarValue::Int(150),
             })
-            .with_constraint(TypeConstraint::NonNegativeInt);
+            // Use Range instead of NonNegativeInt
+            .with_constraint(TypeConstraint::Range {
+                min: ScalarValue::Int(0),
+                max: ScalarValue::Int(i64::MAX),
+            });
 
         assert!(
             age_constraints
@@ -490,25 +389,6 @@ mod tests {
                 .is_satisfied_by(&ScalarValue::String("pass".to_string()))
                 .unwrap()
         );
-    }
-
-    #[test]
-    fn test_custom_constraint() {
-        let constraint = TypeConstraint::Custom {
-            validator: Some(Box::new(|v| {
-                if let ScalarValue::Int(n) = v {
-                    n % 2 == 0 // Even numbers only
-                } else {
-                    false
-                }
-            })),
-            description: "Must be even".to_string(),
-        };
-
-        assert!(constraint.is_satisfied_by(&ScalarValue::Int(2)).unwrap());
-        assert!(constraint.is_satisfied_by(&ScalarValue::Int(100)).unwrap());
-        assert!(!constraint.is_satisfied_by(&ScalarValue::Int(1)).unwrap());
-        assert!(!constraint.is_satisfied_by(&ScalarValue::Int(99)).unwrap());
     }
 
     #[test]
@@ -618,44 +498,6 @@ mod tests {
     }
 
     #[test]
-    fn test_positive_int_with_negative() {
-        let constraint = TypeConstraint::PositiveInt;
-
-        assert!(!constraint.is_satisfied_by(&ScalarValue::Int(-100)).unwrap());
-        assert!(!constraint.is_satisfied_by(&ScalarValue::Int(-1)).unwrap());
-    }
-
-    #[test]
-    fn test_non_negative_int_with_negative() {
-        let constraint = TypeConstraint::NonNegativeInt;
-
-        // Zero should pass
-        assert!(constraint.is_satisfied_by(&ScalarValue::Int(0)).unwrap());
-
-        // Negative should fail
-        assert!(!constraint.is_satisfied_by(&ScalarValue::Int(-1)).unwrap());
-        assert!(!constraint.is_satisfied_by(&ScalarValue::Int(-100)).unwrap());
-    }
-
-    #[test]
-    fn test_non_negative_int_type_mismatch() {
-        let constraint = TypeConstraint::NonNegativeInt;
-
-        // Should return error for non-int type
-        let result = constraint.is_satisfied_by(&ScalarValue::String("test".to_string()));
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_positive_int_type_mismatch() {
-        let constraint = TypeConstraint::PositiveInt;
-
-        // Should return error for non-int type
-        let result = constraint.is_satisfied_by(&ScalarValue::Float(1.5));
-        assert!(result.is_err());
-    }
-
-    #[test]
     fn test_enum_constraint_with_different_types() {
         let constraint = TypeConstraint::Enum {
             allowed_values: vec![
@@ -668,47 +510,6 @@ mod tests {
         // Wrong type should return error (type mismatch)
         let result = constraint.is_satisfied_by(&ScalarValue::String("1".to_string()));
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_custom_constraint_clone() {
-        let constraint = TypeConstraint::Custom {
-            validator: Some(Box::new(|v: &ScalarValue| match v {
-                ScalarValue::Int(i) => *i % 2 == 0,
-                _ => false,
-            })),
-            description: "Even numbers only".to_string(),
-        };
-
-        let cloned = constraint.clone();
-
-        // Cloned validator should be None
-        if let TypeConstraint::Custom {
-            validator,
-            description,
-        } = cloned
-        {
-            assert!(validator.is_none());
-            assert_eq!(description, "Even numbers only");
-        } else {
-            panic!("Expected Custom variant");
-        }
-    }
-
-    #[test]
-    fn test_custom_constraint_without_validator() {
-        // Custom constraint with validator = None should always pass
-        let constraint = TypeConstraint::Custom {
-            validator: None,
-            description: "No validator".to_string(),
-        };
-
-        assert!(constraint.is_satisfied_by(&ScalarValue::Int(42)).unwrap());
-        assert!(
-            constraint
-                .is_satisfied_by(&ScalarValue::String("anything".to_string()))
-                .unwrap()
-        );
     }
 
     #[test]
@@ -738,7 +539,11 @@ mod tests {
     #[test]
     fn test_attribute_constraints_multiple_failures() {
         let constraints = AttributeConstraints::new("age".to_string(), ScalarType::Int)
-            .with_constraint(TypeConstraint::PositiveInt)
+            // Use Range instead of PositiveInt
+            .with_constraint(TypeConstraint::Range {
+                min: ScalarValue::Int(1),
+                max: ScalarValue::Int(i64::MAX),
+            })
             .with_constraint(TypeConstraint::Range {
                 min: ScalarValue::Int(1),
                 max: ScalarValue::Int(120),

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -326,6 +326,7 @@ impl<E: StorageEngine> Database<E> {
     /// use relvar_core::types::{TupleType, RelationType, ScalarType};
     /// use relvar_core::constraints::AttributeConstraints;
     /// use relvar_core::constraints::TypeConstraint;
+    /// use relvar_core::values::ScalarValue;
     ///
     /// let mut db = Database::new(InMemoryEngine::new());
     /// let rel_type = RelationType::new(
@@ -334,7 +335,7 @@ impl<E: StorageEngine> Database<E> {
     /// db.create_relvar("TEST", rel_type).unwrap();
     ///
     /// let attr_constraints = AttributeConstraints::new("count".to_string(), ScalarType::Int)
-    ///     .with_constraint(TypeConstraint::PositiveInt);
+    ///     .with_constraint(TypeConstraint::Range { min: ScalarValue::Int(1), max: ScalarValue::Int(i64::MAX) });
     ///
     /// db.set_type_constraints("TEST", "count", attr_constraints).unwrap();
     /// ```
@@ -360,7 +361,7 @@ impl<E: StorageEngine> Database<E> {
     /// use relvar_core::database::Database;
     /// use relvar_core::storage_engine::InMemoryEngine;
     /// use relvar_core::types::{TupleType, RelationType, ScalarType};
-    /// use relvar_core::constraints::{CheckConstraints, CheckConstraint, ConstraintExpression, ValueOrRef};
+    /// use relvar_core::constraints::{CheckConstraints, CheckConstraint, ConstraintExpression, CmpOp, ValueOrRef};
     /// use relvar_core::values::ScalarValue;
     ///
     /// let mut db = Database::new(InMemoryEngine::new());
@@ -372,13 +373,14 @@ impl<E: StorageEngine> Database<E> {
     ///
     /// // Age must be >= 0
     /// let constraints = CheckConstraints::new()
-    ///     .with_constraint(CheckConstraint::from_expression(
+    ///     .with_constraint(CheckConstraint::new(
     ///         "valid_age",
     ///         "Age must be non-negative",
-    ///         ConstraintExpression::Gt(
-    ///             "age".to_string(),
-    ///             ValueOrRef::Value(ScalarValue::Int(-1))
-    ///         )
+    ///         ConstraintExpression::Cmp {
+    ///             left: "age".to_string(),
+    ///             op: CmpOp::Gt,
+    ///             right: ValueOrRef::Value(ScalarValue::Int(-1))
+    ///         }
     ///     ));
     ///
     /// db.set_check_constraints("PEOPLE", constraints).unwrap();
@@ -811,7 +813,7 @@ impl<E: StorageEngine> Database<E> {
 mod tests {
     use super::*;
     use crate::constraints::check::{CheckConstraint, CheckConstraints};
-    use crate::constraints::expression::{ConstraintExpression, ValueOrRef};
+    use crate::constraints::expression::{CmpOp, ConstraintExpression, ValueOrRef};
     use crate::storage_engine::InMemoryEngine;
     use crate::tuple;
     use crate::types::{ScalarType, TupleType};
@@ -1073,7 +1075,10 @@ mod tests {
 
         // Add positive int constraint
         let attr_constraints = AttributeConstraints::new("id".to_string(), ScalarType::Int)
-            .with_constraint(TypeConstraint::PositiveInt);
+            .with_constraint(TypeConstraint::Range {
+                min: ScalarValue::Int(1),
+                max: ScalarValue::Int(i64::MAX),
+            });
         db.set_type_constraints("TEST", "id", attr_constraints)
             .unwrap();
 
@@ -1750,15 +1755,15 @@ mod tests {
         db.create_relvar("EMPLOYEES", rel_type).unwrap();
 
         // Create CHECK constraint: salary must be positive
-        let constraints =
-            CheckConstraints::new().with_constraint(CheckConstraint::from_expression(
-                "positive_salary",
-                "Salary must be positive",
-                ConstraintExpression::Gt(
-                    "salary".to_string(),
-                    ValueOrRef::Value(ScalarValue::Int(0)),
-                ),
-            ));
+        let constraints = CheckConstraints::new().with_constraint(CheckConstraint::new(
+            "positive_salary",
+            "Salary must be positive",
+            ConstraintExpression::Cmp {
+                left: "salary".to_string(),
+                op: CmpOp::Gt,
+                right: ValueOrRef::Value(ScalarValue::Int(0)),
+            },
+        ));
 
         db.set_check_constraints("EMPLOYEES", constraints).unwrap();
     }
@@ -1779,15 +1784,15 @@ mod tests {
             .unwrap();
 
         // Try to add CHECK constraint - should fail because existing data violates it
-        let constraints =
-            CheckConstraints::new().with_constraint(CheckConstraint::from_expression(
-                "positive_salary",
-                "Salary must be positive",
-                ConstraintExpression::Gt(
-                    "salary".to_string(),
-                    ValueOrRef::Value(ScalarValue::Int(0)),
-                ),
-            ));
+        let constraints = CheckConstraints::new().with_constraint(CheckConstraint::new(
+            "positive_salary",
+            "Salary must be positive",
+            ConstraintExpression::Cmp {
+                left: "salary".to_string(),
+                op: CmpOp::Gt,
+                right: ValueOrRef::Value(ScalarValue::Int(0)),
+            },
+        ));
 
         let result = db.set_check_constraints("EMPLOYEES", constraints);
         assert!(result.is_err());
@@ -1811,15 +1816,15 @@ mod tests {
         db.create_relvar("EMPLOYEES", rel_type).unwrap();
 
         // Add CHECK constraint: salary must be positive
-        let constraints =
-            CheckConstraints::new().with_constraint(CheckConstraint::from_expression(
-                "positive_salary",
-                "Salary must be positive",
-                ConstraintExpression::Gt(
-                    "salary".to_string(),
-                    ValueOrRef::Value(ScalarValue::Int(0)),
-                ),
-            ));
+        let constraints = CheckConstraints::new().with_constraint(CheckConstraint::new(
+            "positive_salary",
+            "Salary must be positive",
+            ConstraintExpression::Cmp {
+                left: "salary".to_string(),
+                op: CmpOp::Gt,
+                right: ValueOrRef::Value(ScalarValue::Int(0)),
+            },
+        ));
         db.set_check_constraints("EMPLOYEES", constraints).unwrap();
 
         // Insert with positive salary should succeed
@@ -1849,21 +1854,22 @@ mod tests {
         db.create_relvar("PERSONS", rel_type).unwrap();
 
         // Add complex CHECK constraint: age between 0 and 150
-        let constraints =
-            CheckConstraints::new().with_constraint(CheckConstraint::from_expression(
-                "valid_age",
-                "Age must be between 0 and 150",
-                ConstraintExpression::And(
-                    Box::new(ConstraintExpression::Gt(
-                        "age".to_string(),
-                        ValueOrRef::Value(ScalarValue::Int(0)),
-                    )),
-                    Box::new(ConstraintExpression::Lt(
-                        "age".to_string(),
-                        ValueOrRef::Value(ScalarValue::Int(150)),
-                    )),
-                ),
-            ));
+        let constraints = CheckConstraints::new().with_constraint(CheckConstraint::new(
+            "valid_age",
+            "Age must be between 0 and 150",
+            ConstraintExpression::And(
+                Box::new(ConstraintExpression::Cmp {
+                    left: "age".to_string(),
+                    op: CmpOp::Gt,
+                    right: ValueOrRef::Value(ScalarValue::Int(0)),
+                }),
+                Box::new(ConstraintExpression::Cmp {
+                    left: "age".to_string(),
+                    op: CmpOp::Lt,
+                    right: ValueOrRef::Value(ScalarValue::Int(150)),
+                }),
+            ),
+        ));
         db.set_check_constraints("PERSONS", constraints).unwrap();
 
         // Insert with valid age should succeed

--- a/relvar-core/src/lib.rs
+++ b/relvar-core/src/lib.rs
@@ -27,9 +27,9 @@ pub use values::{Relation, ScalarValue, Tuple};
 // Re-export constraint types
 pub use constraints::{
     AttributeConstraints, CandidateKey, CheckConstraint, CheckConstraintError, CheckConstraints,
-    CheckPredicate, CmpOp, ConstraintExpression, ConstraintManagerError, ExpressionError,
-    ForeignKey, ForeignKeyConstraints, ForeignKeyError, KeyConstraintError, KeyConstraints,
-    PrimaryKey, TypeConstraint, TypeConstraintError, ValueOrRef,
+    CmpOp, ConstraintExpression, ConstraintManagerError, ExpressionError, ForeignKey,
+    ForeignKeyConstraints, ForeignKeyError, KeyConstraintError, KeyConstraints, PrimaryKey,
+    TypeConstraint, TypeConstraintError, ValueOrRef,
 };
 
 // Re-export storage engine types


### PR DESCRIPTION
This PR simplifies the constraint system in `relvar-core` by enforcing strictly declarative constraints. It removes closure-based validation (`CheckPredicate::Dynamic` and `TypeConstraint::Custom`) which could not be persisted, fixing a potential architectural issue. It also consolidates `ConstraintExpression` variants into a single `Cmp` variant and removes redundant `TypeConstraint` shorthands.

---
*PR created automatically by Jules for task [6071324508499694341](https://jules.google.com/task/6071324508499694341) started by @madmax983*