### PR TITLE
🛡️ Sentry: Add crash recovery test for uncommitted data

### DIFF
--- a/relvar-storage/src/persistent_engine.rs
+++ b/relvar-storage/src/persistent_engine.rs
@@ -1983,4 +1983,47 @@ mod tests {
 
         engine.commit_transaction(snapshot2).unwrap();
     }
+
+    #[test]
+    fn test_recovery_undoes_uncommitted_data() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // 1. Create database and perform uncommitted work
+        {
+            let mut engine = PersistentEngine::open(temp_dir.path()).unwrap();
+            engine.create_relation("TEST", test_rel_type()).unwrap();
+
+            // Begin transaction
+            let _snapshot = engine.begin_transaction().unwrap();
+
+            // Insert tuple (written to WAL and Heap)
+            // insert_tuple uses the active transaction established by begin_transaction
+            engine
+                .insert_tuple("TEST", tuple! { id: 1i64, name: "Uncommitted" })
+                .unwrap();
+
+            // CRASH! (Drop engine without calling commit_transaction)
+            // WAL contains: Begin, Insert
+            // WAL does NOT contain: Commit
+        }
+
+        // 2. Reopen database (Trigger Recovery)
+        {
+            let engine = PersistentEngine::open(temp_dir.path()).unwrap();
+
+            // Recovery should:
+            // 1. See uncommitted transaction in WAL
+            // 2. Scan heap files and remove tuples created by that transaction
+            //    (via undo_uncommitted_inserts)
+
+            let relation = engine.load_relation("TEST").unwrap();
+
+            // Verify tuple is gone
+            assert_eq!(
+                relation.cardinality(),
+                0,
+                "Recovery failed to undo uncommitted insert"
+            );
+        }
+    }
 }


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 **Target**: Crash recovery logic in `PersistentEngine` (`undo_uncommitted_inserts`).

💣 **Risk**: Uncommitted data persists after a crash, violating Atomicity. If the WAL contains a `BEGIN` and `INSERT` but no `COMMIT`, the system must ensure the inserted data is not visible after recovery.

🧪 **Strategy**: 
- Create a `PersistentEngine` in a temp dir.
- Begin a transaction and insert a tuple (which writes to WAL and Heap).
- Drop the engine instance (simulating a crash before commit).
- Re-open the engine (triggering recovery).
- Verify the relation is empty (the uncommitted tuple was undone).

🔬 **Verification**: 
`cargo test -p relvar-storage --lib persistent_engine::tests::test_recovery_undoes_uncommitted_data`
Passed successfully.

---
*PR created automatically by Jules for task [15366835563010580281](https://jules.google.com/task/15366835563010580281) started by @madmax983*