### PR TITLE
🌟 Nova: System Catalog Views (Reflection)

### DIFF
--- a/relvar/src/experimental/mod.rs
+++ b/relvar/src/experimental/mod.rs
@@ -29,3 +29,5 @@
 
 pub mod exporter;
 pub mod mock;
+/// System catalog views (`_RELVARS`, `_ATTRIBUTES`, etc.) for database reflection.
+pub mod system_views;

--- a/relvar/src/experimental/system_views.rs
+++ b/relvar/src/experimental/system_views.rs
@@ -1,0 +1,109 @@
+use crate::Database;
+use crate::database::DatabaseError;
+use crate::storage_engine::StorageEngine;
+use crate::tuple;
+use crate::types::{RelationType, ScalarType, TupleType};
+use crate::values::Relation;
+
+/// Registers system views (virtual relvars) that expose database metadata.
+///
+/// This function defines the following virtual relvars:
+///
+/// - `_RELVARS`: Lists all relvars in the database.
+///   - `name` (String): The name of the relvar.
+///   - `degree` (Int): The number of attributes in the relvar.
+///
+/// - `_ATTRIBUTES`: Lists all attributes of all relvars.
+///   - `relvar_name` (String): The name of the relvar.
+///   - `attribute_name` (String): The name of the attribute.
+///   - `type` (String): The scalar type of the attribute.
+///   - `is_pk` (Bool): Whether the attribute is part of the primary key.
+pub fn register<E: StorageEngine + 'static>(db: &mut Database<E>) -> Result<(), DatabaseError> {
+    // Define _RELVARS
+    let relvars_type = RelationType::new(
+        TupleType::new()
+            .with_attribute("name", ScalarType::String)
+            .with_attribute("degree", ScalarType::Int),
+    );
+
+    db.define_virtual_relvar("_RELVARS", relvars_type, relvars_evaluator::<E>)?;
+
+    // Define _ATTRIBUTES
+    let attributes_type = RelationType::new(
+        TupleType::new()
+            .with_attribute("relvar_name", ScalarType::String)
+            .with_attribute("attribute_name", ScalarType::String)
+            .with_attribute("type", ScalarType::String)
+            .with_attribute("is_pk", ScalarType::Bool),
+    );
+
+    db.define_virtual_relvar("_ATTRIBUTES", attributes_type, attributes_evaluator::<E>)?;
+
+    Ok(())
+}
+
+fn relvars_evaluator<E: StorageEngine>(db: &mut Database<E>) -> Result<Relation, DatabaseError> {
+    let relvar_names = db.list_relvars();
+
+    let heading = TupleType::new()
+        .with_attribute("name", ScalarType::String)
+        .with_attribute("degree", ScalarType::Int);
+
+    // Create empty relation
+    let mut relation = Relation::new(RelationType::new(heading));
+
+    for name in relvar_names {
+        // Skip if we can't get the type (shouldn't happen for valid relvars)
+        if let Ok(rel_type) = db.get_relvar_type(&name) {
+            let degree = rel_type.degree() as i64;
+            relation.insert(tuple! {
+                name: name,
+                degree: degree
+            })?;
+        }
+    }
+
+    Ok(relation)
+}
+
+fn attributes_evaluator<E: StorageEngine>(db: &mut Database<E>) -> Result<Relation, DatabaseError> {
+    let relvar_names = db.list_relvars();
+
+    let heading = TupleType::new()
+        .with_attribute("relvar_name", ScalarType::String)
+        .with_attribute("attribute_name", ScalarType::String)
+        .with_attribute("type", ScalarType::String)
+        .with_attribute("is_pk", ScalarType::Bool);
+
+    let mut relation = Relation::new(RelationType::new(heading));
+
+    for name in relvar_names {
+        if let Ok(rel_type) = db.get_relvar_type(&name) {
+            // Check for PK
+            let pk_attrs = if let Some(key_constraints) = db.get_key_constraints(&name) {
+                if let Some(pk) = key_constraints.primary_key() {
+                    pk.attributes().to_vec()
+                } else {
+                    Vec::new()
+                }
+            } else {
+                Vec::new()
+            };
+
+            for attr_name in rel_type.heading().attribute_names() {
+                let attr_type = rel_type.heading().get_attribute_type(attr_name).unwrap();
+                let type_str = format!("{:?}", attr_type);
+                let is_pk = pk_attrs.contains(attr_name);
+
+                relation.insert(tuple! {
+                    relvar_name: name.clone(),
+                    attribute_name: attr_name.clone(),
+                    type: type_str,
+                    is_pk: is_pk
+                })?;
+            }
+        }
+    }
+
+    Ok(relation)
+}

--- a/relvar/tests/test_system_views.rs
+++ b/relvar/tests/test_system_views.rs
@@ -1,7 +1,7 @@
-use relvar::{Database, InMemoryEngine};
-use relvar::types::{RelationType, ScalarType, TupleType};
-use relvar::experimental::system_views;
 use relvar::constraints::{KeyConstraints, PrimaryKey};
+use relvar::experimental::system_views;
+use relvar::types::{RelationType, ScalarType, TupleType};
+use relvar::{Database, InMemoryEngine};
 
 #[test]
 fn test_register_system_views() {
@@ -21,7 +21,7 @@ fn test_query_relvars() {
     let rel_type = RelationType::new(
         TupleType::new()
             .with_attribute("id", ScalarType::Int)
-            .with_attribute("name", ScalarType::String)
+            .with_attribute("name", ScalarType::String),
     );
     db.create_relvar("USERS", rel_type).unwrap();
 
@@ -32,16 +32,18 @@ fn test_query_relvars() {
     assert!(relvars.cardinality() >= 3);
 
     // Verify USERS
-    let users_tuple = relvars.tuples().find(|t|
-        t.get_typed::<String>("name").unwrap() == "USERS"
-    ).unwrap();
+    let users_tuple = relvars
+        .tuples()
+        .find(|t| t.get_typed::<String>("name").unwrap() == "USERS")
+        .unwrap();
 
     assert_eq!(users_tuple.get_typed::<i64>("degree").unwrap(), 2);
 
     // Verify _RELVARS itself
-    let meta_tuple = relvars.tuples().find(|t|
-        t.get_typed::<String>("name").unwrap() == "_RELVARS"
-    ).unwrap();
+    let meta_tuple = relvars
+        .tuples()
+        .find(|t| t.get_typed::<String>("name").unwrap() == "_RELVARS")
+        .unwrap();
     assert_eq!(meta_tuple.get_typed::<i64>("degree").unwrap(), 2);
 }
 
@@ -54,34 +56,35 @@ fn test_query_attributes_with_pk() {
     let rel_type = RelationType::new(
         TupleType::new()
             .with_attribute("id", ScalarType::Int)
-            .with_attribute("email", ScalarType::String)
+            .with_attribute("email", ScalarType::String),
     );
     db.create_relvar("USERS", rel_type).unwrap();
 
     let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
-    db.set_key_constraints("USERS", KeyConstraints::new().with_primary_key(pk)).unwrap();
+    db.set_key_constraints("USERS", KeyConstraints::new().with_primary_key(pk))
+        .unwrap();
 
     // Query _ATTRIBUTES
     let attrs = db.query("_ATTRIBUTES").unwrap();
 
     // Filter for USERS
-    let user_attrs = attrs.restrict(|t|
-        t.get_typed::<String>("relvar_name").unwrap() == "USERS"
-    );
+    let user_attrs = attrs.restrict(|t| t.get_typed::<String>("relvar_name").unwrap() == "USERS");
 
     assert_eq!(user_attrs.cardinality(), 2);
 
     // Check id (PK)
-    let id_attr = user_attrs.tuples().find(|t|
-        t.get_typed::<String>("attribute_name").unwrap() == "id"
-    ).unwrap();
+    let id_attr = user_attrs
+        .tuples()
+        .find(|t| t.get_typed::<String>("attribute_name").unwrap() == "id")
+        .unwrap();
     assert_eq!(id_attr.get_typed::<String>("type").unwrap(), "Int");
     assert!(id_attr.get_typed::<bool>("is_pk").unwrap());
 
     // Check email (not PK)
-    let email_attr = user_attrs.tuples().find(|t|
-        t.get_typed::<String>("attribute_name").unwrap() == "email"
-    ).unwrap();
+    let email_attr = user_attrs
+        .tuples()
+        .find(|t| t.get_typed::<String>("attribute_name").unwrap() == "email")
+        .unwrap();
     assert_eq!(email_attr.get_typed::<String>("type").unwrap(), "String");
     assert!(!email_attr.get_typed::<bool>("is_pk").unwrap());
 }
@@ -103,5 +106,9 @@ fn test_dynamic_updates() {
     assert_eq!(count_after, count_before + 1);
 
     let relvars = db.query("_RELVARS").unwrap();
-    assert!(relvars.tuples().any(|t| t.get_typed::<String>("name").unwrap() == "NEW_REL"));
+    assert!(
+        relvars
+            .tuples()
+            .any(|t| t.get_typed::<String>("name").unwrap() == "NEW_REL")
+    );
 }

--- a/relvar/tests/test_system_views.rs
+++ b/relvar/tests/test_system_views.rs
@@ -1,0 +1,107 @@
+use relvar::{Database, InMemoryEngine};
+use relvar::types::{RelationType, ScalarType, TupleType};
+use relvar::experimental::system_views;
+use relvar::constraints::{KeyConstraints, PrimaryKey};
+
+#[test]
+fn test_register_system_views() {
+    let mut db = Database::new(InMemoryEngine::new());
+    system_views::register(&mut db).unwrap();
+
+    assert!(db.relvar_exists("_RELVARS"));
+    assert!(db.relvar_exists("_ATTRIBUTES"));
+}
+
+#[test]
+fn test_query_relvars() {
+    let mut db = Database::new(InMemoryEngine::new());
+    system_views::register(&mut db).unwrap();
+
+    // Create a user relvar
+    let rel_type = RelationType::new(
+        TupleType::new()
+            .with_attribute("id", ScalarType::Int)
+            .with_attribute("name", ScalarType::String)
+    );
+    db.create_relvar("USERS", rel_type).unwrap();
+
+    // Query _RELVARS
+    let relvars = db.query("_RELVARS").unwrap();
+
+    // Should contain USERS, _RELVARS, and _ATTRIBUTES
+    assert!(relvars.cardinality() >= 3);
+
+    // Verify USERS
+    let users_tuple = relvars.tuples().find(|t|
+        t.get_typed::<String>("name").unwrap() == "USERS"
+    ).unwrap();
+
+    assert_eq!(users_tuple.get_typed::<i64>("degree").unwrap(), 2);
+
+    // Verify _RELVARS itself
+    let meta_tuple = relvars.tuples().find(|t|
+        t.get_typed::<String>("name").unwrap() == "_RELVARS"
+    ).unwrap();
+    assert_eq!(meta_tuple.get_typed::<i64>("degree").unwrap(), 2);
+}
+
+#[test]
+fn test_query_attributes_with_pk() {
+    let mut db = Database::new(InMemoryEngine::new());
+    system_views::register(&mut db).unwrap();
+
+    // Create relvar with PK
+    let rel_type = RelationType::new(
+        TupleType::new()
+            .with_attribute("id", ScalarType::Int)
+            .with_attribute("email", ScalarType::String)
+    );
+    db.create_relvar("USERS", rel_type).unwrap();
+
+    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    db.set_key_constraints("USERS", KeyConstraints::new().with_primary_key(pk)).unwrap();
+
+    // Query _ATTRIBUTES
+    let attrs = db.query("_ATTRIBUTES").unwrap();
+
+    // Filter for USERS
+    let user_attrs = attrs.restrict(|t|
+        t.get_typed::<String>("relvar_name").unwrap() == "USERS"
+    );
+
+    assert_eq!(user_attrs.cardinality(), 2);
+
+    // Check id (PK)
+    let id_attr = user_attrs.tuples().find(|t|
+        t.get_typed::<String>("attribute_name").unwrap() == "id"
+    ).unwrap();
+    assert_eq!(id_attr.get_typed::<String>("type").unwrap(), "Int");
+    assert!(id_attr.get_typed::<bool>("is_pk").unwrap());
+
+    // Check email (not PK)
+    let email_attr = user_attrs.tuples().find(|t|
+        t.get_typed::<String>("attribute_name").unwrap() == "email"
+    ).unwrap();
+    assert_eq!(email_attr.get_typed::<String>("type").unwrap(), "String");
+    assert!(!email_attr.get_typed::<bool>("is_pk").unwrap());
+}
+
+#[test]
+fn test_dynamic_updates() {
+    let mut db = Database::new(InMemoryEngine::new());
+    system_views::register(&mut db).unwrap();
+
+    // Initially empty (except system views)
+    let count_before = db.query("_RELVARS").unwrap().cardinality();
+
+    // Add new relvar
+    let rel_type = RelationType::new(TupleType::new().with_attribute("x", ScalarType::Int));
+    db.create_relvar("NEW_REL", rel_type).unwrap();
+
+    // Query again
+    let count_after = db.query("_RELVARS").unwrap().cardinality();
+    assert_eq!(count_after, count_before + 1);
+
+    let relvars = db.query("_RELVARS").unwrap();
+    assert!(relvars.tuples().any(|t| t.get_typed::<String>("name").unwrap() == "NEW_REL"));
+}


### PR DESCRIPTION
Implemented `system_views` module in `relvar::experimental`.
This module provides a `register` function that adds two virtual relvars to a `Database` instance:
1. `_RELVARS`: {name: String, degree: Int}
2. `_ATTRIBUTES`: {relvar_name: String, attribute_name: String, type: String, is_pk: Bool}

These views allow "reflection" - querying the database structure using the database itself.
The implementation uses the existing public API of `Database` (list_relvars, get_relvar_type, get_key_constraints).

Added `relvar/tests/test_system_views.rs` to verify:
- Registration.
- Querying metadata.
- PK detection.
- Dynamic updates (new relvars appear in views).


---
*PR created automatically by Jules for task [3061653519503736385](https://jules.google.com/task/3061653519503736385) started by @madmax983*