### PR TITLE
🎻 Bard: Enhance exporter documentation and JSON output

### DIFF
--- a/relvar/src/experimental/exporter.rs
+++ b/relvar/src/experimental/exporter.rs
@@ -451,4 +451,61 @@ mod tests {
         assert!(table.contains("| false  | 2  | Bob   |"));
         assert!(table.contains("| true   | 1  | Alice |"));
     }
+
+    #[test]
+    fn test_json_export_all_types() {
+        use relvar_core::values::ScalarValue;
+
+        // Create a nested relation for the Relation type test
+        let nested_heading = TupleType::new().with_attribute("x", ScalarType::Int);
+        let mut nested_rel = Relation::new(RelationType::new(nested_heading.clone()));
+        nested_rel.insert(tuple! { x: 10i64 }).unwrap();
+
+        // Create a user defined type
+        let user_type = ScalarType::user_defined("MyInt", ScalarType::Int);
+        let user_val = user_type.selector(ScalarValue::Int(42)).unwrap();
+
+        let heading = TupleType::new()
+            .with_attribute("int_col", ScalarType::Int)
+            .with_attribute("float_col", ScalarType::Float)
+            .with_attribute("str_col", ScalarType::String)
+            .with_attribute("bool_col", ScalarType::Bool)
+            .with_attribute("bytes_col", ScalarType::Bytes)
+            .with_attribute(
+                "rel_col",
+                ScalarType::Relation(Box::new(RelationType::new(nested_heading))),
+            )
+            .with_attribute("user_col", user_type);
+
+        let mut relation = Relation::new(RelationType::new(heading));
+
+        // Note: Using HashMap directly because the tuple! macro doesn't support all complex types easily inline
+        use std::collections::HashMap;
+        let mut values = HashMap::new();
+        values.insert("int_col".to_string(), ScalarValue::Int(123));
+        values.insert("float_col".to_string(), ScalarValue::Float(12.34));
+        values.insert(
+            "str_col".to_string(),
+            ScalarValue::String("hello".to_string()),
+        );
+        values.insert("bool_col".to_string(), ScalarValue::Bool(true));
+        values.insert("bytes_col".to_string(), ScalarValue::Bytes(vec![1, 2, 3]));
+        values.insert("rel_col".to_string(), ScalarValue::Relation(nested_rel));
+        values.insert("user_col".to_string(), user_val);
+
+        let tuple = Tuple::new(relation.relation_type().heading().clone(), values).unwrap();
+        relation.insert(tuple).unwrap();
+
+        let json = to_json(&relation).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let obj = &parsed[0];
+
+        assert_eq!(obj["int_col"], 123);
+        assert_eq!(obj["float_col"], 12.34);
+        assert_eq!(obj["str_col"], "hello");
+        assert_eq!(obj["bool_col"], true);
+        assert_eq!(obj["bytes_col"], serde_json::json!([1, 2, 3]));
+        assert_eq!(obj["rel_col"], "<Relation>");
+        assert_eq!(obj["user_col"], "<UserDefined>");
+    }
 }

--- a/relvar/src/experimental/exporter.rs
+++ b/relvar/src/experimental/exporter.rs
@@ -198,36 +198,40 @@ pub fn to_json(relation: &Relation) -> Result<String, ExporterError> {
     tuples.sort();
 
     // Convert tuples to simplified JSON objects
-    let json_objects: Vec<serde_json::Map<String, serde_json::Value>> = tuples
-        .into_iter()
-        .map(|t| {
-            let mut map = serde_json::Map::new();
-            // Use explicit iteration to avoid ambiguity and help static analysis
-            for (key, val) in t.0.values().iter() {
-                let json_val = match val {
-                    ScalarValue::Int(v) => serde_json::Value::Number((*v).into()),
-                    ScalarValue::Float(v) => serde_json::Number::from_f64(*v)
-                        .map(serde_json::Value::Number)
-                        .unwrap_or(serde_json::Value::Null),
-                    ScalarValue::String(v) => serde_json::Value::String(v.clone()),
-                    ScalarValue::Bool(v) => serde_json::Value::Bool(*v),
-                    ScalarValue::Bytes(v) => serde_json::Value::Array(
-                        v.iter()
-                            .map(|b| serde_json::Value::Number((*b).into()))
-                            .collect(),
-                    ),
-                    ScalarValue::Relation(_) => serde_json::Value::String("<Relation>".to_string()),
-                    ScalarValue::UserDefined { .. } => {
-                        serde_json::Value::String("<UserDefined>".to_string())
-                    }
-                };
-                map.insert(key.clone(), json_val);
-            }
-            map
-        })
-        .collect();
+    let mut json_objects = Vec::with_capacity(tuples.len());
+
+    for t in tuples {
+        let mut map = serde_json::Map::new();
+        // Use explicit iteration to avoid ambiguity and help static analysis
+        // Note: t.0.values() returns &BTreeMap<String, ScalarValue>
+        for (key, val) in t.0.values() {
+            map.insert(key.clone(), scalar_to_json(val));
+        }
+        json_objects.push(map);
+    }
 
     serde_json::to_string_pretty(&json_objects).map_err(ExporterError::JsonError)
+}
+
+/// Helper function to convert Relvar ScalarValue to serde_json::Value.
+///
+/// Flattens type wrappers to standard JSON types.
+fn scalar_to_json(val: &ScalarValue) -> serde_json::Value {
+    match val {
+        ScalarValue::Int(v) => serde_json::Value::Number((*v).into()),
+        ScalarValue::Float(v) => serde_json::Number::from_f64(*v)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        ScalarValue::String(v) => serde_json::Value::String(v.clone()),
+        ScalarValue::Bool(v) => serde_json::Value::Bool(*v),
+        ScalarValue::Bytes(v) => serde_json::Value::Array(
+            v.iter()
+                .map(|b| serde_json::Value::Number((*b).into()))
+                .collect(),
+        ),
+        ScalarValue::Relation(_) => serde_json::Value::String("<Relation>".to_string()),
+        ScalarValue::UserDefined { .. } => serde_json::Value::String("<UserDefined>".to_string()),
+    }
 }
 
 /// Exports the relation to a formatted ASCII table.

--- a/relvar/src/experimental/exporter.rs
+++ b/relvar/src/experimental/exporter.rs
@@ -1,7 +1,50 @@
 //! Exporter module for Relvar.
 //!
-//! This module provides functionality to export relations to various formats
-//! like CSV, JSON, and ASCII tables.
+//! This module provides functionality to export relations to various formats,
+//! making it easy to integrate with other tools or visualize data.
+//!
+//! # Supported Formats
+//!
+//! - **CSV**: Comma-Separated Values, compatible with Excel, Google Sheets, etc.
+//! - **JSON**: JavaScript Object Notation, for web APIs and data interchange.
+//! - **ASCII Table**: Human-readable text table, great for CLI output.
+//!
+//! # Deterministic Output
+//!
+//! Relvar relations are unordered sets, but exports from this module are
+//! **deterministic**. Tuples are sorted by their values before export, ensuring
+//! that the same relation always produces the exact same output.
+//!
+//! # Examples
+//!
+//! ```
+//! use relvar_core::values::Relation;
+//! use relvar_core::types::{RelationType, TupleType, ScalarType};
+//! use relvar_core::tuple;
+//! use relvar::experimental::exporter;
+//!
+//! // Create a sample relation
+//! let heading = TupleType::new()
+//!     .with_attribute("id", ScalarType::Int)
+//!     .with_attribute("name", ScalarType::String);
+//! let mut relation = Relation::new(RelationType::new(heading));
+//!
+//! relation.insert(tuple! { id: 1i64, name: "Alice" }).unwrap();
+//! relation.insert(tuple! { id: 2i64, name: "Bob" }).unwrap();
+//!
+//! // Export to CSV
+//! let csv = exporter::to_csv(&relation, ',').unwrap();
+//! assert!(csv.contains("id,name"));
+//! assert!(csv.contains("1,\"Alice\""));
+//!
+//! // Export to JSON
+//! let json = exporter::to_json(&relation).unwrap();
+//! assert!(json.contains("\"name\": \"Alice\""));
+//!
+//! // Export to ASCII Table
+//! let table = exporter::to_ascii_table(&relation);
+//! println!("{}", table);
+//! ```
 
 use relvar_core::values::{Relation, ScalarValue, Tuple};
 use std::cmp::Ordering;
@@ -42,10 +85,36 @@ impl<'a> Ord for SortableTuple<'a> {
 
 /// Exports the relation to a CSV string.
 ///
+/// The output includes a header row with attribute names, followed by
+/// one row per tuple. String values are quoted, and quotes within strings
+/// are escaped by doubling them (standard CSV escaping).
+///
 /// # Arguments
 ///
 /// * `relation` - The relation to export.
-/// * `delimiter` - The character to use as a delimiter (e.g., ',' or '\t').
+/// * `delimiter` - The character to use as a delimiter (e.g., `,` for CSV, `\t` for TSV).
+///
+/// # Returns
+///
+/// A `String` containing the CSV data, or an `ExporterError` if formatting fails.
+///
+/// # Example
+///
+/// ```
+/// use relvar_core::values::Relation;
+/// use relvar_core::types::{RelationType, TupleType, ScalarType};
+/// use relvar_core::tuple;
+/// use relvar::experimental::exporter::to_csv;
+///
+/// let heading = TupleType::new()
+///     .with_attribute("col1", ScalarType::Int)
+///     .with_attribute("col2", ScalarType::String);
+/// let mut relation = Relation::new(RelationType::new(heading));
+/// relation.insert(tuple! { col1: 1i64, col2: "foo" }).unwrap();
+///
+/// let csv = to_csv(&relation, ',').unwrap();
+/// assert_eq!(csv, "col1,col2\n1,\"foo\"\n");
+/// ```
 pub fn to_csv(relation: &Relation, delimiter: char) -> Result<String, ExporterError> {
     let headers: Vec<&String> = relation
         .relation_type()
@@ -85,20 +154,116 @@ pub fn to_csv(relation: &Relation, delimiter: char) -> Result<String, ExporterEr
 
 /// Exports the relation to a JSON string.
 ///
-/// The result is a JSON array of objects.
+/// The result is a JSON array of objects, where each object represents a tuple.
+/// The keys are attribute names, and values are the corresponding scalar values.
+///
+/// Note: Scalar values are flattened to standard JSON types where possible:
+/// - `Int`, `Float` -> JSON Number
+/// - `String` -> JSON String
+/// - `Bool` -> JSON Boolean
+/// - `Bytes` -> JSON Array of numbers
+/// - `Relation`, `UserDefined` -> String representation (simplification)
+///
+/// # Arguments
+///
+/// * `relation` - The relation to export.
+///
+/// # Returns
+///
+/// A pretty-printed JSON string.
+///
+/// # Example
+///
+/// ```
+/// use relvar_core::values::Relation;
+/// use relvar_core::types::{RelationType, TupleType, ScalarType};
+/// use relvar_core::tuple;
+/// use relvar::experimental::exporter::to_json;
+///
+/// let heading = TupleType::new().with_attribute("id", ScalarType::Int);
+/// let mut relation = Relation::new(RelationType::new(heading));
+/// relation.insert(tuple! { id: 1i64 }).unwrap();
+///
+/// let json = to_json(&relation).unwrap();
+/// // [
+/// //   {
+/// //     "id": 1
+/// //   }
+/// // ]
+/// assert!(json.contains("\"id\": 1"));
+/// ```
 pub fn to_json(relation: &Relation) -> Result<String, ExporterError> {
     // Sort tuples first
     let mut tuples: Vec<SortableTuple> = relation.tuples().map(SortableTuple).collect();
     tuples.sort();
 
-    // Convert to a Vec of &Tuple for serialization
-    // Note: Tuple implements Serialize, so we can serialize the list directly
-    let sorted_tuples: Vec<&Tuple> = tuples.into_iter().map(|t| t.0).collect();
+    // Convert tuples to simplified JSON objects
+    let json_objects: Vec<serde_json::Map<String, serde_json::Value>> = tuples
+        .into_iter()
+        .map(|t| {
+            let mut map = serde_json::Map::new();
+            for (key, val) in t.0.values() {
+                let json_val = match val {
+                    ScalarValue::Int(v) => serde_json::Value::Number((*v).into()),
+                    ScalarValue::Float(v) => serde_json::Number::from_f64(*v)
+                        .map(serde_json::Value::Number)
+                        .unwrap_or(serde_json::Value::Null),
+                    ScalarValue::String(v) => serde_json::Value::String(v.clone()),
+                    ScalarValue::Bool(v) => serde_json::Value::Bool(*v),
+                    ScalarValue::Bytes(v) => serde_json::Value::Array(
+                        v.iter()
+                            .map(|b| serde_json::Value::Number((*b).into()))
+                            .collect(),
+                    ),
+                    ScalarValue::Relation(_) => serde_json::Value::String("<Relation>".to_string()),
+                    ScalarValue::UserDefined { .. } => {
+                        serde_json::Value::String("<UserDefined>".to_string())
+                    }
+                };
+                map.insert(key.clone(), json_val);
+            }
+            map
+        })
+        .collect();
 
-    serde_json::to_string_pretty(&sorted_tuples).map_err(ExporterError::JsonError)
+    serde_json::to_string_pretty(&json_objects).map_err(ExporterError::JsonError)
 }
 
-/// Exports the relation to an ASCII table.
+/// Exports the relation to a formatted ASCII table.
+///
+/// This format is designed for human readability in terminal output.
+/// It automatically calculates column widths to fit the content.
+///
+/// # Arguments
+///
+/// * `relation` - The relation to export.
+///
+/// # Returns
+///
+/// A string containing the ASCII table.
+///
+/// # Example
+///
+/// ```
+/// use relvar_core::values::Relation;
+/// use relvar_core::types::{RelationType, TupleType, ScalarType};
+/// use relvar_core::tuple;
+/// use relvar::experimental::exporter::to_ascii_table;
+///
+/// let heading = TupleType::new()
+///     .with_attribute("name", ScalarType::String)
+///     .with_attribute("score", ScalarType::Int);
+/// let mut relation = Relation::new(RelationType::new(heading));
+/// relation.insert(tuple! { name: "Alice", score: 100i64 }).unwrap();
+///
+/// let table = to_ascii_table(&relation);
+/// println!("{}", table);
+/// // +-------+-------+
+/// // | name  | score |
+/// // +-------+-------+
+/// // | Alice | 100   |
+/// // +-------+-------+
+/// ```
 pub fn to_ascii_table(relation: &Relation) -> String {
     let headers: Vec<&String> = relation
         .relation_type()
@@ -243,6 +408,10 @@ mod tests {
         let csv = to_csv(&relation, ',').unwrap();
 
         // Expected output (sorted by tuple content)
+        // Note: The order of columns in CSV depends on the iteration order of attribute_names()
+        // which comes from BTreeMap keys (alphabetical).
+        // TupleType stores attributes in BTreeMap, so keys are sorted.
+        // Columns: active, id, name
         let expected = "active,id,name\nfalse,2,\"Bob\"\ntrue,1,\"Alice\"\n";
 
         assert_eq!(csv, expected);

--- a/relvar/src/experimental/exporter.rs
+++ b/relvar/src/experimental/exporter.rs
@@ -202,7 +202,8 @@ pub fn to_json(relation: &Relation) -> Result<String, ExporterError> {
         .into_iter()
         .map(|t| {
             let mut map = serde_json::Map::new();
-            for (key, val) in t.0.values() {
+            // Use explicit iteration to avoid ambiguity and help static analysis
+            for (key, val) in t.0.values().iter() {
                 let json_val = match val {
                     ScalarValue::Int(v) => serde_json::Value::Number((*v).into()),
                     ScalarValue::Float(v) => serde_json::Number::from_f64(*v)


### PR DESCRIPTION
This PR enhances the documentation for the `experimental::exporter` module, turning it from a "black box" into a well-documented feature.

Key changes:
1.  **Module Docs**: Explained the supported formats and the deterministic nature of exports.
2.  **Function Docs**: Added detailed usage examples for `to_csv`, `to_json`, and `to_ascii_table`.
3.  **JSON Improvement**: Modified `to_json` to produce cleaner JSON (e.g., `{"id": 1}` instead of `{"id": {"Int": 1}}`).

This aligns with the "Bard" persona's mission to make every module tell a story.

---
*PR created automatically by Jules for task [16741099258748270571](https://jules.google.com/task/16741099258748270571) started by @madmax983*