### PR TITLE
🔒 Warden: Fix Like Operator Memory DoS

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -73,3 +73,14 @@ This discrepancy caused the size check to pass, but the actual insertion to fail
 Modified `check_versioned_tuple_size_limit` to accept a `has_prev_version` boolean flag.
 Updated `insert_tuple_versioned` to pass `false` and `update_tuple_versioned` to pass `true`.
 This ensures the size check accurately accounts for the 8-byte overhead of the `prev_version` pointer during updates.
+
+## 2026-02-07 - Like Operator Memory Exhaustion DoS
+**Threat:**
+The `ConstraintExpression::Like` operator implementation used a dynamic programming table of size `O(N*M)` (where N is text length and M is pattern length).
+An attacker could supply a pattern and text both of large size (e.g., 1MB), causing a quadratic memory allocation (1 trillion bytes = 1TB) which would crash the process (OOM DoS).
+Even with moderate sizes (e.g., 50KB), concurrent requests could exhaust server memory.
+
+**Defense:**
+Refactored `matches_pattern` to use an optimized DP approach that only stores two rows (current and previous) instead of the full matrix.
+This reduces space complexity from `O(N*M)` to `O(M)`, preventing memory exhaustion even with large inputs.
+Added a regression test `relvar-core/tests/warden_exploit_like.rs` to verify the fix and prevent regression.

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -226,7 +226,7 @@ impl ConstraintExpression {
     /// _ matches exactly one character
     ///
     /// Time complexity: O(n*m) where n = text length, m = pattern length
-    /// Space complexity: O(n*m) for DP table
+    /// Space complexity: O(m) optimized (was O(n*m))
     fn matches_pattern(text: &str, pattern: &str) -> bool {
         let text_chars: Vec<char> = text.chars().collect();
         let pattern_chars: Vec<char> = pattern.chars().collect();
@@ -234,41 +234,53 @@ impl ConstraintExpression {
         let text_len = text_chars.len();
         let pattern_len = pattern_chars.len();
 
-        // DP table: dp[i][j] = true if text[0..i] matches pattern[0..j]
-        let mut dp = vec![vec![false; pattern_len + 1]; text_len + 1];
+        // DP state: only need previous row and current row
+        // dp[j] stores whether pattern[0..j] matches current text prefix
+        let mut prev_dp = vec![false; pattern_len + 1];
+        let mut curr_dp = vec![false; pattern_len + 1];
 
-        // Empty pattern matches empty text
-        dp[0][0] = true;
+        // Base case: empty text matches empty pattern
+        prev_dp[0] = true;
 
         // Handle patterns that start with % (can match empty text)
         for j in 1..=pattern_len {
             if pattern_chars[j - 1] == '%' {
-                dp[0][j] = dp[0][j - 1];
+                prev_dp[j] = prev_dp[j - 1];
+            } else {
+                prev_dp[j] = false;
             }
         }
 
-        // Fill DP table
+        // Iterate through text characters
         for i in 1..=text_len {
+            // New row starts with false (non-empty text doesn't match empty pattern)
+            curr_dp[0] = false;
+
             for j in 1..=pattern_len {
                 match pattern_chars[j - 1] {
                     '%' => {
-                        // % can match zero characters (dp[i][j-1])
-                        // or match one or more characters (dp[i-1][j])
-                        dp[i][j] = dp[i][j - 1] || dp[i - 1][j];
+                        // % matches zero chars (curr_dp[j-1]) or one/more (prev_dp[j])
+                        // Note: In full DP, this was dp[i][j] = dp[i][j-1] || dp[i-1][j]
+                        // Here: curr_dp[j] = curr_dp[j-1] || prev_dp[j]
+                        curr_dp[j] = curr_dp[j - 1] || prev_dp[j];
                     }
                     '_' => {
-                        // _ matches exactly one character
-                        dp[i][j] = dp[i - 1][j - 1];
+                        // _ matches exactly one char
+                        // dp[i][j] = dp[i-1][j-1]
+                        curr_dp[j] = prev_dp[j - 1];
                     }
                     c => {
-                        // Literal character must match
-                        dp[i][j] = dp[i - 1][j - 1] && text_chars[i - 1] == c;
+                        // Literal char match
+                        // dp[i][j] = dp[i-1][j-1] && char_match
+                        curr_dp[j] = prev_dp[j - 1] && text_chars[i - 1] == c;
                     }
                 }
             }
+            // Move current row to previous for next iteration
+            prev_dp.copy_from_slice(&curr_dp);
         }
 
-        dp[text_len][pattern_len]
+        prev_dp[pattern_len]
     }
 
     /// Helper to resolve a ValueOrRef to a concrete ScalarValue from the tuple.

--- a/relvar-core/tests/warden_exploit_like.rs
+++ b/relvar-core/tests/warden_exploit_like.rs
@@ -1,0 +1,25 @@
+use relvar_core::constraints::expression::ConstraintExpression;
+use relvar_core::tuple;
+
+#[test]
+fn test_like_dos_allocation_regression() {
+    // Regression test for O(N*M) space allocation vulnerability.
+    // We use a moderately large size that would have consumed significant memory
+    // (though not crashing) but runs quickly with O(M) space.
+    //
+    // With N=M=5000:
+    // Old O(N*M) space: 25M bools = 25MB (fine, but quadratic growth)
+    // New O(M) space: 5K bools = 5KB
+    //
+    // We want to ensure it completes reasonably fast.
+
+    let size = 5_000;
+    let text = "a".repeat(size);
+    let pattern = "a".repeat(size);
+
+    let expr = ConstraintExpression::Like("col".to_string(), pattern);
+    let tuple = tuple! { col: text };
+
+    // This should complete quickly (sub-second or few seconds)
+    assert!(expr.evaluate(&tuple).unwrap());
+}


### PR DESCRIPTION
Fix O(N*M) memory DoS in Like operator

Refactored `ConstraintExpression::matches_pattern` to use an optimized Dynamic Programming approach with O(M) space complexity (where M is pattern length), replacing the previous O(N*M) implementation.

This prevents a Denial of Service vulnerability where large strings/patterns could cause memory exhaustion (OOM).

Changes:
- Modified `relvar-core/src/constraints/expression.rs` to use two-row DP.
- Added regression test `relvar-core/tests/warden_exploit_like.rs`.
- Updated `.jules/warden.md` with vulnerability report.

---
*PR created automatically by Jules for task [8175374804887248342](https://jules.google.com/task/8175374804887248342) started by @madmax983*