### PR TITLE
🛡️ Sentry: [test coverage improvement] for ConstraintManager

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -29,3 +29,6 @@
 ## 2026-10-24 - Inconsistent NaN Handling in Scalar Values
 **Learning:** Found that `ScalarValue::Float` relied on `f64::to_bits()` for equality and hashing, causing different NaN payloads to be treated as distinct values (and distinct groups in `summarize`).
 **Action:** When implementing database types, always normalize NaNs in `Eq`, `Hash`, and `Ord` to ensure set semantics (all NaNs are equal), regardless of the underlying bit pattern.
+## 2026-02-14 - [Testing ConstraintManager with InMemoryEngine]
+**Learning:** Logic components that depend on persistence traits (like `StorageEngine`) can be unit tested effectively by using an in-memory implementation (like `InMemoryEngine`) rather than mocking. This avoids the pain of setting up mock expectations for complex stateful interactions (like loading relations) and tests the actual orchestration logic.
+**Action:** When testing components that orchestrate storage operations, prefer using a real in-memory engine over a mock object to verify state transitions and complex integrity checks naturally.

--- a/relvar-core/src/constraints/manager.rs
+++ b/relvar-core/src/constraints/manager.rs
@@ -403,3 +403,277 @@ impl ConstraintManager {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constraints::check::{CheckConstraint, CheckConstraints};
+    use crate::constraints::expression::{CmpOp, ConstraintExpression, ValueOrRef};
+    use crate::constraints::{
+        AttributeConstraints, ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey,
+        TypeConstraint,
+    };
+    use crate::storage_engine::InMemoryEngine;
+    use crate::tuple;
+    use crate::types::{RelationType, ScalarType, TupleType};
+    use crate::values::{Relation, ScalarValue};
+
+    // --- Helpers ---
+    fn setup_engine() -> InMemoryEngine {
+        InMemoryEngine::new()
+    }
+
+    fn create_test_rel(engine: &mut InMemoryEngine, name: &str) -> RelationType {
+        let heading = TupleType::new()
+            .with_attribute("id", ScalarType::Int)
+            .with_attribute("name", ScalarType::String);
+        let rel_type = RelationType::new(heading);
+        engine.create_relation(name, rel_type.clone()).unwrap();
+        rel_type
+    }
+
+    // --- Tests ---
+
+    #[test]
+    fn test_set_key_constraints_valid() {
+        let mut engine = setup_engine();
+        let mut manager = ConstraintManager::new();
+        create_test_rel(&mut engine, "TEST");
+
+        let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+        let constraints = KeyConstraints::new().with_primary_key(pk);
+
+        assert!(
+            manager
+                .set_key_constraints(&mut engine, "TEST", constraints)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_set_key_constraints_missing_relation() {
+        let mut engine = setup_engine();
+        let mut manager = ConstraintManager::new();
+        let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+        let constraints = KeyConstraints::new().with_primary_key(pk);
+
+        let result = manager.set_key_constraints(&mut engine, "MISSING", constraints);
+        assert!(matches!(
+            result,
+            Err(ConstraintManagerError::RelationNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn test_validate_key_constraints_bulk_violation() {
+        let mut engine = setup_engine();
+        let mut manager = ConstraintManager::new();
+        create_test_rel(&mut engine, "TEST");
+
+        // Insert duplicates
+        engine
+            .insert_tuple("TEST", tuple! { id: 1i64, name: "A" })
+            .unwrap();
+        engine
+            .insert_tuple("TEST", tuple! { id: 1i64, name: "B" })
+            .unwrap();
+
+        let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+        let constraints = KeyConstraints::new().with_primary_key(pk);
+
+        let result = manager.set_key_constraints(&mut engine, "TEST", constraints);
+        assert!(matches!(
+            result,
+            Err(ConstraintManagerError::PrimaryKeyViolation)
+        ));
+    }
+
+    #[test]
+    fn test_validate_key_constraints_single_tuple() {
+        let mut engine = setup_engine();
+        let mut manager = ConstraintManager::new();
+        create_test_rel(&mut engine, "TEST");
+
+        let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+        let constraints = KeyConstraints::new().with_primary_key(pk);
+        manager
+            .set_key_constraints(&mut engine, "TEST", constraints)
+            .unwrap();
+
+        engine
+            .insert_tuple("TEST", tuple! { id: 1i64, name: "A" })
+            .unwrap();
+        let current_rel = engine.load_relation("TEST").unwrap();
+
+        // New tuple with unique ID
+        let t1 = tuple! { id: 2i64, name: "B" };
+        assert!(
+            manager
+                .validate_key_constraints_single_tuple("TEST", &t1, &current_rel)
+                .is_ok()
+        );
+
+        // Tuple with duplicate ID
+        let t2 = tuple! { id: 1i64, name: "C" };
+        assert!(matches!(
+            manager.validate_key_constraints_single_tuple("TEST", &t2, &current_rel),
+            Err(ConstraintManagerError::PrimaryKeyViolation)
+        ));
+    }
+
+    #[test]
+    fn test_foreign_key_violation_on_insert() {
+        let mut engine = setup_engine();
+        let mut manager = ConstraintManager::new();
+
+        // Referenced: PARENT(id)
+        let parent_type = RelationType::new(TupleType::new().with_attribute("id", ScalarType::Int));
+        engine
+            .create_relation("PARENT", parent_type.clone())
+            .unwrap();
+        engine.insert_tuple("PARENT", tuple! { id: 1i64 }).unwrap();
+
+        // Referencing: CHILD(pid)
+        let child_type = RelationType::new(TupleType::new().with_attribute("pid", ScalarType::Int));
+        engine.create_relation("CHILD", child_type.clone()).unwrap();
+
+        // Set FK: CHILD.pid -> PARENT.id
+        let fk = ForeignKey::new(
+            vec!["pid".to_string()],
+            "PARENT".to_string(),
+            vec!["id".to_string()],
+        )
+        .unwrap();
+        let constraints = ForeignKeyConstraints::new().with_foreign_key(fk);
+        manager
+            .set_foreign_key_constraints(&mut engine, "CHILD", constraints)
+            .unwrap();
+
+        // Valid insert
+        let t1 = tuple! { pid: 1i64 };
+        assert!(
+            manager
+                .validate_foreign_keys_single_tuple(&mut engine, "CHILD", &t1)
+                .is_ok()
+        );
+
+        // Invalid insert (orphan)
+        let t2 = tuple! { pid: 99i64 };
+        assert!(matches!(
+            manager.validate_foreign_keys_single_tuple(&mut engine, "CHILD", &t2),
+            Err(ConstraintManagerError::ForeignKeyViolation(_))
+        ));
+    }
+
+    #[test]
+    fn test_referencing_fk_blocks_delete() {
+        let mut engine = setup_engine();
+        let mut manager = ConstraintManager::new();
+
+        // Referenced: PARENT(id)
+        let parent_type = RelationType::new(TupleType::new().with_attribute("id", ScalarType::Int));
+        engine
+            .create_relation("PARENT", parent_type.clone())
+            .unwrap();
+        engine.insert_tuple("PARENT", tuple! { id: 1i64 }).unwrap();
+        engine.insert_tuple("PARENT", tuple! { id: 2i64 }).unwrap();
+
+        // Referencing: CHILD(pid)
+        let child_type = RelationType::new(TupleType::new().with_attribute("pid", ScalarType::Int));
+        engine.create_relation("CHILD", child_type.clone()).unwrap();
+        engine.insert_tuple("CHILD", tuple! { pid: 1i64 }).unwrap();
+
+        // Set FK: CHILD.pid -> PARENT.id
+        let fk = ForeignKey::new(
+            vec!["pid".to_string()],
+            "PARENT".to_string(),
+            vec!["id".to_string()],
+        )
+        .unwrap();
+        let constraints = ForeignKeyConstraints::new().with_foreign_key(fk);
+        manager
+            .set_foreign_key_constraints(&mut engine, "CHILD", constraints)
+            .unwrap();
+
+        // Try deleting id=1 (referenced by child)
+        // Construct relation AFTER delete (simulate delete of id=1)
+        let mut rel_after_delete = Relation::new(parent_type.clone());
+        rel_after_delete.insert(tuple! { id: 2i64 }).unwrap(); // id=1 is gone
+
+        let result =
+            manager.validate_referencing_foreign_keys(&mut engine, "PARENT", &rel_after_delete);
+        assert!(matches!(
+            result,
+            Err(ConstraintManagerError::ForeignKeyViolation(_))
+        ));
+
+        // Try deleting id=2 (not referenced)
+        let mut rel_after_delete_2 = Relation::new(parent_type.clone());
+        rel_after_delete_2.insert(tuple! { id: 1i64 }).unwrap(); // id=2 is gone
+
+        let result_2 =
+            manager.validate_referencing_foreign_keys(&mut engine, "PARENT", &rel_after_delete_2);
+        assert!(result_2.is_ok());
+    }
+
+    #[test]
+    fn test_type_constraints() {
+        let mut engine = setup_engine();
+        let mut manager = ConstraintManager::new();
+        create_test_rel(&mut engine, "TEST");
+
+        let constraints = AttributeConstraints::new("id".to_string(), ScalarType::Int)
+            .with_constraint(TypeConstraint::Range {
+                min: ScalarValue::Int(1),
+                max: ScalarValue::Int(10),
+            });
+
+        manager
+            .set_type_constraints(&mut engine, "TEST", "id", constraints)
+            .unwrap();
+
+        // Valid
+        let t1 = tuple! { id: 5i64, name: "A" };
+        assert!(manager.validate_type_constraints("TEST", &t1).is_ok());
+
+        // Invalid
+        let t2 = tuple! { id: 11i64, name: "B" };
+        assert!(matches!(
+            manager.validate_type_constraints("TEST", &t2),
+            Err(ConstraintManagerError::TypeConstraintViolation(_))
+        ));
+    }
+
+    #[test]
+    fn test_check_constraints() {
+        let mut engine = setup_engine();
+        let mut manager = ConstraintManager::new();
+        create_test_rel(&mut engine, "TEST");
+
+        let check = CheckConstraint::new(
+            "check1",
+            "id > 0",
+            ConstraintExpression::Cmp {
+                left: "id".to_string(),
+                op: CmpOp::Gt,
+                right: ValueOrRef::Value(ScalarValue::Int(0)),
+            },
+        );
+        let constraints = CheckConstraints::new().with_constraint(check);
+
+        manager
+            .set_check_constraints(&mut engine, "TEST", constraints)
+            .unwrap();
+
+        // Valid
+        let t1 = tuple! { id: 1i64, name: "A" };
+        assert!(manager.validate_check_constraints("TEST", &t1).is_ok());
+
+        // Invalid
+        let t2 = tuple! { id: 0i64, name: "B" };
+        assert!(matches!(
+            manager.validate_check_constraints("TEST", &t2),
+            Err(ConstraintManagerError::CheckConstraintViolation(_))
+        ));
+    }
+}


### PR DESCRIPTION
This PR adds a dedicated unit test suite for the `ConstraintManager` in `relvar-core/src/constraints/manager.rs`. Previously, this critical component was only tested indirectly via `Database` integration tests. The new tests verify `PrimaryKey`, `ForeignKey` (both insert and delete paths), `TypeConstraint`, and `CheckConstraint` logic in isolation using `InMemoryEngine` to simulate storage. This increases confidence in the correctness of data integrity enforcement and provides a safety net for future refactoring of constraint logic.

---
*PR created automatically by Jules for task [355311440885523751](https://jules.google.com/task/355311440885523751) started by @madmax983*