### PR TITLE
Remove speculative UserDefined types from ScalarType/ScalarValue

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -37,3 +37,8 @@
 **Bloat:** `TypeConstraint::PositiveInt` and `NonNegativeInt`
 **Cut:** Replaced with `Range`.
 **Saved:** Removed redundant enum variants.
+
+## [Reduction]
+**Bloat:** `ScalarType::UserDefined` and `ScalarValue::UserDefined` variants and related "POSSREP" pattern support methods (`selector`, `observer`).
+**Cut:** Removed the speculative generality for user-defined types that was only used in tests.
+**Saved:** ~300 lines of code, simplified `ScalarType` and `ScalarValue` enums, removed `ScalarTypeError` and `ScalarValueError`.

--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -2,14 +2,12 @@
 //!
 //! This module defines [`ScalarType`], which represents the atomic types that
 //! can appear as attribute values in tuples. It includes built-in types
-//! (Int, Float, String, Bool, Bytes) and user-defined types.
+//! (Int, Float, String, Bool, Bytes).
 //!
 //! # TTM Compliance
 //!
-//! - **Prescription 1**: User-defined scalar types are supported via the POSSREP
-//!   (possible representation) pattern
-//! - Type identity for user-defined types is structural (name + representation)
-//! - Built-in types provide the foundation for user-defined types
+//! - **Proscription 4**: No attribute ordering (attributes identified by name)
+//! - Type equality is structural, not physical
 //!
 //! # Example
 //!
@@ -19,33 +17,9 @@
 //! // Built-in types
 //! let int_type = ScalarType::Int;
 //! let string_type = ScalarType::String;
-//!
-//! // User-defined types with distinct identity
-//! let widget_id = ScalarType::user_defined("WidgetId", ScalarType::Int);
-//! let supplier_id = ScalarType::user_defined("SupplierId", ScalarType::Int);
-//!
-//! // Same representation, but different types!
-//! assert_ne!(widget_id, supplier_id);
 //! ```
 
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
-
-/// Errors that can occur during scalar type operations.
-#[derive(Debug, Error)]
-pub enum ScalarTypeError {
-    /// A value's type doesn't match the expected type.
-    ///
-    /// This typically occurs when using a selector with a value of the
-    /// wrong representation type.
-    #[error("Type mismatch: expected {expected}, got {actual}")]
-    TypeMismatch {
-        /// The expected type name.
-        expected: String,
-        /// The actual type name of the provided value.
-        actual: String,
-    },
-}
 
 /// Represents a scalar (atomic) type in the relational model.
 ///
@@ -63,35 +37,6 @@ pub enum ScalarTypeError {
 /// # Advanced Types
 ///
 /// - [`Relation`](ScalarType::Relation) - Nested relation (relation-valued attribute)
-/// - [`UserDefined`](ScalarType::UserDefined) - Custom type with POSSREP pattern
-///
-/// # TTM Prescription 1
-///
-/// Users can define their own scalar types using the POSSREP (possible
-/// representation) pattern. A user-defined type has:
-///
-/// - A **name** that provides type identity
-/// - A **representation** type for storage
-///
-/// Two user-defined types with the same representation but different names
-/// are considered distinct types.
-///
-/// # Example
-///
-/// ```
-/// use relvar_core::types::ScalarType;
-///
-/// // Built-in types
-/// let age_type = ScalarType::Int;
-/// let name_type = ScalarType::String;
-///
-/// // User-defined type for type safety
-/// let employee_id = ScalarType::user_defined("EmployeeId", ScalarType::Int);
-/// let department_id = ScalarType::user_defined("DepartmentId", ScalarType::Int);
-///
-/// // These are different types despite same representation
-/// assert_ne!(employee_id, department_id);
-/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ScalarType {
     /// 64-bit signed integer.
@@ -124,27 +69,6 @@ pub enum ScalarType {
     /// Contains a nested relation, enabling hierarchical data modeling.
     /// The boxed `RelationType` specifies the heading of the nested relation.
     Relation(Box<crate::types::RelationType>),
-
-    /// User-defined scalar type.
-    ///
-    /// Implements the POSSREP (possible representation) pattern from TTM.
-    /// The type has a unique name (providing type identity) and a base
-    /// representation type (defining storage and valid values).
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use relvar_core::types::ScalarType;
-    ///
-    /// let currency = ScalarType::user_defined("Currency", ScalarType::Float);
-    /// assert_eq!(currency.name(), "Currency");
-    /// ```
-    UserDefined {
-        /// The unique name identifying this type.
-        name: String,
-        /// The underlying representation type.
-        representation: Box<ScalarType>,
-    },
 }
 
 impl ScalarType {
@@ -157,91 +81,6 @@ impl ScalarType {
             ScalarType::Bool => "Bool".to_string(),
             ScalarType::Bytes => "Bytes".to_string(),
             ScalarType::Relation(_) => "Relation".to_string(),
-            ScalarType::UserDefined { name, .. } => name.clone(),
-        }
-    }
-
-    /// Creates a user-defined type with the given name and representation type.
-    ///
-    /// TTM Prescription 1: Users can define their own scalar types.
-    /// TTM: This implements the POSSREP pattern - the type has a name (identity)
-    /// and a representation type (storage).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar_core::types::ScalarType;
-    ///
-    /// let widget_id = ScalarType::user_defined("WidgetId", ScalarType::Int);
-    /// let supplier_id = ScalarType::user_defined("SupplierId", ScalarType::Int);
-    ///
-    /// // Same representation, but different types
-    /// assert_ne!(widget_id, supplier_id);
-    /// ```
-    pub fn user_defined(name: impl Into<String>, representation: ScalarType) -> Self {
-        ScalarType::UserDefined {
-            name: name.into(),
-            representation: Box::new(representation),
-        }
-    }
-
-    /// POSSREP selector: constructs a value of this type from its representation.
-    ///
-    /// TTM: The selector takes a value of the representation type and produces
-    /// a value of this user-defined type.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use relvar_core::types::ScalarType;
-    /// use relvar_core::values::ScalarValue;
-    ///
-    /// // Define a user-defined type backed by Int
-    /// let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-    ///
-    /// // Successful selection
-    /// let widget = widget_id_type.selector(ScalarValue::Int(42)).unwrap();
-    /// assert_eq!(widget.scalar_type().name(), "WidgetId");
-    ///
-    /// // Type mismatch error
-    /// let result = widget_id_type.selector(ScalarValue::String("not an int".into()));
-    /// assert!(result.is_err());
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err` if the provided value's type doesn't match the expected
-    /// representation type.
-    pub fn selector(
-        &self,
-        value: crate::values::ScalarValue,
-    ) -> Result<crate::values::ScalarValue, ScalarTypeError> {
-        use crate::values::ScalarValue;
-
-        match self {
-            ScalarType::UserDefined { representation, .. } => {
-                // Check that the value matches the representation type
-                if !value.is_type(representation) {
-                    return Err(ScalarTypeError::TypeMismatch {
-                        expected: representation.name(),
-                        actual: value.scalar_type().name(),
-                    });
-                }
-                Ok(ScalarValue::UserDefined {
-                    type_def: self.clone(),
-                    value: Box::new(value),
-                })
-            }
-            // For built-in types, the value must already be of this type
-            ty => {
-                if !value.is_type(ty) {
-                    return Err(ScalarTypeError::TypeMismatch {
-                        expected: ty.name(),
-                        actual: value.scalar_type().name(),
-                    });
-                }
-                Ok(value)
-            }
         }
     }
 }
@@ -261,13 +100,6 @@ impl std::hash::Hash for ScalarType {
             ScalarType::Relation(rel_type) => {
                 // Hash the relation type's heading
                 rel_type.heading().hash(state);
-            }
-            ScalarType::UserDefined {
-                name,
-                representation,
-            } => {
-                name.hash(state);
-                representation.hash(state);
             }
         }
     }
@@ -291,7 +123,6 @@ impl Ord for ScalarType {
             ScalarType::Bool => 3,
             ScalarType::Bytes => 4,
             ScalarType::Relation(_) => 5,
-            ScalarType::UserDefined { .. } => 6,
         };
 
         match disc_value(self).cmp(&disc_value(other)) {
@@ -341,19 +172,6 @@ impl Ord for ScalarType {
                             other => other,
                         }
                     }
-                    (
-                        ScalarType::UserDefined {
-                            name: a_name,
-                            representation: a_rep,
-                        },
-                        ScalarType::UserDefined {
-                            name: b_name,
-                            representation: b_rep,
-                        },
-                    ) => match a_name.cmp(b_name) {
-                        Ordering::Equal => a_rep.cmp(b_rep),
-                        other => other,
-                    },
                     _ => unreachable!("Discriminants matched but variants don't"),
                 }
             }
@@ -433,30 +251,12 @@ mod tests {
         assert!(set.contains(&ScalarType::Float));
     }
 
-    #[test]
-    fn test_builtin_selector_validates_type() {
-        use crate::values::ScalarValue;
-
-        // Selector for built-in types should reject values of wrong type
-        let int_type = ScalarType::Int;
-        let string_value = ScalarValue::String("not an int".to_string());
-
-        let result = int_type.selector(string_value);
-        assert!(result.is_err());
-
-        // Should accept correct type
-        let int_value = ScalarValue::Int(42);
-        let result = int_type.selector(int_value.clone());
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), int_value);
-    }
-
     // Tests for Ord/PartialOrd implementations (for coverage)
     #[test]
     fn test_scalar_type_ord_basic_types() {
         use std::cmp::Ordering;
 
-        // Test discriminant ordering: Int < Float < String < Bool < Bytes < Relation < UserDefined
+        // Test discriminant ordering: Int < Float < String < Bool < Bytes < Relation
         assert_eq!(ScalarType::Int.cmp(&ScalarType::Float), Ordering::Less);
         assert_eq!(ScalarType::Float.cmp(&ScalarType::String), Ordering::Less);
         assert_eq!(ScalarType::String.cmp(&ScalarType::Bool), Ordering::Less);
@@ -516,37 +316,6 @@ mod tests {
     }
 
     #[test]
-    fn test_scalar_type_ord_user_defined_by_name() {
-        use std::cmp::Ordering;
-
-        let widget_id = ScalarType::user_defined("WidgetId", ScalarType::Int);
-        let supplier_id = ScalarType::user_defined("SupplierId", ScalarType::Int);
-        let widget_id_copy = ScalarType::user_defined("WidgetId", ScalarType::Int);
-
-        // Same name and representation should be equal
-        assert_eq!(widget_id.cmp(&widget_id_copy), Ordering::Equal);
-
-        // Different names should have consistent ordering
-        let result = widget_id.cmp(&supplier_id);
-        assert_ne!(result, Ordering::Equal);
-        assert_eq!(supplier_id.cmp(&widget_id), result.reverse());
-    }
-
-    #[test]
-    fn test_scalar_type_ord_user_defined_by_representation() {
-        use std::cmp::Ordering;
-
-        // Same name but different representation
-        let widget_id_int = ScalarType::user_defined("WidgetId", ScalarType::Int);
-        let widget_id_string = ScalarType::user_defined("WidgetId", ScalarType::String);
-
-        // Different representations should have consistent ordering
-        let result = widget_id_int.cmp(&widget_id_string);
-        assert_ne!(result, Ordering::Equal);
-        assert_eq!(widget_id_string.cmp(&widget_id_int), result.reverse());
-    }
-
-    #[test]
     fn test_scalar_type_ord_mixed_variants() {
         use crate::types::{RelationType, TupleType};
         use std::cmp::Ordering;
@@ -555,16 +324,9 @@ mod tests {
         let relation_type = ScalarType::Relation(Box::new(RelationType::new(
             TupleType::new().with_attribute("a", ScalarType::Int),
         )));
-        let user_type = ScalarType::user_defined("CustomType", ScalarType::Int);
 
         // Relation comes after basic types
         assert_eq!(int_type.cmp(&relation_type), Ordering::Less);
-
-        // UserDefined comes after Relation
-        assert_eq!(relation_type.cmp(&user_type), Ordering::Less);
-
-        // Transitive property
-        assert_eq!(int_type.cmp(&user_type), Ordering::Less);
     }
 
     #[test]
@@ -592,7 +354,6 @@ mod tests {
             ScalarType::String,
             ScalarType::Bool,
             ScalarType::Bytes,
-            ScalarType::user_defined("Test", ScalarType::Int),
         ];
 
         for ty in types {

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -7,7 +7,6 @@
 //!
 //! - All values carry their type (introspection is possible)
 //! - No NULL values are permitted
-//! - User-defined values via POSSREP pattern (Prescription 1)
 //!
 //! # Example
 //!
@@ -28,17 +27,6 @@
 
 use crate::types::ScalarType;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
-
-/// Errors that can occur during scalar value operations.
-#[derive(Debug, Error)]
-pub enum ScalarValueError {
-    /// Attempted to use an observer on a built-in type.
-    ///
-    /// The observer operation is only valid for user-defined types.
-    #[error("Cannot extract observer from built-in type")]
-    NotUserDefined,
-}
 
 /// Represents an atomic (scalar) value at runtime.
 ///
@@ -57,7 +45,6 @@ pub enum ScalarValueError {
 /// # Advanced Values
 ///
 /// - [`Relation`](ScalarValue::Relation) - Nested relation (for RVAs)
-/// - [`UserDefined`](ScalarValue::UserDefined) - Custom type value
 ///
 /// # Equality and Hashing
 ///
@@ -100,19 +87,6 @@ pub enum ScalarValue {
     ///
     /// Enables nested relations within tuples.
     Relation(crate::values::Relation),
-
-    /// User-defined type value.
-    ///
-    /// Implements the POSSREP pattern: the value carries both its type
-    /// identity (via `type_def`) and its representation value (via `value`).
-    ///
-    /// Use [`ScalarType::selector()`] to create user-defined values.
-    UserDefined {
-        /// The type definition for this user-defined value.
-        type_def: ScalarType,
-        /// The underlying representation value.
-        value: Box<ScalarValue>,
-    },
 }
 
 impl ScalarValue {
@@ -143,7 +117,6 @@ impl ScalarValue {
             ScalarValue::Relation(rel) => {
                 ScalarType::Relation(Box::new(rel.relation_type().clone()))
             }
-            ScalarValue::UserDefined { type_def, .. } => type_def.clone(),
         }
     }
 
@@ -151,58 +124,11 @@ impl ScalarValue {
     pub fn is_type(&self, ty: &ScalarType) -> bool {
         &self.scalar_type() == ty
     }
-
-    /// POSSREP observer: extracts the underlying representation value.
-    ///
-    /// TTM: The observer function extracts the representation from a
-    /// user-defined type value.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use relvar_core::types::ScalarType;
-    /// use relvar_core::values::ScalarValue;
-    ///
-    /// let widget_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-    /// let widget_val = widget_type.selector(ScalarValue::Int(42)).unwrap();
-    ///
-    /// // Observer extracts the Int(42)
-    /// let representation = widget_val.observer().unwrap();
-    /// assert_eq!(representation, ScalarValue::Int(42));
-    ///
-    /// // Built-in types have no observer
-    /// let raw_int = ScalarValue::Int(42);
-    /// assert!(raw_int.observer().is_err());
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err` if called on a built-in type (only user-defined types
-    /// have observers).
-    pub fn observer(&self) -> Result<ScalarValue, ScalarValueError> {
-        match self {
-            ScalarValue::UserDefined { value, .. } => Ok((**value).clone()),
-            _ => Err(ScalarValueError::NotUserDefined),
-        }
-    }
-
-    /// Helper constructor for user-defined values (used in tests).
-    /// Prefer using `ScalarType::selector()` in production code.
-    #[cfg(test)]
-    pub fn user_defined(type_def: ScalarType, value: ScalarValue) -> Self {
-        ScalarValue::UserDefined {
-            type_def,
-            value: Box::new(value),
-        }
-    }
 }
 
 // Custom PartialEq implementation for ScalarValue
 // Note: Float comparison uses bit equality, which is appropriate for
 // database values (we want NaN == NaN for set semantics)
-//
-// TTM: User-defined values are equal only if they have the same type AND
-// the same representation value. This ensures type safety.
 impl PartialEq for ScalarValue {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -218,16 +144,6 @@ impl PartialEq for ScalarValue {
             (ScalarValue::Bool(a), ScalarValue::Bool(b)) => a == b,
             (ScalarValue::Bytes(a), ScalarValue::Bytes(b)) => a == b,
             (ScalarValue::Relation(a), ScalarValue::Relation(b)) => a == b,
-            (
-                ScalarValue::UserDefined {
-                    type_def: type_a,
-                    value: val_a,
-                },
-                ScalarValue::UserDefined {
-                    type_def: type_b,
-                    value: val_b,
-                },
-            ) => type_a == type_b && val_a == val_b,
             _ => false,
         }
     }
@@ -237,7 +153,6 @@ impl PartialEq for ScalarValue {
 impl Eq for ScalarValue {}
 
 // Custom Hash implementation
-// TTM: User-defined values hash based on both type and value
 impl std::hash::Hash for ScalarValue {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
@@ -269,11 +184,6 @@ impl std::hash::Hash for ScalarValue {
                 5u8.hash(state);
                 v.hash(state);
             }
-            ScalarValue::UserDefined { type_def, value } => {
-                6u8.hash(state);
-                type_def.hash(state);
-                value.hash(state);
-            }
         }
     }
 }
@@ -287,7 +197,6 @@ impl PartialOrd for ScalarValue {
 
 // Custom Ord implementation for use in BTreeMap
 // We order by type first, then by value within type
-// TTM: User-defined values are ordered by type identity first, then by representation value
 impl Ord for ScalarValue {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         use std::cmp::Ordering;
@@ -301,7 +210,6 @@ impl Ord for ScalarValue {
                 ScalarValue::Bool(_) => 3,
                 ScalarValue::Bytes(_) => 4,
                 ScalarValue::Relation(_) => 5,
-                ScalarValue::UserDefined { .. } => 6,
             }
         }
 
@@ -327,22 +235,6 @@ impl Ord for ScalarValue {
                         // For relations, order by cardinality first, then degree
                         match a.cardinality().cmp(&b.cardinality()) {
                             Ordering::Equal => a.degree().cmp(&b.degree()),
-                            other => other,
-                        }
-                    }
-                    (
-                        ScalarValue::UserDefined {
-                            type_def: type_a,
-                            value: val_a,
-                        },
-                        ScalarValue::UserDefined {
-                            type_def: type_b,
-                            value: val_b,
-                        },
-                    ) => {
-                        // Order by type identity first (structural comparison), then by value
-                        match type_a.cmp(type_b) {
-                            Ordering::Equal => val_a.cmp(val_b),
                             other => other,
                         }
                     }
@@ -453,154 +345,6 @@ mod tests {
         let int_val = ScalarValue::Int(42);
         assert!(int_val.is_type(&ScalarType::Int));
         assert!(!int_val.is_type(&ScalarType::Float));
-    }
-
-    // Consolidated tests from user_defined_test.rs
-
-    #[test]
-    fn test_user_defined_types_are_distinct_from_builtin_types() {
-        // Define two user-defined types, both backed by Int
-        let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-        let supplier_id_type = ScalarType::user_defined("SupplierId", ScalarType::Int);
-
-        // These types should NOT be equal even though they have the same representation
-        assert_ne!(widget_id_type, supplier_id_type);
-
-        // They should also not equal the built-in Int type
-        assert_ne!(widget_id_type, ScalarType::Int);
-        assert_ne!(supplier_id_type, ScalarType::Int);
-    }
-
-    #[test]
-    fn test_user_defined_values_are_type_safe() {
-        let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-        let supplier_id_type = ScalarType::user_defined("SupplierId", ScalarType::Int);
-
-        // Create values with the same underlying Int value (5)
-        let widget_5 = ScalarValue::user_defined(widget_id_type.clone(), ScalarValue::Int(5));
-        let supplier_5 = ScalarValue::user_defined(supplier_id_type.clone(), ScalarValue::Int(5));
-
-        // These should NOT be equal - different types!
-        assert_ne!(widget_5, supplier_5);
-
-        // Values should also not equal raw Int(5)
-        assert_ne!(widget_5, ScalarValue::Int(5));
-        assert_ne!(supplier_5, ScalarValue::Int(5));
-    }
-
-    #[test]
-    fn test_user_defined_values_of_same_type_are_equal() {
-        let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-
-        let widget_5_a = ScalarValue::user_defined(widget_id_type.clone(), ScalarValue::Int(5));
-        let widget_5_b = ScalarValue::user_defined(widget_id_type.clone(), ScalarValue::Int(5));
-        let widget_7 = ScalarValue::user_defined(widget_id_type.clone(), ScalarValue::Int(7));
-
-        assert_eq!(widget_5_a, widget_5_b);
-        assert_ne!(widget_5_a, widget_7);
-    }
-
-    #[test]
-    fn test_user_defined_types_have_names() {
-        let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-
-        assert_eq!(widget_id_type.name(), "WidgetId");
-    }
-
-    #[test]
-    fn test_user_defined_values_carry_their_type() {
-        let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-        let widget_5 = ScalarValue::user_defined(widget_id_type.clone(), ScalarValue::Int(5));
-
-        assert_eq!(widget_5.scalar_type(), widget_id_type);
-        assert_ne!(widget_5.scalar_type(), ScalarType::Int);
-    }
-
-    #[test]
-    fn test_possrep_selector_constructs_value() {
-        let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-
-        // Selector: construct a WidgetId from an Int
-        let widget = widget_id_type.selector(ScalarValue::Int(42)).unwrap();
-
-        assert_eq!(widget.scalar_type(), widget_id_type);
-    }
-
-    #[test]
-    fn test_possrep_observer_extracts_representation() {
-        let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-        let widget = widget_id_type.selector(ScalarValue::Int(42)).unwrap();
-
-        // Observer: extract the underlying Int value
-        let underlying = widget.observer().unwrap();
-
-        assert_eq!(underlying, ScalarValue::Int(42));
-    }
-
-    #[test]
-    fn test_nested_user_defined_types() {
-        let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-        let special_widget_type =
-            ScalarType::user_defined("SpecialWidgetId", widget_id_type.clone());
-
-        let widget = widget_id_type.selector(ScalarValue::Int(42)).unwrap();
-        let special_widget = special_widget_type.selector(widget.clone()).unwrap();
-
-        assert_ne!(special_widget.scalar_type(), widget_id_type);
-        assert_eq!(special_widget.scalar_type(), special_widget_type);
-    }
-
-    #[test]
-    fn test_type_safety_prevents_wrong_representation() {
-        let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-
-        // Should fail: trying to construct WidgetId from String
-        let result = widget_id_type.selector(ScalarValue::String("not an int".to_string()));
-
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_user_defined_types_serialize() {
-        let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-        let widget = widget_id_type.selector(ScalarValue::Int(42)).unwrap();
-
-        let serialized = serde_json::to_string(&widget).unwrap();
-        let deserialized: ScalarValue = serde_json::from_str(&serialized).unwrap();
-
-        assert_eq!(widget, deserialized);
-        assert_eq!(deserialized.scalar_type(), widget_id_type);
-    }
-
-    #[test]
-    fn test_user_defined_values_can_be_hashed() {
-        use std::collections::HashSet;
-
-        let widget_id_type = ScalarType::user_defined("WidgetId", ScalarType::Int);
-        let supplier_id_type = ScalarType::user_defined("SupplierId", ScalarType::Int);
-
-        let mut set = HashSet::new();
-        set.insert(widget_id_type.selector(ScalarValue::Int(5)).unwrap());
-        set.insert(widget_id_type.selector(ScalarValue::Int(5)).unwrap()); // Duplicate
-        set.insert(supplier_id_type.selector(ScalarValue::Int(5)).unwrap()); // Different type
-        set.insert(ScalarValue::Int(5)); // Raw Int
-
-        // Should have 3 distinct values:
-        // - WidgetId(5)
-        // - SupplierId(5)
-        // - Int(5)
-        assert_eq!(set.len(), 3);
-    }
-
-    #[test]
-    fn test_user_defined_type_names_must_be_unique() {
-        let type1 = ScalarType::user_defined("MyType", ScalarType::Int);
-        let type2 = ScalarType::user_defined("MyType", ScalarType::String);
-
-        // This test documents that types with the same name but different
-        // representations are distinct, as `PartialEq` is structural.
-        assert_ne!(type1, type2);
-        assert_eq!(type1.name(), type2.name());
     }
 
     // Bytes tests

--- a/relvar/src/experimental/exporter.rs
+++ b/relvar/src/experimental/exporter.rs
@@ -162,7 +162,7 @@ pub fn to_csv(relation: &Relation, delimiter: char) -> Result<String, ExporterEr
 /// - `String` -> JSON String
 /// - `Bool` -> JSON Boolean
 /// - `Bytes` -> JSON Array of numbers
-/// - `Relation`, `UserDefined` -> String representation (simplification)
+/// - `Relation` -> String representation (simplification)
 ///
 /// # Arguments
 ///
@@ -339,7 +339,6 @@ fn format_scalar_csv(val: &ScalarValue) -> String {
         ScalarValue::Bool(v) => v.to_string(),
         ScalarValue::Bytes(v) => format!("{:?}", v),
         ScalarValue::Relation(_) => "<Relation>".to_string(),
-        ScalarValue::UserDefined { .. } => "<UserDefined>".to_string(),
     }
 }
 
@@ -351,7 +350,6 @@ fn scalar_to_json(val: &ScalarValue) -> serde_json::Value {
         ScalarValue::Bool(v) => serde_json::json!(v),
         ScalarValue::Bytes(v) => serde_json::json!(v),
         ScalarValue::Relation(_) => serde_json::json!("<Relation>"),
-        ScalarValue::UserDefined { .. } => serde_json::json!("<UserDefined>"),
     }
 }
 
@@ -363,7 +361,6 @@ fn format_scalar_table(val: &ScalarValue) -> String {
         ScalarValue::Bool(v) => v.to_string(),
         ScalarValue::Bytes(_) => "<Bytes>".to_string(),
         ScalarValue::Relation(_) => "<Relation>".to_string(),
-        ScalarValue::UserDefined { .. } => "<UserDefined>".to_string(),
     }
 }
 
@@ -446,10 +443,6 @@ mod tests {
         let mut nested_rel = Relation::new(RelationType::new(nested_heading.clone()));
         nested_rel.insert(tuple! { x: 10i64 }).unwrap();
 
-        // Create a user defined type
-        let user_type = ScalarType::user_defined("MyInt", ScalarType::Int);
-        let user_val = user_type.selector(ScalarValue::Int(42)).unwrap();
-
         let heading = TupleType::new()
             .with_attribute("int_col", ScalarType::Int)
             .with_attribute("float_col", ScalarType::Float)
@@ -459,8 +452,7 @@ mod tests {
             .with_attribute(
                 "rel_col",
                 ScalarType::Relation(Box::new(RelationType::new(nested_heading))),
-            )
-            .with_attribute("user_col", user_type);
+            );
 
         let mut relation = Relation::new(RelationType::new(heading));
 
@@ -476,7 +468,6 @@ mod tests {
         values.insert("bool_col".to_string(), ScalarValue::Bool(true));
         values.insert("bytes_col".to_string(), ScalarValue::Bytes(vec![1, 2, 3]));
         values.insert("rel_col".to_string(), ScalarValue::Relation(nested_rel));
-        values.insert("user_col".to_string(), user_val);
 
         let tuple = Tuple::new(relation.relation_type().heading().clone(), values).unwrap();
         relation.insert(tuple).unwrap();
@@ -491,6 +482,5 @@ mod tests {
         assert_eq!(obj["bool_col"], true);
         assert_eq!(obj["bytes_col"], serde_json::json!([1, 2, 3]));
         assert_eq!(obj["rel_col"], "<Relation>");
-        assert_eq!(obj["user_col"], "<UserDefined>");
     }
 }

--- a/relvar/src/experimental/importer.rs
+++ b/relvar/src/experimental/importer.rs
@@ -187,15 +187,6 @@ fn json_value_to_scalar(
                 from_json(inner_json.as_bytes(), *inner_type.clone()).map_err(|e| e.to_string())?;
             Ok(ScalarValue::Relation(rel))
         }
-        // UserDefined (recursive wrapper)
-        (val, ScalarType::UserDefined { representation, .. }) => {
-            let inner_val = json_value_to_scalar(val, representation)?;
-            // We need to wrap it. But ScalarValue doesn't expose a raw constructor easily?
-            // It has ScalarType::selector().
-            expected_type
-                .selector(inner_val)
-                .map_err(|e| format!("Selector error: {:?}", e)) // generic debug error
-        }
         _ => Err(format!(
             "Incompatible value {:?} for type {:?}",
             value, expected_type
@@ -347,12 +338,6 @@ fn str_to_scalar(s: &str, expected_type: &ScalarType) -> Result<ScalarValue, Str
             Ok(ScalarValue::Bytes(v))
         }
         ScalarType::Relation(_) => Err("Cannot import nested relations from CSV".to_string()),
-        ScalarType::UserDefined { representation, .. } => {
-            let inner_val = str_to_scalar(s, representation)?;
-            expected_type
-                .selector(inner_val)
-                .map_err(|e| format!("{:?}", e))
-        }
     }
 }
 
@@ -375,29 +360,6 @@ mod tests {
 
         let relation = from_json(json.as_bytes(), rel_type).unwrap();
         assert_eq!(relation.cardinality(), 2);
-    }
-
-    #[test]
-    fn test_from_json_nested() {
-        // Define UserType
-        let user_id_type = ScalarType::user_defined("UserId", ScalarType::Int);
-
-        let heading = TupleType::new()
-            .with_attribute("uid", user_id_type.clone())
-            .with_attribute("score", ScalarType::Float);
-        let rel_type = RelationType::new(heading);
-
-        let json = r#"[
-            {"uid": 100, "score": 99.5},
-            {"uid": 101, "score": 88.0}
-        ]"#;
-
-        let relation = from_json(json.as_bytes(), rel_type).unwrap();
-        assert_eq!(relation.cardinality(), 2);
-
-        let tuple = relation.tuples().next().unwrap();
-        let val = tuple.get("uid").unwrap();
-        assert_eq!(val.scalar_type(), user_id_type);
     }
 
     #[test]
@@ -574,26 +536,6 @@ mod tests {
             result.unwrap_err(),
             ImporterError::TypeError(attr, _, _) if attr == "id"
         ));
-    }
-
-    #[test]
-    fn test_csv_bytes_and_user_defined() {
-        let user_type = ScalarType::user_defined("UserId", ScalarType::Int);
-        let heading = TupleType::new()
-            .with_attribute("uid", user_type.clone())
-            .with_attribute("data", ScalarType::Bytes);
-        let rel_type = RelationType::new(heading);
-
-        // CSV uses JSON array syntax for bytes
-        let csv = "uid,data\n100,\"[1, 2, 3]\"";
-
-        let result = from_csv(csv.as_bytes(), rel_type, ',');
-        assert!(result.is_ok());
-        let rel = result.unwrap();
-        let tuple = rel.tuples().next().unwrap();
-
-        assert_eq!(tuple.get("uid").unwrap().scalar_type(), user_type);
-        assert_eq!(tuple.get("data"), Some(&ScalarValue::Bytes(vec![1, 2, 3])));
     }
 
     #[test]

--- a/relvar/src/experimental/mock.rs
+++ b/relvar/src/experimental/mock.rs
@@ -113,14 +113,6 @@ impl MockRelation {
                 // Nested relation: return empty for now to avoid infinite recursion
                 ScalarValue::Relation(Relation::new(*rel_type.clone()))
             }
-            ScalarType::UserDefined { representation, .. } => {
-                // Recursively generate value for the representation
-                let inner_value = self.generate_value(representation, rng);
-                ScalarValue::UserDefined {
-                    type_def: scalar_type.clone(),
-                    value: Box::new(inner_value),
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Removed `ScalarType::UserDefined` and `ScalarValue::UserDefined` variants and their associated POSSREP pattern support methods (`selector`, `observer`). These features were speculative, unused in the core codebase, and added unnecessary complexity to the type system.

This reduction simplifies the core type system and removes about 300 lines of code and tests that were not serving any production purpose.


---
*PR created automatically by Jules for task [13771849798602492009](https://jules.google.com/task/13771849798602492009) started by @madmax983*