### PR TITLE
⚡ Bolt: optimize collection allocations in join and extend

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2026-02-05 - Pre-allocation in Collection Transformations
 **Learning:** Relational algebra operations often involve transforming one relation to another with preserved or predictable cardinality. Naively collecting into a `Vec` before building a `HashSet` (or other collection) incurs double allocation.
 **Action:** Use `Iterator::size_hint` in constructors (like `from_tuples`) and pass iterators directly instead of intermediate collections. Add `with_capacity` constructors to custom collection types.
+
+## 2026-02-05 - Pre-allocation in Hot Loops
+**Learning:** Relational operators like `join`, `theta_join`, and `extend` often construct new tuples in tight loops. Pre-allocating the `HashMap` or `Vec` for the new tuple's attributes using `with_capacity(degree)` significantly reduces reallocation overhead when the resulting size is known.
+**Action:** Always use `with_capacity` when constructing collections inside hot paths if the target size is known or can be estimated (e.g., from the relation heading).

--- a/relvar-core/src/algebra/extend.rs
+++ b/relvar-core/src/algebra/extend.rs
@@ -99,7 +99,7 @@ impl Relation {
         let new_heading_arc = std::sync::Arc::new(new_heading);
 
         // Create extended tuples
-        let mut extended_tuples = Vec::new();
+        let mut extended_tuples = Vec::with_capacity(self.cardinality());
         for tuple in self.tuples() {
             let mut new_values = tuple.values().clone();
             let computed_value = compute(tuple);

--- a/relvar-core/src/algebra/join.rs
+++ b/relvar-core/src/algebra/join.rs
@@ -147,7 +147,8 @@ impl Relation {
         // Value: Vec<&Tuple> (tuples that have these values)
         // Note: We use &ScalarValue to avoid cloning the values for the key,
         // relying on ScalarValue's Hash implementation which works transitively.
-        let mut build_map: HashMap<Vec<&ScalarValue>, Vec<&Tuple>> = HashMap::new();
+        let mut build_map: HashMap<Vec<&ScalarValue>, Vec<&Tuple>> =
+            HashMap::with_capacity(build_rel.cardinality());
 
         for tuple in build_rel.tuples() {
             let mut key: Vec<&ScalarValue> = Vec::with_capacity(common_attrs.len());
@@ -171,7 +172,7 @@ impl Relation {
             if let Some(matching_tuples) = build_map.get(&key) {
                 for build_tuple in matching_tuples {
                     // Combine tuples
-                    let mut combined_values = HashMap::new();
+                    let mut combined_values = HashMap::with_capacity(result_heading_arc.degree());
 
                     // Add all values from build_tuple
                     for (attr_name, value) in build_tuple.values() {
@@ -297,7 +298,7 @@ impl Relation {
             for tuple2 in other.tuples() {
                 if predicate(tuple1, tuple2) {
                     // Combine tuples
-                    let mut combined_values = HashMap::new();
+                    let mut combined_values = HashMap::with_capacity(result_heading_arc.degree());
 
                     for (attr_name, value) in tuple1.values() {
                         combined_values.insert(attr_name.clone(), value.clone());


### PR DESCRIPTION
This PR implements performance optimizations identified by Bolt ⚡.

It pre-allocates memory for collections in `relvar-core`'s relational algebra operators where the target size is known or can be estimated.

Specifically:
- `relvar-core/src/algebra/join.rs`:
    - `join`: Pre-allocate `build_map` using `build_rel.cardinality()`.
    - `join`: Pre-allocate `combined_values` map for new tuples using `result_heading.degree()`.
    - `theta_join`: Pre-allocate `combined_values` map for new tuples using `result_heading.degree()`.
- `relvar-core/src/algebra/extend.rs`:
    - `extend`: Pre-allocate `extended_tuples` vector using `self.cardinality()`.

These changes reduce memory reallocation overhead in hot paths without altering logic or safety.

---
*PR created automatically by Jules for task [14692744453725131320](https://jules.google.com/task/14692744453725131320) started by @madmax983*