### PR TITLE
Docs: Update README and fix intra-doc links

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -22,3 +22,7 @@ This ensures the map matches the territory.
 ## 2024-05-24 - Update Validation Performance
 **Confusion:** Updating a large relation seemed slower than expected, even for small changes.
 **Clarification:** To ensure absolute data integrity, `Database::update` currently re-validates ALL constraints (Type, CHECK, Foreign Key) against EVERY tuple in the resulting relation, not just the modified ones. This is an O(N) operation. While safe, it is a known performance bottleneck that will be optimized in future versions.
+
+## 2024-05-24 - Implemented Features Listed as Future
+**Confusion:** The README listed MVCC and WAL as "Future Enhancements", but they are fully implemented in `relvar-storage`.
+**Clarification:** I updated the README to reflect the current state of the codebase. The `relvar-storage` crate implements full MVCC snapshot isolation and Write-Ahead Logging.

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ Unlike SQL databases, Relvar adheres strictly to relational theory:
 - **Storage Layer**
   - Page-based persistent storage (4KB pages)
   - Slotted page architecture for variable-length tuples
-  - B-tree indexes for efficient lookups
   - System catalog for metadata
   - Heap files for tuple storage
+  - Concurrency control (MVCC) for snapshot isolation
+  - Write-Ahead Logging (WAL) for durability and crash recovery
 
 - **Database API**
   - Create/drop relation variables (relvars)
@@ -306,8 +307,6 @@ GitHub Actions automatically runs on every push:
 ### Future Enhancements
 
 - [ ] Query optimizer (cost-based optimization)
-- [ ] Concurrency control (MVCC or 2PL)
-- [ ] Write-Ahead Logging (WAL) for durability
 - [ ] Query language parser (Tutorial D or custom syntax)
 - [ ] Network protocol (client-server architecture)
 - [ ] REPL (Read-Eval-Print Loop) for interactive use

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -428,7 +428,7 @@ impl<E: StorageEngine> Database<E> {
     /// Returns an error if:
     /// - The relation doesn't exist ([`DatabaseError::RelationNotFound`])
     /// - Deleting the tuples would violate a foreign key constraint in another relation
-    ///   ([`ConstraintManagerError::ForeignKeyViolation`])
+    ///   ([`crate::constraints::ConstraintManagerError::ForeignKeyViolation`])
     ///
     /// # Example
     ///
@@ -485,10 +485,10 @@ impl<E: StorageEngine> Database<E> {
     /// Returns an error if:
     /// - The relation doesn't exist ([`DatabaseError::RelationNotFound`])
     /// - The updated tuple doesn't match the relation type ([`DatabaseError::TupleMismatch`])
-    /// - A key constraint is violated ([`ConstraintManagerError::PrimaryKeyViolation`], [`ConstraintManagerError::CandidateKeyViolation`])
-    /// - A foreign key constraint is violated ([`ConstraintManagerError::ForeignKeyViolation`])
-    /// - A type constraint is violated ([`ConstraintManagerError::TypeConstraintViolation`])
-    /// - A CHECK constraint is violated ([`ConstraintManagerError::CheckConstraintViolation`])
+    /// - A key constraint is violated ([`crate::constraints::ConstraintManagerError::PrimaryKeyViolation`], [`crate::constraints::ConstraintManagerError::CandidateKeyViolation`])
+    /// - A foreign key constraint is violated ([`crate::constraints::ConstraintManagerError::ForeignKeyViolation`])
+    /// - A type constraint is violated ([`crate::constraints::ConstraintManagerError::TypeConstraintViolation`])
+    /// - A CHECK constraint is violated ([`crate::constraints::ConstraintManagerError::CheckConstraintViolation`])
     ///
     /// # Performance
     ///


### PR DESCRIPTION
This PR updates the project documentation to match the current implementation state.

**Key Changes:**
1.  **README.md**:
    *   Moved "Concurrency control (MVCC)" and "Write-Ahead Logging (WAL)" from "Future Enhancements" to the "Storage Layer" features section, as these are implemented in `relvar-storage`.
    *   Removed "B-tree indexes" from "Storage Layer" as the codebase uses heap files without B-tree indexing.
2.  **relvar-core/src/database.rs**:
    *   Fixed broken documentation links to `ConstraintManagerError` by using fully qualified paths (e.g., `[`crate::constraints::ConstraintManagerError::ForeignKeyViolation`]`).
3.  **Bard's Journal**:
    *   Added an entry documenting the confusion around implemented features listed as future enhancements.

Verified with `cargo doc --no-deps`, `cargo test`, and `cargo clippy`.

---
*PR created automatically by Jules for task [5137664401148971456](https://jules.google.com/task/5137664401148971456) started by @madmax983*