### PR TITLE
🌟 Nova: Relational Query Builder & AST

### DIFF
--- a/relvar/src/experimental/mod.rs
+++ b/relvar/src/experimental/mod.rs
@@ -9,6 +9,7 @@
 //! - **Importer**: Tools for importing relations from CSV and JSON.
 //! - **Pivot**: Operator to rotate unique values from one column into multiple columns.
 //! - **Mock**: Tools for generating random relations for testing.
+//! - **Query**: A serializable AST and query builder for relational queries.
 //!
 //! # Example: Using the Exporter
 //!
@@ -34,3 +35,4 @@ pub mod exporter;
 pub mod importer;
 pub mod mock;
 pub mod pivot;
+pub mod query;

--- a/relvar/src/experimental/query.rs
+++ b/relvar/src/experimental/query.rs
@@ -167,12 +167,8 @@ impl Query {
                 // We use evaluate() inside, but we must handle errors.
                 // Currently, we treat evaluation errors as false (exclude tuple).
                 let predicate = predicate.clone();
-                let result = relation.restrict(move |tuple| {
-                    match predicate.evaluate(tuple) {
-                        Ok(matches) => matches,
-                        Err(_) => false, // Treat error as non-match
-                    }
-                });
+                let result = relation
+                    .restrict(move |tuple| predicate.evaluate(tuple).unwrap_or_default());
                 Ok(result)
             }
             Query::Project { input, attributes } => {

--- a/relvar/src/experimental/query.rs
+++ b/relvar/src/experimental/query.rs
@@ -1,0 +1,320 @@
+//! Query Builder and AST for relational queries.
+//!
+//! This module provides a serializable AST ([`Query`]) and a fluent builder API
+//! for constructing relational algebra queries. It allows queries to be
+//! defined data-driven (e.g., from JSON), optimized, inspected ([`Query::explain`]),
+//! and executed against a [`Database`].
+//!
+//! # Example
+//!
+//! ```
+//! use relvar::experimental::query::{Query, QueryAggregation, QueryAggregationFn};
+//! use relvar::constraints::{ConstraintExpression, CmpOp, ValueOrRef};
+//! use relvar::values::ScalarValue;
+//! use relvar::types::ScalarType;
+//! use relvar::{Database, InMemoryEngine, tuple};
+//!
+//! # let mut db = Database::new(InMemoryEngine::new());
+//! # use relvar::types::{RelationType, TupleType};
+//! # let heading = TupleType::new()
+//! #    .with_attribute("id", ScalarType::Int)
+//! #    .with_attribute("name", ScalarType::String);
+//! # db.create_relvar("USERS", RelationType::new(heading)).unwrap();
+//!
+//! // Build a query: SELECT name FROM USERS WHERE id = 1
+//! let query = Query::scan("USERS")
+//!     .restrict(ConstraintExpression::Cmp {
+//!         left: "id".to_string(),
+//!         op: CmpOp::Eq,
+//!         right: ValueOrRef::Value(ScalarValue::Int(1)),
+//!     })
+//!     .project(vec!["name"]);
+//!
+//! // Execute
+//! let result = query.execute(&mut db).unwrap();
+//!
+//! // Explain
+//! println!("{}", query.explain());
+//! ```
+
+use crate::algebra::summarize::{Aggregation, AggregationFn};
+use crate::constraints::{ConstraintExpression, ExpressionError};
+use crate::error::DatabaseError;
+use crate::types::ScalarType;
+use crate::{Database, Relation, StorageEngine};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// AST for a relational query.
+///
+/// This structure represents a query plan that can be serialized, inspected,
+/// optimized, and executed against a database.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Query {
+    /// Scan a relation variable (base table).
+    Scan(String),
+
+    /// Restrict tuples based on a predicate (Selection/WHERE).
+    Restrict {
+        /// The input query to filter.
+        input: Box<Query>,
+        /// The predicate condition.
+        predicate: ConstraintExpression,
+    },
+
+    /// Project specific attributes (Projection/SELECT).
+    Project {
+        /// The input query.
+        input: Box<Query>,
+        /// The list of attribute names to keep.
+        attributes: Vec<String>,
+    },
+
+    /// Rename attributes.
+    Rename {
+        /// The input query.
+        input: Box<Query>,
+        /// Mapping of (old_name, new_name).
+        mappings: Vec<(String, String)>,
+    },
+
+    /// Natural Join two relations.
+    Join {
+        /// The left relation.
+        left: Box<Query>,
+        /// The right relation.
+        right: Box<Query>,
+    },
+
+    /// Summarize (Group By + Aggregation).
+    Summarize {
+        /// The input query.
+        input: Box<Query>,
+        /// Attributes to group by.
+        group_by: Vec<String>,
+        /// Aggregations to perform.
+        aggregations: Vec<QueryAggregation>,
+    },
+}
+
+/// Serializable representation of an aggregation function.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum QueryAggregationFn {
+    /// Count the number of tuples.
+    Count,
+    /// Sum an integer attribute.
+    Sum(String),
+    /// Average an integer attribute.
+    Avg(String),
+    /// Minimum value of an attribute.
+    Min(String),
+    /// Maximum value of an attribute.
+    Max(String),
+}
+
+/// Serializable representation of an aggregation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryAggregation {
+    /// The name of the resulting attribute.
+    pub result_name: String,
+    /// The type of the resulting attribute.
+    pub result_type: ScalarType,
+    /// The aggregation function to apply.
+    pub function: QueryAggregationFn,
+}
+
+impl From<QueryAggregation> for Aggregation {
+    fn from(q: QueryAggregation) -> Self {
+        let function = match q.function {
+            QueryAggregationFn::Count => AggregationFn::Count,
+            QueryAggregationFn::Sum(attr) => AggregationFn::Sum(attr),
+            QueryAggregationFn::Avg(attr) => AggregationFn::Avg(attr),
+            QueryAggregationFn::Min(attr) => AggregationFn::Min(attr),
+            QueryAggregationFn::Max(attr) => AggregationFn::Max(attr),
+        };
+        Aggregation {
+            result_name: q.result_name,
+            result_type: q.result_type,
+            function,
+        }
+    }
+}
+
+/// Errors that can occur during query execution.
+#[derive(Debug, Error)]
+pub enum QueryError {
+    /// Error from the database engine.
+    #[error("Database error: {0}")]
+    Database(#[from] DatabaseError),
+
+    /// Error evaluating a constraint expression.
+    #[error("Constraint evaluation error: {0}")]
+    Constraint(#[from] ExpressionError),
+
+    /// Error in relational algebra operation.
+    #[error("Algebra error: {0}")]
+    Algebra(String),
+}
+
+impl Query {
+    /// Executes the query plan against the given database.
+    pub fn execute<S: StorageEngine>(&self, db: &mut Database<S>) -> Result<Relation, QueryError> {
+        match self {
+            Query::Scan(table_name) => Ok(db.query(table_name)?),
+            Query::Restrict { input, predicate } => {
+                let relation = input.execute(db)?;
+                // Note: Relation::restrict takes a closure that returns bool.
+                // We use evaluate() inside, but we must handle errors.
+                // Currently, we treat evaluation errors as false (exclude tuple).
+                let predicate = predicate.clone();
+                let result = relation.restrict(move |tuple| {
+                    match predicate.evaluate(tuple) {
+                        Ok(matches) => matches,
+                        Err(_) => false, // Treat error as non-match
+                    }
+                });
+                Ok(result)
+            }
+            Query::Project { input, attributes } => {
+                let relation = input.execute(db)?;
+                let attrs_ref: Vec<&str> = attributes.iter().map(|s| s.as_str()).collect();
+                Ok(relation.project(&attrs_ref))
+            }
+            Query::Rename { input, mappings } => {
+                let relation = input.execute(db)?;
+                let mappings_ref: Vec<(&str, &str)> = mappings
+                    .iter()
+                    .map(|(a, b)| (a.as_str(), b.as_str()))
+                    .collect();
+                Ok(relation.rename(&mappings_ref))
+            }
+            Query::Join { left, right } => {
+                let left_rel = left.execute(db)?;
+                let right_rel = right.execute(db)?;
+                Ok(left_rel.join(&right_rel)?)
+            }
+            Query::Summarize {
+                input,
+                group_by,
+                aggregations,
+            } => {
+                let relation = input.execute(db)?;
+                let aggs: Vec<Aggregation> = aggregations.iter().cloned().map(Into::into).collect();
+                let group_by_ref: Vec<&str> = group_by.iter().map(|s| s.as_str()).collect();
+                Ok(relation
+                    .summarize(&group_by_ref, &aggs)
+                    .map_err(|e| QueryError::Algebra(e.to_string()))?)
+            }
+        }
+    }
+
+    /// Returns a human-readable explanation of the query plan.
+    pub fn explain(&self) -> String {
+        self.explain_recursive(0)
+    }
+
+    fn explain_recursive(&self, depth: usize) -> String {
+        let indent = "  ".repeat(depth);
+        match self {
+            Query::Scan(table) => format!("{}Scan({})", indent, table),
+            Query::Restrict { input, predicate } => {
+                format!(
+                    "{}Restrict({:?})\n{}",
+                    indent,
+                    predicate,
+                    input.explain_recursive(depth + 1)
+                )
+            }
+            Query::Project { input, attributes } => {
+                format!(
+                    "{}Project({:?})\n{}",
+                    indent,
+                    attributes,
+                    input.explain_recursive(depth + 1)
+                )
+            }
+            Query::Rename { input, mappings } => {
+                format!(
+                    "{}Rename({:?})\n{}",
+                    indent,
+                    mappings,
+                    input.explain_recursive(depth + 1)
+                )
+            }
+            Query::Join { left, right } => {
+                format!(
+                    "{}Join\n{}\n{}",
+                    indent,
+                    left.explain_recursive(depth + 1),
+                    right.explain_recursive(depth + 1)
+                )
+            }
+            Query::Summarize {
+                input,
+                group_by,
+                aggregations,
+            } => {
+                format!(
+                    "{}Summarize(group_by={:?}, aggs={:?})\n{}",
+                    indent,
+                    group_by,
+                    aggregations,
+                    input.explain_recursive(depth + 1)
+                )
+            }
+        }
+    }
+
+    /// Creates a Scan query.
+    pub fn scan(table: impl Into<String>) -> Self {
+        Query::Scan(table.into())
+    }
+
+    /// Wraps the query in a Restrict operation.
+    pub fn restrict(self, predicate: ConstraintExpression) -> Self {
+        Query::Restrict {
+            input: Box::new(self),
+            predicate,
+        }
+    }
+
+    /// Wraps the query in a Project operation.
+    pub fn project<S: Into<String>>(self, attributes: Vec<S>) -> Self {
+        Query::Project {
+            input: Box::new(self),
+            attributes: attributes.into_iter().map(|s| s.into()).collect(),
+        }
+    }
+
+    /// Wraps the query in a Rename operation.
+    pub fn rename<S1: Into<String>, S2: Into<String>>(self, mappings: Vec<(S1, S2)>) -> Self {
+        Query::Rename {
+            input: Box::new(self),
+            mappings: mappings
+                .into_iter()
+                .map(|(a, b)| (a.into(), b.into()))
+                .collect(),
+        }
+    }
+
+    /// Joins this query with another query.
+    pub fn join(self, right: Query) -> Self {
+        Query::Join {
+            left: Box::new(self),
+            right: Box::new(right),
+        }
+    }
+
+    /// Wraps the query in a Summarize operation.
+    pub fn summarize<S: Into<String>>(
+        self,
+        group_by: Vec<S>,
+        aggregations: Vec<QueryAggregation>,
+    ) -> Self {
+        Query::Summarize {
+            input: Box::new(self),
+            group_by: group_by.into_iter().map(|s| s.into()).collect(),
+            aggregations,
+        }
+    }
+}

--- a/relvar/src/experimental/query.rs
+++ b/relvar/src/experimental/query.rs
@@ -167,8 +167,8 @@ impl Query {
                 // We use evaluate() inside, but we must handle errors.
                 // Currently, we treat evaluation errors as false (exclude tuple).
                 let predicate = predicate.clone();
-                let result = relation
-                    .restrict(move |tuple| predicate.evaluate(tuple).unwrap_or_default());
+                let result =
+                    relation.restrict(move |tuple| predicate.evaluate(tuple).unwrap_or_default());
                 Ok(result)
             }
             Query::Project { input, attributes } => {

--- a/relvar/tests/query_builder.rs
+++ b/relvar/tests/query_builder.rs
@@ -1,0 +1,166 @@
+use relvar::constraints::{CmpOp, ConstraintExpression, ValueOrRef};
+use relvar::experimental::query::{Query, QueryAggregation, QueryAggregationFn};
+use relvar::types::{RelationType, ScalarType, TupleType};
+use relvar::values::ScalarValue;
+use relvar::{tuple, Database, InMemoryEngine};
+
+#[test]
+fn test_query_builder_e2e() {
+    // 1. Setup Database
+    let mut db = Database::new(InMemoryEngine::new());
+
+    // Create EMPLOYEES
+    let emp_heading = TupleType::new()
+        .with_attribute("id", ScalarType::Int)
+        .with_attribute("name", ScalarType::String)
+        .with_attribute("dept_id", ScalarType::Int)
+        .with_attribute("salary", ScalarType::Int);
+
+    db.create_relvar("EMPLOYEES", RelationType::new(emp_heading))
+        .unwrap();
+
+    db.insert(
+        "EMPLOYEES",
+        tuple! { id: 1i64, name: "Alice", dept_id: 10i64, salary: 50000i64 },
+    )
+    .unwrap();
+    db.insert(
+        "EMPLOYEES",
+        tuple! { id: 2i64, name: "Bob", dept_id: 20i64, salary: 60000i64 },
+    )
+    .unwrap();
+    db.insert(
+        "EMPLOYEES",
+        tuple! { id: 3i64, name: "Charlie", dept_id: 10i64, salary: 55000i64 },
+    )
+    .unwrap();
+
+    // Create DEPARTMENTS
+    let dept_heading = TupleType::new()
+        .with_attribute("dept_id", ScalarType::Int)
+        .with_attribute("dept_name", ScalarType::String);
+
+    db.create_relvar("DEPARTMENTS", RelationType::new(dept_heading))
+        .unwrap();
+
+    db.insert(
+        "DEPARTMENTS",
+        tuple! { dept_id: 10i64, dept_name: "Engineering" },
+    )
+    .unwrap();
+    db.insert(
+        "DEPARTMENTS",
+        tuple! { dept_id: 20i64, dept_name: "Sales" },
+    )
+    .unwrap();
+
+    // 2. Build Query
+    // Query: Get Engineering employees (dept_id=10), show name and salary
+    let query = Query::scan("EMPLOYEES")
+        .restrict(ConstraintExpression::Cmp {
+            left: "dept_id".to_string(),
+            op: CmpOp::Eq,
+            right: ValueOrRef::Value(ScalarValue::Int(10)),
+        })
+        .project(vec!["name", "salary"]);
+
+    // 3. Execute
+    let result = query.execute(&mut db).unwrap();
+
+    assert_eq!(result.cardinality(), 2);
+    // Alice and Charlie
+
+    // 4. Explain
+    let explanation = query.explain();
+    println!("Explanation:\n{}", explanation);
+    assert!(explanation.contains("Scan(EMPLOYEES)"));
+    assert!(explanation.contains("Restrict"));
+    assert!(explanation.contains("Project"));
+
+    // 5. Serialize / Deserialize
+    let json = serde_json::to_string(&query).unwrap();
+    println!("JSON:\n{}", json);
+    let loaded: Query = serde_json::from_str(&json).unwrap();
+
+    let result_loaded = loaded.execute(&mut db).unwrap();
+    assert_eq!(result_loaded.cardinality(), 2);
+}
+
+#[test]
+fn test_query_join_summarize() {
+    let mut db = Database::new(InMemoryEngine::new());
+
+    // Create EMPLOYEES
+    let emp_heading = TupleType::new()
+        .with_attribute("id", ScalarType::Int)
+        .with_attribute("dept_id", ScalarType::Int)
+        .with_attribute("salary", ScalarType::Int);
+
+    db.create_relvar("EMPLOYEES", RelationType::new(emp_heading))
+        .unwrap();
+    db.insert(
+        "EMPLOYEES",
+        tuple! { id: 1i64, dept_id: 10i64, salary: 50000i64 },
+    )
+    .unwrap();
+    db.insert(
+        "EMPLOYEES",
+        tuple! { id: 2i64, dept_id: 10i64, salary: 60000i64 },
+    )
+    .unwrap();
+    db.insert(
+        "EMPLOYEES",
+        tuple! { id: 3i64, dept_id: 20i64, salary: 70000i64 },
+    )
+    .unwrap();
+
+    // Create DEPARTMENTS
+    let dept_heading = TupleType::new()
+        .with_attribute("dept_id", ScalarType::Int)
+        .with_attribute("dept_name", ScalarType::String);
+
+    db.create_relvar("DEPARTMENTS", RelationType::new(dept_heading))
+        .unwrap();
+    db.insert(
+        "DEPARTMENTS",
+        tuple! { dept_id: 10i64, dept_name: "Engineering" },
+    )
+    .unwrap();
+    db.insert(
+        "DEPARTMENTS",
+        tuple! { dept_id: 20i64, dept_name: "Sales" },
+    )
+    .unwrap();
+
+    // Query: Join Emp + Dept, Summarize by Dept Name, Count and Avg Salary
+    let query = Query::scan("EMPLOYEES")
+        .join(Query::scan("DEPARTMENTS"))
+        .summarize(
+            vec!["dept_name"],
+            vec![
+                QueryAggregation {
+                    result_name: "count".to_string(),
+                    result_type: ScalarType::Int,
+                    function: QueryAggregationFn::Count,
+                },
+                QueryAggregation {
+                    result_name: "avg_salary".to_string(),
+                    result_type: ScalarType::Float,
+                    function: QueryAggregationFn::Avg("salary".to_string()),
+                },
+            ],
+        );
+
+    let result = query.execute(&mut db).unwrap();
+
+    assert_eq!(result.cardinality(), 2);
+
+    // Verify Engineering (dept_id 10) -> count 2, avg 55000
+    let eng_tuple = result
+        .tuples()
+        .find(|t| t.get_typed::<String>("dept_name").unwrap() == "Engineering")
+        .unwrap();
+
+    assert_eq!(eng_tuple.get_typed::<i64>("count").unwrap(), 2);
+    assert_eq!(eng_tuple.get_typed::<f64>("avg_salary").unwrap(), 55000.0);
+}

--- a/relvar/tests/query_builder.rs
+++ b/relvar/tests/query_builder.rs
@@ -2,7 +2,7 @@ use relvar::constraints::{CmpOp, ConstraintExpression, ValueOrRef};
 use relvar::experimental::query::{Query, QueryAggregation, QueryAggregationFn};
 use relvar::types::{RelationType, ScalarType, TupleType};
 use relvar::values::ScalarValue;
-use relvar::{tuple, Database, InMemoryEngine};
+use relvar::{Database, InMemoryEngine, tuple};
 
 #[test]
 fn test_query_builder_e2e() {

--- a/relvar/tests/query_builder.rs
+++ b/relvar/tests/query_builder.rs
@@ -2,7 +2,7 @@ use relvar::constraints::{CmpOp, ConstraintExpression, ValueOrRef};
 use relvar::experimental::query::{Query, QueryAggregation, QueryAggregationFn};
 use relvar::types::{RelationType, ScalarType, TupleType};
 use relvar::values::ScalarValue;
-use relvar::{tuple, Database, InMemoryEngine};
+use relvar::{Database, InMemoryEngine, tuple};
 
 #[test]
 fn test_query_builder_e2e() {
@@ -48,11 +48,8 @@ fn test_query_builder_e2e() {
         tuple! { dept_id: 10i64, dept_name: "Engineering" },
     )
     .unwrap();
-    db.insert(
-        "DEPARTMENTS",
-        tuple! { dept_id: 20i64, dept_name: "Sales" },
-    )
-    .unwrap();
+    db.insert("DEPARTMENTS", tuple! { dept_id: 20i64, dept_name: "Sales" })
+        .unwrap();
 
     // 2. Build Query
     // Query: Get Engineering employees (dept_id=10), show name and salary
@@ -126,11 +123,8 @@ fn test_query_join_summarize() {
         tuple! { dept_id: 10i64, dept_name: "Engineering" },
     )
     .unwrap();
-    db.insert(
-        "DEPARTMENTS",
-        tuple! { dept_id: 20i64, dept_name: "Sales" },
-    )
-    .unwrap();
+    db.insert("DEPARTMENTS", tuple! { dept_id: 20i64, dept_name: "Sales" })
+        .unwrap();
 
     // Query: Join Emp + Dept, Summarize by Dept Name, Count and Avg Salary
     let query = Query::scan("EMPLOYEES")

--- a/relvar/tests/query_builder.rs
+++ b/relvar/tests/query_builder.rs
@@ -2,7 +2,7 @@ use relvar::constraints::{CmpOp, ConstraintExpression, ValueOrRef};
 use relvar::experimental::query::{Query, QueryAggregation, QueryAggregationFn};
 use relvar::types::{RelationType, ScalarType, TupleType};
 use relvar::values::ScalarValue;
-use relvar::{Database, InMemoryEngine, tuple};
+use relvar::{tuple, Database, InMemoryEngine};
 
 #[test]
 fn test_query_builder_e2e() {
@@ -157,4 +157,64 @@ fn test_query_join_summarize() {
 
     assert_eq!(eng_tuple.get_typed::<i64>("count").unwrap(), 2);
     assert_eq!(eng_tuple.get_typed::<f64>("avg_salary").unwrap(), 55000.0);
+}
+
+#[test]
+fn test_query_rename_aggregations() {
+    let mut db = Database::new(InMemoryEngine::new());
+
+    let heading = TupleType::new()
+        .with_attribute("id", ScalarType::Int)
+        .with_attribute("score", ScalarType::Int);
+
+    db.create_relvar("SCORES", RelationType::new(heading))
+        .unwrap();
+    db.insert("SCORES", tuple! { id: 1i64, score: 10i64 })
+        .unwrap();
+    db.insert("SCORES", tuple! { id: 1i64, score: 20i64 })
+        .unwrap();
+    db.insert("SCORES", tuple! { id: 2i64, score: 5i64 })
+        .unwrap();
+
+    // Query: Rename id -> player_id, Summarize by player_id, Min(score), Max(score), Sum(score)
+    let query = Query::scan("SCORES")
+        .rename(vec![("id", "player_id")])
+        .summarize(
+            vec!["player_id"],
+            vec![
+                QueryAggregation {
+                    result_name: "min_score".to_string(),
+                    result_type: ScalarType::Int,
+                    function: QueryAggregationFn::Min("score".to_string()),
+                },
+                QueryAggregation {
+                    result_name: "max_score".to_string(),
+                    result_type: ScalarType::Int,
+                    function: QueryAggregationFn::Max("score".to_string()),
+                },
+                QueryAggregation {
+                    result_name: "total_score".to_string(),
+                    result_type: ScalarType::Int,
+                    function: QueryAggregationFn::Sum("score".to_string()),
+                },
+            ],
+        );
+
+    let result = query.execute(&mut db).unwrap();
+    assert_eq!(result.cardinality(), 2);
+
+    let p1 = result
+        .tuples()
+        .find(|t| t.get_typed::<i64>("player_id").unwrap() == 1)
+        .unwrap();
+    assert_eq!(p1.get_typed::<i64>("min_score").unwrap(), 10);
+    assert_eq!(p1.get_typed::<i64>("max_score").unwrap(), 20);
+    assert_eq!(p1.get_typed::<i64>("total_score").unwrap(), 30);
+
+    // Explain check for Rename coverage
+    let explanation = query.explain();
+    assert!(explanation.contains("Rename"));
+    assert!(explanation.contains("Min"));
+    assert!(explanation.contains("Max"));
+    assert!(explanation.contains("Sum"));
 }


### PR DESCRIPTION
This PR introduces a new experimental feature: a serializable Query AST and Builder API.

**Key Changes:**
1.  **`relvar/src/experimental/query.rs`**: Defined the `Query` enum representing a relational algebra tree.
    *   Supported operators: `Scan`, `Restrict`, `Project`, `Rename`, `Join`, `Summarize`.
    *   Implemented `execute(&mut db)` to run the query.
    *   Implemented `explain()` to return a human-readable plan.
    *   Implemented a fluent builder API (e.g., `Query::scan("T").restrict(...)`).
    *   Added `serde` support for full serialization/deserialization of queries.
2.  **`relvar/src/experimental/mod.rs`**: Exposed the `query` module.
3.  **`relvar/tests/query_builder.rs`**: Added comprehensive integration tests covering E2E execution, joins, aggregations, and serialization.

**Why this is cool (Nova's Pitch):**
This feature moves `relvar` beyond simple method chaining. By reifying the query as a data structure, we enable:
*   **Serialization:** Save queries to disk or send them over a network.
*   **Introspection:** See exactly what a query will do before running it (`explain()`).
*   **Optimization:** In the future, we can rewrite the `Query` tree (e.g., push down predicates) before execution.

This is a purely additive change located in the `experimental` module.


---
*PR created automatically by Jules for task [7295522749373492252](https://jules.google.com/task/7295522749373492252) started by @madmax983*