### PR TITLE
🎻 Bard: Documentation improvements for core operators and storage

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -14,3 +14,11 @@
 - `relvar`: Facade crate that re-exports the core API
 
 This ensures the map matches the territory.
+
+## 2024-05-24 - Project Operator Silently Ignores Attributes
+**Confusion:** Users might expect `relation.project(&["non_existent"])` to panic or return a Result::Err.
+**Clarification:** The `project` operator follows set intersection logic. It projects the relation onto the intersection of the relation's heading and the requested attributes. If a requested attribute doesn't exist, it is simply not in the result. Asking for a set of non-existent attributes correctly returns a relation with an empty heading (TABLE_DEE or TABLE_DUM), which is mathematically consistent but potentially surprising to SQL users.
+
+## 2024-05-24 - Update Validation Performance
+**Confusion:** Updating a large relation seemed slower than expected, even for small changes.
+**Clarification:** To ensure absolute data integrity, `Database::update` currently re-validates ALL constraints (Type, CHECK, Foreign Key) against EVERY tuple in the resulting relation, not just the modified ones. This is an O(N) operation. While safe, it is a known performance bottleneck that will be optimized in future versions.

--- a/relvar-core/src/algebra/project.rs
+++ b/relvar-core/src/algebra/project.rs
@@ -50,9 +50,11 @@ impl Relation {
     ///
     /// # Behavior
     ///
-    /// - Attributes not in the list are removed
-    /// - Attributes that don't exist in the relation are silently ignored
-    /// - Duplicate tuples are automatically eliminated
+    /// - Attributes not in the list are removed.
+    /// - **Warning:** Attributes requested that do not exist in the relation are silently ignored.
+    ///   This follows set intersection logic: the result contains only attributes present in BOTH
+    ///   the relation and the request list.
+    /// - Duplicate tuples are automatically eliminated.
     ///
     /// # Example
     ///
@@ -70,6 +72,12 @@ impl Relation {
     ///
     /// let names_only = relation.project(&["name"]);
     /// assert_eq!(names_only.degree(), 1);
+    ///
+    /// // Projecting non-existent attributes results in empty heading (TABLE_DEE or TABLE_DUM)
+    /// // Here, since the relation is not empty, we get TABLE_DEE (degree 0, cardinality 1)
+    /// let ignored = relation.project(&["non_existent_attr"]);
+    /// assert_eq!(ignored.degree(), 0);
+    /// assert_eq!(ignored.cardinality(), 1);
     /// ```
     pub fn project(&self, attributes: &[&str]) -> Self {
         // Build new heading with selected attributes

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -110,7 +110,24 @@ pub enum ConstraintExpression {
     In(String, Vec<ScalarValue>),
 
     /// Pattern matching: attribute LIKE pattern
-    /// (Simple SQL-style patterns: % for any chars, _ for single char)
+    ///
+    /// # Wildcards
+    /// - `%`: Matches any sequence of characters (including empty).
+    /// - `_`: Matches exactly one character.
+    ///
+    /// # Complexity
+    /// Uses a dynamic programming approach with **O(N*M)** time and space complexity,
+    /// where N is the string length and M is the pattern length.
+    ///
+    /// # Example
+    /// ```
+    /// use relvar_core::constraints::expression::ConstraintExpression;
+    /// use relvar_core::tuple;
+    ///
+    /// // Matches "data_2024.csv", "data_final.csv", etc.
+    /// let expr = ConstraintExpression::Like("filename".to_string(), "data_%.csv".to_string());
+    /// assert!(expr.evaluate(&tuple! { filename: "data_2024.csv" }).unwrap());
+    /// ```
     Like(String, String),
 }
 

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -539,6 +539,13 @@ impl<E: StorageEngine> Database<E> {
     /// - A type constraint is violated ([`ConstraintManagerError::TypeConstraintViolation`])
     /// - A CHECK constraint is violated ([`ConstraintManagerError::CheckConstraintViolation`])
     ///
+    /// # Performance
+    ///
+    /// - **Constraint Validation:** Currently, all constraints (CHECK, Type, Foreign Key) are re-validated
+    ///   against **every tuple** in the relation after the update, not just the modified ones.
+    ///   This ensures total consistency but has O(N) complexity where N is the relation size.
+    ///   Future versions may optimize this to O(K) where K is the number of updated tuples.
+    ///
     /// # Example
     ///
     /// ```

--- a/relvar-storage/src/storage/page.rs
+++ b/relvar-storage/src/storage/page.rs
@@ -43,8 +43,14 @@ use thiserror::Error;
 
 /// Page size in bytes (4KB).
 ///
-/// This is a common page size that balances I/O efficiency with memory usage.
-/// Larger pages reduce I/O overhead but may waste space for small tuples.
+/// This size (4096 bytes) is chosen to align with:
+/// - Standard disk sector sizes (typically 4KB on modern SSDs/HDDs).
+/// - Virtual memory page sizes (typically 4KB on x86/ARM).
+///
+/// # Trade-offs
+/// - **I/O Efficiency:** Matches the atomic write unit of most storage hardware, minimizing write amplification.
+/// - **Fragmentation:** Smaller pages reduce wasted space (internal fragmentation) for small tuples but increase metadata overhead.
+/// - **Memory Usage:** 4KB is small enough to keep many pages cached in memory.
 pub const PAGE_SIZE: usize = 4096;
 
 /// Unique identifier for a page within a page file.


### PR DESCRIPTION
Improved documentation across core and storage crates. Specifically, clarified the "silent ignore" behavior of the project operator, the performance characteristics of the update operation, the wildcard support for the Like constraint, and the rationale behind the 4KB page size. Added journal entries for these clarifications. All changes verified with `cargo test` and `cargo doc`.

---
*PR created automatically by Jules for task [10633118855878801401](https://jules.google.com/task/10633118855878801401) started by @madmax983*