### PR TITLE
⚒️ Forge: Refactor PersistentEngine and Database Loops

### DIFF
--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -560,13 +560,13 @@ impl<E: StorageEngine> Database<E> {
         // Validate other constraints (Type, CHECK, FK) on all tuples in the new relation
         // NOTE: In a production system we'd only validate changed tuples, but for now
         // we validate everything to ensure total consistency.
-        for tuple in new_relation.tuples() {
+        new_relation.tuples().try_for_each(|tuple| {
             self.constraints.validate_tuple_content_constraints(
                 &mut self.engine,
                 relation_name,
                 tuple,
-            )?;
-        }
+            )
+        })?;
 
         // Store the new relation
         self.engine.store_relation(relation_name, &new_relation)?;

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -1874,7 +1874,7 @@ mod tests {
         let result = db.update(
             "EMPLOYEES",
             |t| t.get_typed::<i64>("id").unwrap() == 1,
-            |t| tuple! { id: 1i64, salary: -100i64 },
+            |_t| tuple! { id: 1i64, salary: -100i64 },
         );
 
         // Should fail due to constraint violation in the try_for_each loop

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -1843,4 +1843,47 @@ mod tests {
         let result = db.insert("PERSONS", tuple! { id: 3i64, age: 200i64 });
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_update_constraint_violation_in_loop() {
+        let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
+        let rel_type = RelationType::new(
+            TupleType::new()
+                .with_attribute("id", ScalarType::Int)
+                .with_attribute("salary", ScalarType::Int),
+        );
+
+        db.create_relvar("EMPLOYEES", rel_type).unwrap();
+
+        // CHECK constraint: salary > 0
+        let constraints = CheckConstraints::new().with_constraint(CheckConstraint::new(
+            "positive_salary",
+            "Salary must be positive",
+            ConstraintExpression::Cmp {
+                left: "salary".to_string(),
+                op: CmpOp::Gt,
+                right: ValueOrRef::Value(ScalarValue::Int(0)),
+            },
+        ));
+        db.set_check_constraints("EMPLOYEES", constraints).unwrap();
+
+        db.insert("EMPLOYEES", tuple! { id: 1i64, salary: 50000i64 })
+            .unwrap();
+
+        // Update to set salary to -100 (violation)
+        let result = db.update(
+            "EMPLOYEES",
+            |t| t.get_typed::<i64>("id").unwrap() == 1,
+            |t| tuple! { id: 1i64, salary: -100i64 },
+        );
+
+        // Should fail due to constraint violation in the try_for_each loop
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(DatabaseError::Constraint(
+                ConstraintManagerError::CheckConstraintViolation(_)
+            ))
+        ));
+    }
 }

--- a/relvar-storage/src/persistent_engine.rs
+++ b/relvar-storage/src/persistent_engine.rs
@@ -1754,4 +1754,45 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn test_recovery_ignores_dropped_relation() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // 1. Create database, insert, then drop relation, then crash before commit
+        {
+            let mut engine = PersistentEngine::open(temp_dir.path()).unwrap();
+            engine.create_relation("DROPPED_REL", test_rel_type()).unwrap();
+
+            // Begin transaction
+            let _snapshot = engine.begin_transaction().unwrap();
+
+            // Insert tuple (written to WAL)
+            engine
+                .insert_tuple("DROPPED_REL", tuple! { id: 1i64, name: "ToDrop" })
+                .unwrap();
+
+            // Drop relation (removes from catalog and heap file)
+            // Note: In a real crash scenario, the catalog drop might not be durable if not WAL-logged,
+            // but here we simulate the state where the catalog update persisted but the txn didn't commit.
+            engine.drop_relation("DROPPED_REL").unwrap();
+
+            // CRASH! (Drop engine)
+        }
+
+        // 2. Reopen database
+        {
+            // Recovery runs. It sees uncommitted insert for "DROPPED_REL".
+            // It should check if "DROPPED_REL" exists. It doesn't.
+            // It should skip cleanup and open successfully.
+            let engine = PersistentEngine::open(temp_dir.path());
+            assert!(
+                engine.is_ok(),
+                "Engine should open successfully despite uncommitted inserts for dropped relation"
+            );
+
+            let engine = engine.unwrap();
+            assert!(!engine.relation_exists("DROPPED_REL"));
+        }
+    }
 }

--- a/relvar-storage/src/persistent_engine.rs
+++ b/relvar-storage/src/persistent_engine.rs
@@ -104,66 +104,81 @@ impl PersistentEngine {
         &mut self,
         uncommitted_inserts: Vec<crate::wal::UncommittedInsert>,
     ) -> Result<(), StorageError> {
-        use std::collections::HashMap;
+        let by_relation = self.group_uncommitted_inserts(uncommitted_inserts);
 
-        // Group by relation name
-        let mut by_relation: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+        // For each relation, rebuild without uncommitted tuples
+        for (relation_name, uncommitted_tuples) in by_relation {
+            if self
+                .storage_manager
+                .read()
+                .unwrap()
+                .relation_exists(&relation_name)
+            {
+                self.cleanup_relation_uncommitted_inserts(&relation_name, uncommitted_tuples)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Groups uncommitted inserts by relation name.
+    fn group_uncommitted_inserts(
+        &self,
+        uncommitted_inserts: Vec<crate::wal::UncommittedInsert>,
+    ) -> std::collections::HashMap<String, Vec<Vec<u8>>> {
+        let mut by_relation: std::collections::HashMap<String, Vec<Vec<u8>>> =
+            std::collections::HashMap::new();
         for insert in uncommitted_inserts {
             by_relation
                 .entry(insert.relation_name)
                 .or_default()
                 .push(insert.tuple_data);
         }
+        by_relation
+    }
 
-        // For each relation, rebuild without uncommitted tuples
-        for (relation_name, uncommitted_tuples_vec) in by_relation {
-            // Skip if relation doesn't exist
-            if !self
-                .storage_manager
-                .write()
-                .unwrap()
-                .relation_exists(&relation_name)
-            {
-                continue;
+    /// Rebuilds a relation excluding uncommitted tuples and stores it back.
+    fn cleanup_relation_uncommitted_inserts(
+        &mut self,
+        relation_name: &str,
+        uncommitted_tuples_vec: Vec<Vec<u8>>,
+    ) -> Result<(), StorageError> {
+        // Convert to HashSet for O(1) lookup
+        let uncommitted_tuples: std::collections::HashSet<Vec<u8>> =
+            uncommitted_tuples_vec.into_iter().collect();
+
+        // Load all tuples using current snapshot (txn=0, committed_txns set from recovery)
+        let snapshot = self.get_snapshot_for_current_context()?;
+
+        let relation = self.storage_manager.write().unwrap().scan_relation(
+            relation_name,
+            &snapshot,
+            &self.committed_txns,
+        )?;
+
+        // Filter out uncommitted tuples
+        let mut committed_tuples = Vec::new();
+        for tuple in relation.tuples() {
+            let tuple_data = bincode::serialize(&tuple)
+                .map_err(|e| StorageError::Other(format!("Serialization error: {}", e)))?;
+
+            if !uncommitted_tuples.contains(&tuple_data) {
+                committed_tuples.push(tuple.clone());
             }
-
-            // Convert to HashSet for O(1) lookup
-            let uncommitted_tuples: std::collections::HashSet<Vec<u8>> =
-                uncommitted_tuples_vec.into_iter().collect();
-
-            // Load all tuples using current snapshot (txn=0, committed_txns set from recovery)
-            let snapshot = self.get_snapshot_for_current_context()?;
-            let relation = self.storage_manager.write().unwrap().scan_relation(
-                &relation_name,
-                &snapshot,
-                &self.committed_txns,
-            )?;
-
-            // Filter out uncommitted tuples
-            let mut committed_tuples = Vec::new();
-            for tuple in relation.tuples() {
-                let tuple_data = bincode::serialize(&tuple)
-                    .map_err(|e| StorageError::Other(format!("Serialization error: {}", e)))?;
-
-                if !uncommitted_tuples.contains(&tuple_data) {
-                    committed_tuples.push(tuple.clone());
-                }
-            }
-
-            // Rebuild relation with only committed tuples
-            let mut new_relation =
-                relvar_core::values::Relation::new(relation.relation_type().clone());
-
-            for tuple in committed_tuples {
-                new_relation
-                    .insert(tuple)
-                    .map_err(|e| StorageError::Relation(e.to_string()))?;
-            }
-
-            // Store back (effectively removing uncommitted garbage)
-            self.store_relation(&relation_name, &new_relation)?;
         }
 
+        // Rebuild relation with only committed tuples
+        let mut new_relation =
+            relvar_core::values::Relation::new(relation.relation_type().clone());
+
+        for tuple in committed_tuples {
+            new_relation
+                .insert(tuple)
+                .map_err(|e| StorageError::Relation(e.to_string()))?;
+        }
+
+        // Store back (effectively removing uncommitted garbage)
+        self.store_relation(relation_name, &new_relation)?;
         Ok(())
     }
 
@@ -312,14 +327,7 @@ impl StorageEngine for PersistentEngine {
     }
 
     fn store_relation(&mut self, name: &str, relation: &Relation) -> Result<(), StorageError> {
-        // Auto-commit logic
-        let auto_commit = self.current_txn.is_none();
-        let txn_id = if auto_commit {
-            let snapshot = self.begin_transaction()?;
-            snapshot.txn_id
-        } else {
-            self.current_txn.unwrap()
-        };
+        let (txn_id, auto_commit) = self.ensure_transaction()?;
 
         self.storage_manager
             .write()
@@ -335,13 +343,7 @@ impl StorageEngine for PersistentEngine {
     }
 
     fn insert_tuple(&mut self, name: &str, tuple: Tuple) -> Result<(), StorageError> {
-        let auto_commit = self.current_txn.is_none();
-        let txn_id = if auto_commit {
-            let snapshot = self.begin_transaction()?;
-            snapshot.txn_id
-        } else {
-            self.current_txn.unwrap()
-        };
+        let (txn_id, auto_commit) = self.ensure_transaction()?;
 
         // Serialize tuple for WAL
         let tuple_data = bincode::serialize(&tuple)
@@ -419,6 +421,18 @@ impl StorageEngine for PersistentEngine {
 
 // MVCC methods (internal)
 impl PersistentEngine {
+    /// Ensures a transaction is active.
+    ///
+    /// Returns the transaction ID and a boolean indicating if a new transaction was started (auto-commit).
+    fn ensure_transaction(&mut self) -> Result<(TransactionId, bool), StorageError> {
+        if let Some(txn_id) = self.current_txn {
+            Ok((txn_id, false))
+        } else {
+            let snapshot = self.begin_transaction()?;
+            Ok((snapshot.txn_id, true))
+        }
+    }
+
     #[allow(dead_code)]
     pub(crate) fn load_relation_for_txn(
         &mut self,

--- a/relvar-storage/src/persistent_engine.rs
+++ b/relvar-storage/src/persistent_engine.rs
@@ -1762,7 +1762,9 @@ mod tests {
         // 1. Create database, insert, then drop relation, then crash before commit
         {
             let mut engine = PersistentEngine::open(temp_dir.path()).unwrap();
-            engine.create_relation("DROPPED_REL", test_rel_type()).unwrap();
+            engine
+                .create_relation("DROPPED_REL", test_rel_type())
+                .unwrap();
 
             // Begin transaction
             let _snapshot = engine.begin_transaction().unwrap();

--- a/relvar-storage/src/persistent_engine.rs
+++ b/relvar-storage/src/persistent_engine.rs
@@ -168,8 +168,7 @@ impl PersistentEngine {
         }
 
         // Rebuild relation with only committed tuples
-        let mut new_relation =
-            relvar_core::values::Relation::new(relation.relation_type().clone());
+        let mut new_relation = relvar_core::values::Relation::new(relation.relation_type().clone());
 
         for tuple in committed_tuples {
             new_relation

--- a/relvar-storage/src/persistent_engine.rs
+++ b/relvar-storage/src/persistent_engine.rs
@@ -1797,4 +1797,57 @@ mod tests {
             assert!(!engine.relation_exists("DROPPED_REL"));
         }
     }
+
+    #[test]
+    fn test_recovery_retains_valid_data_during_cleanup() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // 1. Create database and insert committed data
+        {
+            let mut engine = PersistentEngine::open(temp_dir.path()).unwrap();
+            engine.create_relation("TEST", test_rel_type()).unwrap();
+
+            // Committed transaction
+            let snapshot = engine.begin_transaction().unwrap();
+            engine
+                .insert_tuple("TEST", tuple! { id: 1i64, name: "Committed" })
+                .unwrap();
+            engine.commit_transaction(snapshot).unwrap();
+
+            // Uncommitted transaction (simulating crash)
+            let _snapshot = engine.begin_transaction().unwrap();
+            engine
+                .insert_tuple("TEST", tuple! { id: 2i64, name: "Uncommitted" })
+                .unwrap();
+
+            // CRASH! (Drop engine)
+        }
+
+        // 2. Reopen database (Trigger Recovery)
+        {
+            let engine = PersistentEngine::open(temp_dir.path()).unwrap();
+            let relation = engine.load_relation("TEST").unwrap();
+
+            // Verify committed tuple exists
+            assert_eq!(
+                relation.cardinality(),
+                1,
+                "Recovery should retain committed data"
+            );
+            assert!(
+                relation
+                    .tuples()
+                    .any(|t| t.get_typed::<i64>("id").unwrap() == 1),
+                "Committed tuple should persist"
+            );
+
+            // Verify uncommitted tuple is gone
+            assert!(
+                !relation
+                    .tuples()
+                    .any(|t| t.get_typed::<i64>("id").unwrap() == 2),
+                "Uncommitted tuple should be removed"
+            );
+        }
+    }
 }


### PR DESCRIPTION
This PR refactors `relvar-storage` and `relvar-core` to improve readability and maintainability without changing runtime behavior.

**Changes:**
1.  **`PersistentEngine` Refactoring:**
    -   Decomposed the complex `undo_uncommitted_inserts` method into smaller, focused helpers: `group_uncommitted_inserts` and `cleanup_relation_uncommitted_inserts`.
    -   Centralized transaction auto-commit logic into a new `ensure_transaction` helper, removing duplication between `insert_tuple` and `store_relation`.
    -   Improved ownership semantics by passing `Vec<Vec<u8>>` by value to `cleanup_relation_uncommitted_inserts`.

2.  **`Database` Refactoring:**
    -   Replaced explicit `for` loops in `Database::update` with `try_for_each` for more idiomatic Rust iterator usage.

**Verification:**
-   `cargo test --package relvar-storage` passed.
-   `cargo test --package relvar-core` passed.
-   No logic changes, purely refactoring.

---
*PR created automatically by Jules for task [13570769133041897576](https://jules.google.com/task/13570769133041897576) started by @madmax983*