### PR TITLE
⚒️ Forge: Refactor Foreign Key Validation Logic

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -17,3 +17,7 @@
 ## 2024-05-26 - HeapFile Helper Extraction
 **Learning:** `HeapFile` still contained significant duplication in tuple extraction (`scan`) and slot allocation (`insert`). Extracting generic helpers (`find_or_allocate_slot`, `extract_tuples_from_slots`, `validate_slot_bounds`) simplified `scan` and `insert` logic, removing redundant loops and bounds checks.
 **Action:** Look for "copy-paste" logic in distinct but similar code paths (like versioned vs standard page handling) and try to unify them with generic helpers or traits, even if the data structures are slightly different.
+
+## 2024-05-27 - Foreign Key Validation Duplication
+**Learning:** `ConstraintManager` was manually re-implementing optimized foreign key validation (HashSet) because `ForeignKey`'s native method was O(N*M). This led to duplication and logic leaks.
+**Action:** Optimized the core domain method (`ForeignKey::is_satisfied_by`) to use the efficient algorithm, allowing `ConstraintManager` to delegate back to the domain object (Rich Domain Model).

--- a/relvar-core/src/constraints/foreign_key.rs
+++ b/relvar-core/src/constraints/foreign_key.rs
@@ -60,8 +60,9 @@
 //! assert!(fk.would_violate_on_insert(&invalid_employee, &departments).unwrap());
 //! ```
 
-use crate::values::{Relation, Tuple};
+use crate::values::{Relation, ScalarValue, Tuple};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use thiserror::Error;
 
 /// Errors that can occur with foreign key constraints.
@@ -189,9 +190,21 @@ impl ForeignKey {
             }
         }
 
+        // Extract referenced keys into a HashSet for O(1) lookups
+        let referenced_keys = extract_keys(referenced_relation, &self.referenced_attributes);
+
+        // Pre-allocate buffer for key construction to avoid repeated allocations
+        let mut key_buffer = Vec::with_capacity(self.foreign_key_attributes.len());
+
         // Check each tuple in referencing relation
         for tuple in referencing_relation.tuples() {
-            if !self.tuple_references_exist(tuple, referenced_relation) {
+            key_buffer.clear();
+            for attr in &self.foreign_key_attributes {
+                // We know attribute exists because of check above
+                key_buffer.push(tuple.get(attr).unwrap());
+            }
+
+            if !referenced_keys.contains(&key_buffer) {
                 return Ok(false);
             }
         }
@@ -205,15 +218,10 @@ impl ForeignKey {
         new_tuple: &Tuple,
         referenced_relation: &Relation,
     ) -> Result<bool, ForeignKeyError> {
-        Ok(!self.tuple_references_exist(new_tuple, referenced_relation))
-    }
-
-    /// Check if a tuple's foreign key values exist in the referenced relation
-    fn tuple_references_exist(&self, tuple: &Tuple, referenced_relation: &Relation) -> bool {
         let foreign_key_values: Vec<_> = self
             .foreign_key_attributes
             .iter()
-            .map(|attr| tuple.get(attr).unwrap())
+            .map(|attr| new_tuple.get(attr).unwrap())
             .collect();
 
         // Check if any tuple in referenced relation matches
@@ -225,11 +233,11 @@ impl ForeignKey {
                 .collect();
 
             if foreign_key_values == referenced_values {
-                return true;
+                return Ok(false); // Found a match, so no violation
             }
         }
 
-        false
+        Ok(true) // No match found, violation
     }
 
     /// Check if deleting a tuple from the referenced relation would violate this constraint
@@ -259,6 +267,26 @@ impl ForeignKey {
 
         Ok(false)
     }
+}
+
+/// Helper to extract a set of attribute value combinations from a relation.
+fn extract_keys<'a>(
+    relation: &'a Relation,
+    attributes: &[String],
+) -> HashSet<Vec<&'a ScalarValue>> {
+    relation
+        .tuples()
+        .map(|tuple| {
+            attributes
+                .iter()
+                .map(|attr| {
+                    tuple
+                        .get(attr)
+                        .expect("Attribute must exist in relation schema")
+                })
+                .collect()
+        })
+        .collect()
 }
 
 /// Collection of foreign key constraints for a relation

--- a/relvar-core/src/constraints/manager.rs
+++ b/relvar-core/src/constraints/manager.rs
@@ -9,7 +9,7 @@ use crate::constraints::{
 };
 use crate::storage_engine::{StorageEngine, StorageError};
 use crate::values::relation::RelationError;
-use crate::values::{Relation, ScalarValue, Tuple};
+use crate::values::{Relation, Tuple};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -134,25 +134,14 @@ impl ConstraintManager {
 
         for fk in constraints.foreign_keys() {
             let referenced_relation = engine.load_relation(fk.referenced_relation_name())?;
-            // Build a HashSet of referenced keys for efficient O(1) lookups.
-            // We store references to avoid cloning potentially large values.
-            let referenced_keys =
-                Self::extract_attribute_values(&referenced_relation, fk.referenced_attributes());
 
-            // Pre-allocate buffer for key construction to avoid repeated allocations
-            let mut fk_key_buffer = Vec::with_capacity(fk.foreign_key_attributes().len());
-
-            for tuple in relation.tuples() {
-                fk_key_buffer.clear();
-                for attr in fk.foreign_key_attributes() {
-                    fk_key_buffer.push(tuple.get(attr).unwrap());
-                }
-
-                if !referenced_keys.contains(&fk_key_buffer) {
-                    return Err(ConstraintManagerError::ForeignKeyViolation(
-                        "Existing tuple violates foreign key".to_string(),
-                    ));
-                }
+            if !fk
+                .is_satisfied_by(&relation, &referenced_relation)
+                .map_err(|e| ConstraintManagerError::ForeignKeyViolation(e.to_string()))?
+            {
+                return Err(ConstraintManagerError::ForeignKeyViolation(
+                    "Existing tuple violates foreign key".to_string(),
+                ));
             }
         }
 
@@ -399,55 +388,18 @@ impl ConstraintManager {
                 if fk.referenced_relation_name() == relation_name {
                     let referencing_relation = engine.load_relation(ref_name)?;
 
-                    // Build a HashSet of keys from the relation after deletion for efficient lookups.
-                    // We store references to avoid cloning potentially large values (Strings, Blobs).
-                    let existing_keys = Self::extract_attribute_values(
-                        relation_after_delete,
-                        fk.referenced_attributes(),
-                    );
-
-                    // Pre-allocate buffer for key construction to avoid repeated allocations
-                    let mut ref_key_buffer = Vec::with_capacity(fk.foreign_key_attributes().len());
-
-                    // Check if any referencing tuples would be orphaned by looking up in the HashSet.
-                    for ref_tuple in referencing_relation.tuples() {
-                        ref_key_buffer.clear();
-                        for attr in fk.foreign_key_attributes() {
-                            if let Some(val) = ref_tuple.get(attr) {
-                                ref_key_buffer.push(val);
-                            }
-                        }
-
-                        if !existing_keys.contains(&ref_key_buffer) {
-                            return Err(ConstraintManagerError::ForeignKeyViolation(format!(
-                                "Deleting tuples would orphan referencing tuples in {}",
-                                ref_name
-                            )));
-                        }
+                    if !fk
+                        .is_satisfied_by(&referencing_relation, relation_after_delete)
+                        .map_err(|e| ConstraintManagerError::ForeignKeyViolation(e.to_string()))?
+                    {
+                        return Err(ConstraintManagerError::ForeignKeyViolation(format!(
+                            "Deleting tuples would orphan referencing tuples in {}",
+                            ref_name
+                        )));
                     }
                 }
             }
         }
         Ok(())
-    }
-
-    /// Helper to extract a set of attribute value combinations from a relation.
-    fn extract_attribute_values<'a>(
-        relation: &'a Relation,
-        attributes: &[String],
-    ) -> std::collections::HashSet<Vec<&'a ScalarValue>> {
-        relation
-            .tuples()
-            .map(|tuple| {
-                attributes
-                    .iter()
-                    .map(|attr| {
-                        tuple
-                            .get(attr)
-                            .expect("Attribute must exist in relation schema")
-                    })
-                    .collect()
-            })
-            .collect()
     }
 }


### PR DESCRIPTION
Refactored Foreign Key validation logic to be more efficient and better encapsulated.

1.  **Modified `relvar-core/src/constraints/foreign_key.rs`**:
    *   Updated `is_satisfied_by` to use a `HashSet` of referenced keys, improving complexity from O(N*M) to O(N+M).
    *   Added `extract_keys` helper function.
    *   Removed `tuple_references_exist` helper.

2.  **Modified `relvar-core/src/constraints/manager.rs`**:
    *   Replaced manual validation loops in `set_foreign_key_constraints` and `validate_referencing_foreign_keys` with calls to `ForeignKey::is_satisfied_by`.
    *   Removed unused `extract_attribute_values` helper.
    *   Removed unused `ScalarValue` import.

3.  **Journal**:
    *   Added entry to `.jules/forge.md` regarding Rich Domain Model and encapsulation.

---
*PR created automatically by Jules for task [13768617895997584747](https://jules.google.com/task/13768617895997584747) started by @madmax983*