### PR TITLE
🛡️ Sentry: Fix inconsistent NaN handling in ScalarValue

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -21,3 +21,11 @@
 ## 2026-06-15 - Unnecessary Integer Overflow in Aggregation
 **Learning:** `Avg` aggregation was using `i64` accumulator, causing it to fail on large datasets where the sum exceeds `i64::MAX` even if the average is small.
 **Action:** Use `i128` (or larger type) accumulators for integer aggregations to prevent intermediate overflows.
+
+## 2026-10-24 - Inconsistent NaN Handling in Scalar Values
+**Learning:** Found that  relied on  for equality and hashing, causing different NaN payloads to be treated as distinct values (and distinct groups in ).
+**Action:** When implementing database types, always normalize NaNs in , , and  to ensure set semantics (all NaNs are equal), regardless of the underlying bit pattern.
+
+## 2026-10-24 - Inconsistent NaN Handling in Scalar Values
+**Learning:** Found that `ScalarValue::Float` relied on `f64::to_bits()` for equality and hashing, causing different NaN payloads to be treated as distinct values (and distinct groups in `summarize`).
+**Action:** When implementing database types, always normalize NaNs in `Eq`, `Hash`, and `Ord` to ensure set semantics (all NaNs are equal), regardless of the underlying bit pattern.

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -207,7 +207,13 @@ impl PartialEq for ScalarValue {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (ScalarValue::Int(a), ScalarValue::Int(b)) => a == b,
-            (ScalarValue::Float(a), ScalarValue::Float(b)) => a.to_bits() == b.to_bits(),
+            (ScalarValue::Float(a), ScalarValue::Float(b)) => {
+                if a.is_nan() && b.is_nan() {
+                    true
+                } else {
+                    a.to_bits() == b.to_bits()
+                }
+            }
             (ScalarValue::String(a), ScalarValue::String(b)) => a == b,
             (ScalarValue::Bool(a), ScalarValue::Bool(b)) => a == b,
             (ScalarValue::Bytes(a), ScalarValue::Bytes(b)) => a == b,
@@ -241,7 +247,11 @@ impl std::hash::Hash for ScalarValue {
             }
             ScalarValue::Float(v) => {
                 1u8.hash(state);
-                v.to_bits().hash(state);
+                if v.is_nan() {
+                    f64::NAN.to_bits().hash(state);
+                } else {
+                    v.to_bits().hash(state);
+                }
             }
             ScalarValue::String(v) => {
                 2u8.hash(state);
@@ -302,8 +312,13 @@ impl Ord for ScalarValue {
                 match (self, other) {
                     (ScalarValue::Int(a), ScalarValue::Int(b)) => a.cmp(b),
                     (ScalarValue::Float(a), ScalarValue::Float(b)) => {
-                        // For floats, use bit ordering (treats NaN consistently)
-                        a.to_bits().cmp(&b.to_bits())
+                        // For floats, treat all NaNs as equal and greater than any other float
+                        match (a.is_nan(), b.is_nan()) {
+                            (true, true) => Ordering::Equal,
+                            (true, false) => Ordering::Greater,
+                            (false, true) => Ordering::Less,
+                            (false, false) => a.to_bits().cmp(&b.to_bits()),
+                        }
                     }
                     (ScalarValue::String(a), ScalarValue::String(b)) => a.cmp(b),
                     (ScalarValue::Bool(a), ScalarValue::Bool(b)) => a.cmp(b),
@@ -729,5 +744,29 @@ mod tests {
             }
             _ => panic!("Expected relation value"),
         }
+    }
+}
+
+#[cfg(test)]
+mod nan_fix_tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_nan_grouping_consistent() {
+        let nan1 = ScalarValue::Float(f64::NAN);
+        let nan2 = ScalarValue::Float(f64::from_bits(f64::NAN.to_bits() ^ 1));
+
+        assert!(nan1.is_type(&ScalarType::Float));
+        assert!(nan2.is_type(&ScalarType::Float));
+
+        // This assertion ensures that different NaN bit patterns are treated as equal
+        assert_eq!(nan1, nan2, "All NaNs should be equal");
+
+        let mut set = HashSet::new();
+        set.insert(nan1.clone());
+        set.insert(nan2.clone());
+
+        assert_eq!(set.len(), 1, "Set should contain only one NaN");
     }
 }


### PR DESCRIPTION
🛡️ Sentry: Fix inconsistent NaN handling in ScalarValue

🎯 **Target**: `relvar-core/src/values/scalar.rs` (ScalarValue equality, hashing, and ordering).

💣 **Risk**: Without this fix, different NaN bit patterns (payloads) are treated as distinct values. This means `summarize` (GROUP BY) could produce multiple groups for "NaN" values, and `join` might fail to match NaNs that should be considered equal in a database context. This violates the "NaN == NaN" expectation for set semantics stated in the README.

🧪 **Strategy**: 
- Added a reproduction test case `test_nan_grouping_consistent` that creates two different NaN bit patterns and asserts they are equal and form a single set entry.
- Modified `PartialEq`, `Hash`, and `Ord` to explicitly check for `is_nan()` and normalize behavior (treat all NaNs as the same canonical value).

🔬 **Verification**: 
- Run `cargo test -p relvar-core test_nan_grouping_consistent` to verify the fix.
- Run `cargo test -p relvar-core` to ensure no regressions in other scalar types or operations.

---
*PR created automatically by Jules for task [2116463780389869400](https://jules.google.com/task/2116463780389869400) started by @madmax983*