### PR TITLE
🔒 Warden: Fix Like Operator Memory Exhaustion DoS

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -84,3 +84,13 @@ Even with moderate sizes (e.g., 50KB), concurrent requests could exhaust server 
 Refactored `matches_pattern` to use an optimized DP approach that only stores two rows (current and previous) instead of the full matrix.
 This reduces space complexity from `O(N*M)` to `O(M)`, preventing memory exhaustion even with large inputs.
 Added a regression test `relvar-core/tests/warden_exploit_like.rs` to verify the fix and prevent regression.
+
+## 2026-02-08 - Like Operator Large Input DoS
+**Threat:**
+The `ConstraintExpression::Like` operator implementation previously collected the input text into a `Vec<char>` for pattern matching.
+An attacker could supply a very large text string (e.g., 100MB), causing a linear memory allocation of 4 bytes per character (400MB total), potentially leading to memory exhaustion (DoS).
+
+**Defense:**
+Refactored `matches_pattern` to iterate over `text.chars()` directly instead of collecting into a vector.
+This reduces space complexity from $O(N+M)$ to $O(M)$ (where $M$ is pattern length), eliminating the DoS vector for large text inputs.
+Added verification test `relvar-core/tests/warden_exploit_like_memory.rs`.

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -236,10 +236,8 @@ impl ConstraintExpression {
     /// Time complexity: O(n*m) where n = text length, m = pattern length
     /// Space complexity: O(m) optimized (was O(n*m))
     fn matches_pattern(text: &str, pattern: &str) -> bool {
-        let text_chars: Vec<char> = text.chars().collect();
+        // Collect pattern chars for random access (usually small)
         let pattern_chars: Vec<char> = pattern.chars().collect();
-
-        let text_len = text_chars.len();
         let pattern_len = pattern_chars.len();
 
         // DP state: only need previous row and current row
@@ -259,8 +257,8 @@ impl ConstraintExpression {
             }
         }
 
-        // Iterate through text characters
-        for i in 1..=text_len {
+        // Iterate through text characters directly (avoids O(N) allocation)
+        for text_char in text.chars() {
             // New row starts with false (non-empty text doesn't match empty pattern)
             curr_dp[0] = false;
 
@@ -280,7 +278,7 @@ impl ConstraintExpression {
                     c => {
                         // Literal char match
                         // dp[i][j] = dp[i-1][j-1] && char_match
-                        curr_dp[j] = prev_dp[j - 1] && text_chars[i - 1] == c;
+                        curr_dp[j] = prev_dp[j - 1] && text_char == c;
                     }
                 }
             }

--- a/relvar-core/tests/warden_exploit_like_memory.rs
+++ b/relvar-core/tests/warden_exploit_like_memory.rs
@@ -1,0 +1,34 @@
+use relvar_core::constraints::expression::ConstraintExpression;
+use relvar_core::tuple;
+
+#[test]
+fn test_like_large_input_correctness() {
+    // This test verifies that the LIKE operator works correctly even with large inputs.
+    // We are simulating a potential DoS where O(N) memory allocation could be problematic.
+    // While we can't easily test OOM here, we can ensure the logic is robust.
+
+    let large_string = "a".repeat(100_000); // 100KB string
+    let pattern = "a%".to_string();
+
+    let expr = ConstraintExpression::Like("data".to_string(), pattern);
+    let tuple = tuple! { data: large_string.clone() };
+
+    assert!(expr.evaluate(&tuple).unwrap());
+
+    let pattern_fail = "b%".to_string();
+    let expr_fail = ConstraintExpression::Like("data".to_string(), pattern_fail);
+    assert!(!expr_fail.evaluate(&tuple).unwrap());
+}
+
+#[test]
+fn test_like_unicode_chars_iterator() {
+    // Verify that iterating over chars works correctly with unicode
+    // "café" -> 'c', 'a', 'f', 'é'
+    let text = "café";
+    let pattern = "caf_";
+
+    let expr = ConstraintExpression::Like("word".to_string(), pattern.to_string());
+    let tuple = tuple! { word: text };
+
+    assert!(expr.evaluate(&tuple).unwrap());
+}


### PR DESCRIPTION
Refactored `ConstraintExpression::Like` to prevent memory exhaustion DoS.
 
 🦠 Threat: `ConstraintExpression::Like` collected input text into `Vec<char>`, leading to O(N) memory allocation. Large inputs could cause memory exhaustion (DoS).
 🛡️ Defense: Refactored `matches_pattern` to iterate over `text.chars()` directly. Space complexity is now O(M) (pattern length).
 💥 Severity: High (DoS vector).
 🧪 Verification: Added `relvar-core/tests/warden_exploit_like_memory.rs` and ran existing tests.

---
*PR created automatically by Jules for task [1202718305179688457](https://jules.google.com/task/1202718305179688457) started by @madmax983*