### PR TITLE
Refactor: Simplify Aggregation, PersistentSnapshot, and Rename

### DIFF
--- a/benches/algebra.rs
+++ b/benches/algebra.rs
@@ -1,5 +1,5 @@
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use relvar::algebra::summarize::{Aggregation, AggregationFn};
+use relvar::algebra::summarize::Aggregation;
 use relvar::tuple;
 use relvar::types::{RelationType, ScalarType, TupleType};
 use relvar::values::{Relation, ScalarValue};
@@ -255,26 +255,7 @@ fn bench_summarize(c: &mut Criterion) {
 
             b.iter(|| {
                 let result = relation
-                    .summarize(
-                        &["dept_id"],
-                        &[
-                            Aggregation::count("count"),
-                            Aggregation {
-                                result_name: "avg_salary".to_string(),
-                                result_type: ScalarType::Float,
-                                function: AggregationFn::Custom(Box::new(|tuples| {
-                                    if tuples.is_empty() {
-                                        return ScalarValue::Float(0.0);
-                                    }
-                                    let sum: f64 = tuples
-                                        .iter()
-                                        .map(|t| t.get_typed::<f64>("salary").unwrap())
-                                        .sum();
-                                    ScalarValue::Float(sum / tuples.len() as f64)
-                                })),
-                            },
-                        ],
-                    )
+                    .summarize(&["dept_id"], &[Aggregation::count("count")])
                     .unwrap();
                 black_box(result);
             });

--- a/relvar-core/benches/algebra.rs
+++ b/relvar-core/benches/algebra.rs
@@ -1,5 +1,5 @@
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use relvar_core::algebra::summarize::{Aggregation, AggregationFn};
+use relvar_core::algebra::summarize::Aggregation;
 use relvar_core::tuple;
 use relvar_core::types::{RelationType, ScalarType, TupleType};
 use relvar_core::values::{Relation, ScalarValue};
@@ -293,26 +293,7 @@ fn bench_summarize(c: &mut Criterion) {
 
             b.iter(|| {
                 let result = relation
-                    .summarize(
-                        &["dept_id"],
-                        &[
-                            Aggregation::count("count"),
-                            Aggregation {
-                                result_name: "avg_salary".to_string(),
-                                result_type: ScalarType::Float,
-                                function: AggregationFn::Custom(Box::new(|tuples| {
-                                    if tuples.is_empty() {
-                                        return ScalarValue::Float(0.0);
-                                    }
-                                    let sum: f64 = tuples
-                                        .iter()
-                                        .map(|t| t.get_typed::<f64>("salary").unwrap())
-                                        .sum();
-                                    ScalarValue::Float(sum / tuples.len() as f64)
-                                })),
-                            },
-                        ],
-                    )
+                    .summarize(&["dept_id"], &[Aggregation::count("count")])
                     .unwrap();
                 black_box(result);
             });

--- a/relvar-core/src/algebra/rename.rs
+++ b/relvar-core/src/algebra/rename.rs
@@ -31,7 +31,6 @@
 
 use crate::types::{RelationType, TupleType};
 use crate::values::{Relation, Tuple};
-use std::collections::HashMap;
 
 impl Relation {
     /// Renames attributes in this relation according to the provided mapping.
@@ -109,19 +108,16 @@ impl Relation {
 
         // Rename attributes in each tuple
         let renamed_tuples = self.tuples().map(|tuple| {
-            let mut values = HashMap::new();
-
-            for (old_name, value) in tuple.values() {
+            let values_iter = tuple.values().iter().map(|(old_name, value)| {
                 let new_name = mappings
                     .iter()
                     .find(|(from, _)| from == old_name)
                     .map(|(_, to)| *to)
                     .unwrap_or(old_name.as_str());
+                (new_name.to_string(), value.clone())
+            });
 
-                values.insert(new_name.to_string(), value.clone());
-            }
-
-            Tuple::new(new_heading.clone(), values)
+            Tuple::new(new_heading.clone(), values_iter)
                 .expect("Rename should maintain type consistency")
         });
 

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -94,12 +94,6 @@ pub enum AggregationFn {
     ///
     /// The string parameter specifies the attribute name.
     Max(String),
-
-    /// A custom aggregation function.
-    ///
-    /// Takes a slice of tuple references and returns a computed scalar value.
-    #[allow(clippy::type_complexity)]
-    Custom(Box<dyn Fn(&[&Tuple]) -> ScalarValue>),
 }
 
 /// Defines a single aggregation to compute in a summarize operation.
@@ -347,7 +341,6 @@ impl Aggregation {
                 }
                 Ok(max_value)
             }
-            AggregationFn::Custom(f) => Ok(f(tuples)),
         }
     }
 }
@@ -902,37 +895,6 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_custom_aggregation() {
-        let heading = TupleType::new().with_attribute("value".to_string(), ScalarType::Int);
-
-        let rel_type = RelationType::new(heading);
-        let mut relation = Relation::new(rel_type);
-        relation.insert(tuple! { value: 10i64 }).unwrap();
-        relation.insert(tuple! { value: 20i64 }).unwrap();
-        relation.insert(tuple! { value: 30i64 }).unwrap();
-
-        // Custom aggregation: product of all values
-        let custom_agg = Aggregation {
-            result_name: "product".to_string(),
-            result_type: ScalarType::Int,
-            function: AggregationFn::Custom(Box::new(|tuples| {
-                let mut product = 1i64;
-                for tuple in tuples {
-                    if let Some(val) = tuple.get_typed::<i64>("value") {
-                        product *= val;
-                    }
-                }
-                ScalarValue::Int(product)
-            })),
-        };
-
-        let result = relation.summarize(&[], &[custom_agg]).unwrap();
-
-        assert_eq!(result.cardinality(), 1);
-        let tuple = result.tuples().next().unwrap();
-        assert_eq!(tuple.get_typed::<i64>("product").unwrap(), 6000); // 10 * 20 * 30
-    }
 
     #[test]
     fn test_min_with_multiple_tuples() {

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -895,7 +895,6 @@ mod tests {
         ));
     }
 
-
     #[test]
     fn test_min_with_multiple_tuples() {
         let heading = TupleType::new()

--- a/relvar-storage/src/persistent_engine.rs
+++ b/relvar-storage/src/persistent_engine.rs
@@ -16,20 +16,6 @@ use std::path::{Path, PathBuf};
 pub struct PersistentSnapshot {
     /// The transaction ID.
     pub txn_id: TransactionId,
-    /// Saved relations (for compatibility with old rollback approach).
-    ///
-    /// # Transition Note
-    ///
-    /// This field is a temporary bridge. Currently, rollback is implemented by
-    /// restoring full relation state from memory.
-    ///
-    /// **Future State:** Once full MVCC integration is complete, rollback will
-    /// be instantaneous (simply discarding the transaction ID), as uncommitted
-    /// versions are automatically invisible to other transactions. At that point,
-    /// this field will be removed.
-    ///
-    /// TODO: Remove once full WAL/MVCC recovery is implemented.
-    pub saved_relations: HashMap<String, Relation>,
 }
 
 /// Persistent storage engine using heap files and JSON catalog.
@@ -543,10 +529,7 @@ impl StorageEngine for PersistentEngine {
 
         // Auto-commit if needed
         if auto_commit {
-            let snapshot = PersistentSnapshot {
-                txn_id,
-                saved_relations: HashMap::new(),
-            };
+            let snapshot = PersistentSnapshot { txn_id };
             self.commit_transaction(snapshot)?;
         }
 
@@ -589,10 +572,7 @@ impl StorageEngine for PersistentEngine {
 
         // Auto-commit if needed
         if auto_commit {
-            let snapshot = PersistentSnapshot {
-                txn_id,
-                saved_relations: HashMap::new(), // Empty for auto-commit
-            };
+            let snapshot = PersistentSnapshot { txn_id };
             self.commit_transaction(snapshot)?;
         }
 
@@ -618,10 +598,7 @@ impl StorageEngine for PersistentEngine {
         self.current_txn = Some(txn_id);
 
         // MVCC handles rollback via visibility - no need to save relations
-        Ok(PersistentSnapshot {
-            txn_id,
-            saved_relations: HashMap::new(),
-        })
+        Ok(PersistentSnapshot { txn_id })
     }
 
     fn commit_transaction(&mut self, snapshot: Self::Snapshot) -> Result<(), StorageError> {


### PR DESCRIPTION
This PR applies Razor principles to simplify the codebase and remove dead code.

Key changes:
1.  **Remove `AggregationFn::Custom`**: This variant contained a `Box<dyn Fn>` which prevented `Aggregation` from being `Send + Sync`. It was only used in tests and benchmarks. Removing it simplifies the type and improves thread safety.
2.  **Remove `PersistentSnapshot::saved_relations`**: This field was a temporary bridge for rollback, but MVCC visibility now handles rollback. The field was unused and populated with empty maps.
3.  **Optimize `Relation::rename`**: Refactored to stream mapped values directly into `Tuple::new` using an iterator, avoiding an intermediate `HashMap` allocation for each tuple.

All tests passed and clippy is clean.

---
*PR created automatically by Jules for task [11650325769688644834](https://jules.google.com/task/11650325769688644834) started by @madmax983*