### PR TITLE
🔒 Warden: Harden bincode deserialization against allocation bombs

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -53,3 +53,12 @@ Added a pre-check `check_tuple_size_limit` using `bincode::serialized_size` on a
 
 **Defense:**
 Modified insertion logic to clone the page structure, insert a dummy entry into the target slot, and use `bincode::serialized_size` to calculate the exact header requirements before committing the write.
+
+## 2026-02-05 - Bincode Allocation Bomb DoS
+**Threat:**
+`relvar-storage` uses `bincode` 1.3.3, which is unmaintained and vulnerable to allocation bomb attacks. `bincode::deserialize` reads length prefixes from the input and pre-allocates memory based on that length before reading the actual data. An attacker could craft a malicious page containing a tuple with a huge declared length (e.g., 1GB) but very little data, causing the server to exhaust memory (DoS) or panic when attempting to allocate.
+
+**Defense:**
+1.  Implemented `deserialize_bounded` helper function in `HeapFile`.
+2.  Configured `bincode::options()` with `.with_limit(PAGE_SIZE)` to reject any allocation request exceeding the page size (4KB). Since no tuple or structure within a page can validly exceed the page size, this prevents unbounded allocation.
+3.  Preserved legacy configuration (`LittleEndian`, `FixedIntEncoding`, `AllowTrailingBytes`) to maintain compatibility with existing disk format.

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -21,11 +21,31 @@
 //! storage references, maintaining the relational abstraction.
 
 use super::page::{PAGE_SIZE, Page, PageError, PageFile, PageId};
+use bincode::Options;
 use relvar_core::types::RelationType;
 use relvar_core::values::{Relation, Tuple};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use thiserror::Error;
+
+/// Helper for bounded deserialization to prevent allocation bombs.
+/// Limits allocation size to PAGE_SIZE (4KB), preventing DoS from malicious length prefixes.
+fn deserialize_bounded<'a, T>(data: &'a [u8]) -> Result<T, HeapError>
+where
+    T: Deserialize<'a>,
+{
+    // Limit deserialization size to PAGE_SIZE to prevent allocation bombs.
+    // bincode 1.3.3's with_limit checks the size of data being deserialized.
+    // For Vec/String, it checks the length prefix against this limit.
+    // NOTE: Must explicitly set LittleEndian and FixedIntEncoding to match legacy bincode::serialize defaults.
+    bincode::options()
+        .with_little_endian()
+        .with_fixint_encoding()
+        .with_limit(PAGE_SIZE as u64)
+        .allow_trailing_bytes()
+        .deserialize(data)
+        .map_err(|e| HeapError::Serialization(e.to_string()))
+}
 
 /// Tuple ID: (page_id, slot_number)
 /// Internal to storage layer only (TTM Proscription 6)
@@ -464,8 +484,7 @@ impl HeapFile {
             return Err(HeapError::TupleNotFound);
         }
 
-        let slotted_page: SlottedPage = bincode::deserialize(page.data())
-            .map_err(|e| HeapError::Serialization(e.to_string()))?;
+        let slotted_page: SlottedPage = deserialize_bounded(page.data())?;
 
         let slot_entry = slotted_page
             .slots
@@ -482,8 +501,7 @@ impl HeapFile {
         }
 
         let tuple_data = &page.data()[start..end];
-        let tuple: Tuple = bincode::deserialize(tuple_data)
-            .map_err(|e| HeapError::Serialization(e.to_string()))?;
+        let tuple: Tuple = deserialize_bounded(tuple_data)?;
 
         Ok(tuple)
     }
@@ -518,8 +536,7 @@ impl HeapFile {
         }
 
         let tuple_data = &page.data()[start..end];
-        let tuple: Tuple = bincode::deserialize(tuple_data)
-            .map_err(|e| HeapError::Serialization(e.to_string()))?;
+        let tuple: Tuple = deserialize_bounded(tuple_data)?;
 
         Ok(tuple)
     }
@@ -918,17 +935,16 @@ impl HeapFile {
                 )));
             }
 
-            bincode::deserialize(&page.data()[5..end_of_header])
-                .map_err(|e| HeapError::Serialization(e.to_string()))
+            deserialize_bounded(&page.data()[5..end_of_header])
         } else {
             // Old format: [slot_dir][tuples]
-            bincode::deserialize(page.data()).map_err(|e| HeapError::Serialization(e.to_string()))
+            deserialize_bounded(page.data())
         }
     }
 
     /// Deserializes a standard slotted page.
     fn deserialize_slotted_page(&self, page: &Page) -> Result<SlottedPage, HeapError> {
-        bincode::deserialize(page.data()).map_err(|e| HeapError::Serialization(e.to_string()))
+        deserialize_bounded(page.data())
     }
 
     /// Validates that a slot points to valid data within the page.
@@ -961,7 +977,7 @@ impl HeapFile {
     ) -> Result<Tuple, HeapError> {
         let (start, end) = self.validate_slot_bounds(page, offset, length)?;
         let tuple_data = &page.data()[start..end];
-        bincode::deserialize(tuple_data).map_err(|e| HeapError::Serialization(e.to_string()))
+        deserialize_bounded(tuple_data)
     }
 
     /// Extracts raw tuple data from a page at the given offset and length.
@@ -1392,8 +1408,7 @@ impl HeapFile {
 
                     if end <= page.data().len() {
                         let tuple_data = &page.data()[start..end];
-                        let tuple: Tuple = bincode::deserialize(tuple_data)
-                            .map_err(|e| HeapError::Serialization(e.to_string()))?;
+                        let tuple: Tuple = deserialize_bounded(tuple_data)?;
                         results.push(tuple);
                     }
                 }
@@ -3468,6 +3483,28 @@ mod tests {
                 println!("Page split happened at insert {}", i);
                 break;
             }
+        }
+    }
+
+    #[test]
+    fn test_allocation_bomb_prevention() {
+        // Construct a malicious payload: a Vec<u8> with length prefix 1GB
+        // bincode uses little-endian by default
+        let huge_len: u64 = 1024 * 1024 * 1024; // 1 GB
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&huge_len.to_le_bytes());
+        // No actual data follows
+
+        // Try to deserialize into Vec<u8> using our bounded deserializer
+        // This should fail immediately because the declared length exceeds PAGE_SIZE
+        let result: Result<Vec<u8>, HeapError> = deserialize_bounded(&payload);
+
+        assert!(result.is_err());
+        match result {
+            Err(HeapError::Serialization(_)) => {
+                // Expected error
+            }
+            _ => panic!("Expected Serialization error, got {:?}", result),
         }
     }
 }


### PR DESCRIPTION
Hardened `relvar-storage` against Denial of Service (DoS) attacks via allocation bombs in `bincode` deserialization.

**Security Hardening:**
- Replaced vulnerable `bincode::deserialize` calls in `HeapFile` with a new `deserialize_bounded` helper.
- Configured `bincode` options to enforce a strict memory allocation limit equal to `PAGE_SIZE` (4KB). This prevents malicious payloads from triggering massive allocations by specifying huge length prefixes.
- Ensured compatibility with existing disk format by explicitly setting `LittleEndian` and `FixedIntEncoding` options, as `bincode::options()` defaults to `Varint` (unlike `bincode::serialize`).

**Verification:**
- Added `test_allocation_bomb_prevention` regression test which confirms that attempting to deserialize a payload with a 1GB length prefix fails safely with an error instead of crashing or hanging.
- Verified all existing storage tests pass, ensuring no regression in valid data handling.

---
*PR created automatically by Jules for task [6726883611077820763](https://jules.google.com/task/6726883611077820763) started by @madmax983*