### PR TITLE
Refactor: Simplify Storage module (Razor)

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -37,3 +37,18 @@
 **Bloat:** `TypeConstraint::PositiveInt` and `NonNegativeInt`
 **Cut:** Replaced with `Range`.
 **Saved:** Removed redundant enum variants.
+
+## [Reduction]
+**Bloat:** `VersionMetadata::new` and `new_with_xmax` methods in public API but only used in tests.
+**Cut:** Moved methods to `#[cfg(test)]` module as helper functions.
+**Saved:** Cleaned up public API, removed `#[allow(dead_code)]` clutter.
+
+## [Reduction]
+**Bloat:** `RelationMetadata` struct in `storage/catalog.rs` duplicated the `name` field which was already the key in `Catalog::relations` HashMap.
+**Cut:** Removed `name` field from `RelationMetadata`.
+**Saved:** Removed data duplication, reduced struct size, simplified initialization.
+
+## [Reduction]
+**Bloat:** `StorageManager::ensure_db_directory` and `load_catalog_from_disk` private helpers called only once.
+**Cut:** Inlined logic into `StorageManager::new`.
+**Saved:** Reduced indirection, improved code locality.

--- a/relvar-storage/src/mvcc/visibility.rs
+++ b/relvar-storage/src/mvcc/visibility.rs
@@ -18,34 +18,6 @@ pub struct VersionMetadata {
     pub xmax: Option<TransactionId>,
 }
 
-impl VersionMetadata {
-    /// Creates new version metadata.
-    ///
-    /// # Arguments
-    /// * `xmin` - Transaction that created this version
-    ///
-    /// NOTE: Currently unused - reserved for future MVCC transaction implementation.
-    #[allow(dead_code)]
-    pub fn new(xmin: TransactionId) -> Self {
-        Self { xmin, xmax: None }
-    }
-
-    /// Creates version metadata with deletion marker.
-    ///
-    /// # Arguments
-    /// * `xmin` - Transaction that created this version
-    /// * `xmax` - Transaction that deleted/updated this version
-    ///
-    /// NOTE: Currently unused - reserved for future MVCC transaction implementation.
-    #[allow(dead_code)]
-    pub fn new_with_xmax(xmin: TransactionId, xmax: TransactionId) -> Self {
-        Self {
-            xmin,
-            xmax: Some(xmax),
-        }
-    }
-}
-
 /// Determines if a tuple version is visible to a transaction.
 ///
 /// # Arguments
@@ -129,10 +101,21 @@ mod tests {
         Lsn::new(value)
     }
 
+    fn new_version(xmin: TransactionId) -> VersionMetadata {
+        VersionMetadata { xmin, xmax: None }
+    }
+
+    fn new_version_with_xmax(xmin: TransactionId, xmax: TransactionId) -> VersionMetadata {
+        VersionMetadata {
+            xmin,
+            xmax: Some(xmax),
+        }
+    }
+
     #[test]
     fn test_version_metadata_new() {
         let xmin = test_txn(1);
-        let version = VersionMetadata::new(xmin);
+        let version = new_version(xmin);
 
         assert_eq!(version.xmin, xmin);
         assert_eq!(version.xmax, None);
@@ -142,7 +125,7 @@ mod tests {
     fn test_version_metadata_new_with_xmax() {
         let xmin = test_txn(1);
         let xmax = test_txn(2);
-        let version = VersionMetadata::new_with_xmax(xmin, xmax);
+        let version = new_version_with_xmax(xmin, xmax);
 
         assert_eq!(version.xmin, xmin);
         assert_eq!(version.xmax, Some(xmax));
@@ -152,7 +135,7 @@ mod tests {
     fn test_version_visible_to_creator() {
         // Transaction creates a version and should see it
         let txn_id = test_txn(1);
-        let version = VersionMetadata::new(txn_id);
+        let version = new_version(txn_id);
 
         let snapshot = TransactionSnapshot::new(txn_id, test_lsn(100), vec![]);
         let committed = HashSet::new(); // txn not committed yet
@@ -167,7 +150,7 @@ mod tests {
         let t1 = test_txn(1);
         let t2 = test_txn(2);
 
-        let version = VersionMetadata::new(t1);
+        let version = new_version(t1);
 
         // T2's snapshot shows T1 as active (concurrent)
         let snapshot = TransactionSnapshot::new(t2, test_lsn(100), vec![t1]);
@@ -182,7 +165,7 @@ mod tests {
         let t1 = test_txn(1);
         let t2 = test_txn(2);
 
-        let version = VersionMetadata::new(t1);
+        let version = new_version(t1);
 
         // T2 starts after T1 committed (T1 not in active list)
         let snapshot = TransactionSnapshot::new(t2, test_lsn(200), vec![]);
@@ -199,7 +182,7 @@ mod tests {
         let t2 = test_txn(2);
         let t3 = test_txn(3);
 
-        let version = VersionMetadata::new_with_xmax(t1, t2);
+        let version = new_version_with_xmax(t1, t2);
 
         // T3 starts after both T1 and T2 committed
         let snapshot = TransactionSnapshot::new(t3, test_lsn(300), vec![]);
@@ -217,7 +200,7 @@ mod tests {
         let t2 = test_txn(2);
         let t3 = test_txn(3);
 
-        let version = VersionMetadata::new_with_xmax(t1, t2);
+        let version = new_version_with_xmax(t1, t2);
 
         // T3 starts, sees T2 as active
         let snapshot = TransactionSnapshot::new(t3, test_lsn(300), vec![t2]);
@@ -234,7 +217,7 @@ mod tests {
         let t1 = test_txn(1);
         let t2 = test_txn(2);
 
-        let version = VersionMetadata::new(t1);
+        let version = new_version(t1);
 
         let snapshot = TransactionSnapshot::new(t2, test_lsn(200), vec![]);
         let committed = HashSet::new(); // T1 NOT in committed set (aborted)
@@ -250,7 +233,7 @@ mod tests {
         let t2 = test_txn(2);
         let t3 = test_txn(3);
 
-        let version = VersionMetadata::new_with_xmax(t1, t2);
+        let version = new_version_with_xmax(t1, t2);
 
         // T3's snapshot shows T2 as active
         let snapshot = TransactionSnapshot::new(t3, test_lsn(300), vec![t2]);
@@ -268,7 +251,7 @@ mod tests {
         let t1 = test_txn(1);
         let t2 = test_txn(2);
 
-        let version = VersionMetadata::new(t1);
+        let version = new_version(t1);
 
         let snapshot = TransactionSnapshot::new(t2, test_lsn(200), vec![]);
         let committed = HashSet::new(); // T1 not committed
@@ -282,7 +265,7 @@ mod tests {
         // T1 creates and deletes in same txn (uncommitted)
         let t1 = test_txn(1);
 
-        let version = VersionMetadata::new_with_xmax(t1, t1);
+        let version = new_version_with_xmax(t1, t1);
 
         let snapshot = TransactionSnapshot::new(t1, test_lsn(100), vec![]);
         let committed = HashSet::new();
@@ -297,7 +280,7 @@ mod tests {
         let t1 = test_txn(1);
         let t2 = test_txn(2);
 
-        let version = VersionMetadata::new(t1);
+        let version = new_version(t1);
 
         let snapshot = TransactionSnapshot::new(t2, test_lsn(100), vec![]);
         let committed = HashSet::new();
@@ -313,7 +296,7 @@ mod tests {
         let t3 = test_txn(3);
         let t4 = test_txn(4);
 
-        let version = VersionMetadata::new(t1);
+        let version = new_version(t1);
 
         // T4 sees T2 and T3 as active, but not T1 (T1 committed before T4 started)
         let snapshot = TransactionSnapshot::new(t4, test_lsn(400), vec![t2, t3]);
@@ -329,7 +312,7 @@ mod tests {
         let t1 = test_txn(1);
         let t1_new = test_txn(10); // Different txn by same "user"
 
-        let version = VersionMetadata::new_with_xmax(t1, t1_new);
+        let version = new_version_with_xmax(t1, t1_new);
 
         let snapshot = TransactionSnapshot::new(t1_new, test_lsn(200), vec![]);
         let mut committed = HashSet::new();
@@ -347,7 +330,7 @@ mod tests {
         let t1 = test_txn(1);
         let t2 = test_txn(2);
 
-        let version = VersionMetadata::new(t2);
+        let version = new_version(t2);
 
         // T1's snapshot captured T2 as active
         let snapshot = TransactionSnapshot::new(t1, test_lsn(100), vec![t2]);
@@ -368,8 +351,8 @@ mod tests {
         let t2 = test_txn(2);
         let t3 = test_txn(3);
 
-        let v1 = VersionMetadata::new_with_xmax(t1, t2);
-        let v2 = VersionMetadata::new(t2);
+        let v1 = new_version_with_xmax(t1, t2);
+        let v2 = new_version(t2);
 
         let snapshot = TransactionSnapshot::new(t3, test_lsn(300), vec![]);
         let mut committed = HashSet::new();

--- a/relvar-storage/src/storage/catalog.rs
+++ b/relvar-storage/src/storage/catalog.rs
@@ -29,13 +29,13 @@
 //! // Register relation in catalog
 //! catalog.create_relation(
 //!     "employees".to_string(),
-//!     rel_type,
+//!     rel_type.clone(),
 //!     PathBuf::from("employees.heap"),
 //! ).unwrap();
 //!
 //! // Look up relation metadata
 //! let metadata = catalog.get_relation("employees").unwrap();
-//! assert_eq!(metadata.name, "employees");
+//! assert_eq!(metadata.relation_type, rel_type);
 //! ```
 
 use relvar_core::types::RelationType;
@@ -75,13 +75,10 @@ const MAX_CATALOG_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
 ///
 /// # Fields
 ///
-/// - `name` - The unique name identifying this relation
 /// - `relation_type` - The type (heading) defining attribute names and types
 /// - `heap_file_path` - Path to the heap file containing the relation's tuples
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelationMetadata {
-    /// The unique name of the relation.
-    pub name: String,
     /// The relation's type (heading).
     pub relation_type: RelationType,
     /// Path to the heap file storing the relation's data.
@@ -228,7 +225,6 @@ impl Catalog {
         }
 
         let metadata = RelationMetadata {
-            name: name.clone(),
             relation_type,
             heap_file_path,
         };
@@ -336,7 +332,6 @@ mod tests {
             .unwrap();
 
         let metadata = catalog.get_relation("employees").unwrap();
-        assert_eq!(metadata.name, "employees");
         assert_eq!(metadata.relation_type, rel_type);
     }
 

--- a/relvar-storage/src/storage/manager.rs
+++ b/relvar-storage/src/storage/manager.rs
@@ -32,11 +32,19 @@ impl StorageManager {
     /// Create a new StorageManager instance.
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, StorageError> {
         let db_path = path.as_ref().to_path_buf();
+
+        if !db_path.exists() {
+            std::fs::create_dir_all(&db_path)
+                .map_err(|e| StorageError::Other(format!("Failed to create directory: {}", e)))?;
+        }
+
         let catalog_path = db_path.join("catalog.json");
 
-        Self::ensure_db_directory(&db_path)?;
-
-        let catalog = Self::load_catalog_from_disk(&catalog_path)?;
+        let catalog = if catalog_path.exists() {
+            Catalog::load(&catalog_path).map_err(Self::convert_catalog_error)?
+        } else {
+            Catalog::new()
+        };
 
         Ok(Self {
             db_path,
@@ -44,24 +52,6 @@ impl StorageManager {
             catalog,
             heap_files: HashMap::new(),
         })
-    }
-
-    /// Ensure the database directory exists.
-    fn ensure_db_directory(path: &Path) -> Result<(), StorageError> {
-        if !path.exists() {
-            std::fs::create_dir_all(path)
-                .map_err(|e| StorageError::Other(format!("Failed to create directory: {}", e)))?;
-        }
-        Ok(())
-    }
-
-    /// Load catalog from disk or create a new one.
-    fn load_catalog_from_disk(catalog_path: &Path) -> Result<Catalog, StorageError> {
-        if catalog_path.exists() {
-            Catalog::load(catalog_path).map_err(Self::convert_catalog_error)
-        } else {
-            Ok(Catalog::new())
-        }
     }
 
     /// Save the catalog to disk.


### PR DESCRIPTION
This PR applies Razor's KISS/YAGNI principles to the `relvar-storage` crate.

**Key Changes:**

1.  **`relvar-storage/src/mvcc/visibility.rs`**:
    - Removed `VersionMetadata::new` and `new_with_xmax` from the public API as they were only used in tests.
    - Moved them to the `#[cfg(test)]` module as helper functions.
    - Removes "Dead Code" clutter.

2.  **`relvar-storage/src/storage/catalog.rs`**:
    - Removed the `name` field from `RelationMetadata`.
    - `Catalog` stores metadata in a `HashMap<String, RelationMetadata>`, so the name was duplicated in the key and the value.
    - This simplifies the struct and removes redundancy.

3.  **`relvar-storage/src/storage/manager.rs`**:
    - Inlined `ensure_db_directory` and `load_catalog_from_disk` private helper functions directly into `StorageManager::new`.
    - These functions were only called once and added unnecessary indirection.

**Verification:**
- `cargo test -p relvar-storage` passed, including doc tests.
- `cargo clippy` and `cargo fmt` checks passed.

---
*PR created automatically by Jules for task [11944232126758764947](https://jules.google.com/task/11944232126758764947) started by @madmax983*