### PR TITLE
Refactor crash recovery to use transaction-based undo

### DIFF
--- a/relvar-storage/src/persistent_engine.rs
+++ b/relvar-storage/src/persistent_engine.rs
@@ -93,78 +93,22 @@ impl PersistentEngine {
             current_txn: None,
         };
 
-        // Undo uncommitted transactions
-        engine.undo_uncommitted_inserts(recovery_result.uncommitted_inserts)?;
+        // Identify transactions to undo (active + aborted)
+        let txns_to_undo: HashSet<TransactionId> = recovery_result
+            .active_txns
+            .union(&recovery_result.aborted_txns)
+            .cloned()
+            .collect();
 
-        Ok(engine)
-    }
-
-    /// Undoes uncommitted inserts identified during recovery.
-    fn undo_uncommitted_inserts(
-        &mut self,
-        uncommitted_inserts: Vec<crate::wal::UncommittedInsert>,
-    ) -> Result<(), StorageError> {
-        use std::collections::HashMap;
-
-        // Group by relation name
-        let mut by_relation: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
-        for insert in uncommitted_inserts {
-            by_relation
-                .entry(insert.relation_name)
-                .or_default()
-                .push(insert.tuple_data);
-        }
-
-        // For each relation, rebuild without uncommitted tuples
-        for (relation_name, uncommitted_tuples_vec) in by_relation {
-            // Skip if relation doesn't exist
-            if !self
+        if !txns_to_undo.is_empty() {
+            engine
                 .storage_manager
                 .write()
                 .unwrap()
-                .relation_exists(&relation_name)
-            {
-                continue;
-            }
-
-            // Convert to HashSet for O(1) lookup
-            let uncommitted_tuples: std::collections::HashSet<Vec<u8>> =
-                uncommitted_tuples_vec.into_iter().collect();
-
-            // Load all tuples using current snapshot (txn=0, committed_txns set from recovery)
-            let snapshot = self.get_snapshot_for_current_context()?;
-            let relation = self.storage_manager.write().unwrap().scan_relation(
-                &relation_name,
-                &snapshot,
-                &self.committed_txns,
-            )?;
-
-            // Filter out uncommitted tuples
-            let mut committed_tuples = Vec::new();
-            for tuple in relation.tuples() {
-                let tuple_data = bincode::serialize(&tuple)
-                    .map_err(|e| StorageError::Other(format!("Serialization error: {}", e)))?;
-
-                if !uncommitted_tuples.contains(&tuple_data) {
-                    committed_tuples.push(tuple.clone());
-                }
-            }
-
-            // Rebuild relation with only committed tuples
-            let mut new_relation =
-                relvar_core::values::Relation::new(relation.relation_type().clone());
-
-            for tuple in committed_tuples {
-                new_relation
-                    .insert(tuple)
-                    .map_err(|e| StorageError::Relation(e.to_string()))?;
-            }
-
-            // Store back (effectively removing uncommitted garbage)
-            self.store_relation(&relation_name, &new_relation)?;
+                .undo_transactions(&txns_to_undo)?;
         }
 
-        Ok(())
+        Ok(engine)
     }
 
     /// Performs a checkpoint to enable WAL truncation and faster recovery.

--- a/relvar-storage/src/persistent_engine.rs
+++ b/relvar-storage/src/persistent_engine.rs
@@ -81,7 +81,7 @@ impl PersistentEngine {
             recover(&mut wal).map_err(|e| StorageError::Other(format!("Recovery error: {}", e)))?;
 
         // Create engine instance
-        let mut engine = Self {
+        let engine = Self {
             storage_manager: RwLock::new(storage_manager),
             wal,
             // Seed transaction ID generator with max ID from WAL + 1 to avoid reuse

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -1319,12 +1319,12 @@ impl HeapFile {
                     }
 
                     // 2. Undo Delete/Update: If deleter (xmax) is aborted, restore the tuple
-                    if let Some(xmax) = slot.xmax {
-                        if txn_ids.contains(&xmax) {
-                            slot.xmax = None;
-                            modifications += 1;
-                            page_modified = true;
-                        }
+                    if let Some(xmax) = slot.xmax
+                        && txn_ids.contains(&xmax)
+                    {
+                        slot.xmax = None;
+                        modifications += 1;
+                        page_modified = true;
                     }
                 }
             }

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -1260,6 +1260,96 @@ impl HeapFile {
     ///
     /// # Errors
     /// Returns `HeapError` if page I/O fails
+    /// Undoes changes made by specific transactions (aborted inserts/updates/deletes).
+    ///
+    /// This is used during crash recovery to clean up effects of transactions
+    /// that were active or aborted at the time of crash.
+    ///
+    /// # Logic
+    /// - If a version was created by an undone txn (xmin in txn_ids): remove it.
+    /// - If a version was deleted by an undone txn (xmax in txn_ids): un-delete it (clear xmax).
+    ///
+    /// # Arguments
+    /// * `txn_ids` - Set of Transaction IDs to undo
+    ///
+    /// # Returns
+    /// Number of modifications made (slots cleared or restored)
+    pub(crate) fn undo_transactions(
+        &mut self,
+        txn_ids: &std::collections::HashSet<crate::wal::TransactionId>,
+    ) -> Result<usize, HeapError> {
+        let mut modifications = 0;
+        let mut page_id = 0;
+
+        loop {
+            let page = self.page_file.read_page(page_id)?;
+
+            if page.is_empty() {
+                break;
+            }
+
+            if !self.is_versioned_page(&page) {
+                page_id += 1;
+                continue;
+            }
+
+            // Try to deserialize as versioned page
+            let mut versioned_page = match self.deserialize_versioned_page(&page) {
+                Ok(vp) => vp,
+                Err(_) => {
+                    page_id += 1;
+                    continue;
+                }
+            };
+
+            // Extract existing tuple data
+            let mut existing_tuples = self.extract_all_tuples(&page, &versioned_page.slots)?;
+
+            let mut page_modified = false;
+
+            for (idx, slot_option) in versioned_page.slots.iter_mut().enumerate() {
+                if let Some(slot) = slot_option {
+                    // 1. Undo Insert: If creator (xmin) is aborted, remove the tuple
+                    if txn_ids.contains(&slot.xmin) {
+                        *slot_option = None;
+                        existing_tuples[idx] = Vec::new();
+                        modifications += 1;
+                        page_modified = true;
+                        continue;
+                    }
+
+                    // 2. Undo Delete/Update: If deleter (xmax) is aborted, restore the tuple
+                    if let Some(xmax) = slot.xmax {
+                        if txn_ids.contains(&xmax) {
+                            slot.xmax = None;
+                            modifications += 1;
+                            page_modified = true;
+                        }
+                    }
+                }
+            }
+
+            // Write page back if modified
+            if page_modified {
+                // Repack slots
+                Self::repack_slots(
+                    &mut versioned_page.slots,
+                    &existing_tuples,
+                    USABLE_PAGE_SIZE_V2,
+                )?;
+
+                let page_data =
+                    self.serialize_versioned_page_with_tuples(&versioned_page, &existing_tuples)?;
+                let updated_page = Page::from_data(page_id, page_data)?;
+                self.page_file.write_page(&updated_page)?;
+            }
+
+            page_id += 1;
+        }
+
+        Ok(modifications)
+    }
+
     pub(crate) fn gc_remove_dead_versions(
         &mut self,
         oldest_active_lsn: crate::wal::Lsn,
@@ -3496,6 +3586,59 @@ mod tests {
             }
             _ => panic!("Expected Serialization error, got {:?}", result),
         }
+    }
+
+    #[test]
+    fn test_undo_transactions() {
+        use crate::mvcc::TransactionSnapshot;
+        use crate::wal::Lsn;
+
+        fn test_lsn(value: u64) -> Lsn {
+            Lsn::new(value)
+        }
+
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+        let rel_type = create_test_relation_type();
+        let mut heap = HeapFile::create(path, rel_type).unwrap();
+
+        // 1. T1 inserts and commits
+        let t1 = tuple! { id: 1i64, name: "Committed" };
+        heap.insert_tuple_versioned(&t1, test_txn(1)).unwrap();
+
+        // 2. T2 inserts (will be undone)
+        let t2 = tuple! { id: 2i64, name: "ToUndo" };
+        heap.insert_tuple_versioned(&t2, test_txn(2)).unwrap();
+
+        // 3. T3 deletes T1 (will be undone)
+        // Need T1's tuple ID. We know it's page 0, slot 0
+        let tid1 = TupleId {
+            page_id: 0,
+            slot: 0,
+        };
+        heap.delete_tuple_versioned(tid1, test_txn(3)).unwrap();
+
+        // 4. Undo T2 and T3
+        let mut to_undo = std::collections::HashSet::new();
+        to_undo.insert(test_txn(2));
+        to_undo.insert(test_txn(3));
+
+        let modifications = heap.undo_transactions(&to_undo).unwrap();
+        assert!(modifications >= 2, "Should have undone insert and delete");
+
+        // Verify state:
+        // T2's insert should be gone (invisible to everyone)
+        // T1 should be visible again (undeleted)
+
+        let snapshot = TransactionSnapshot::new(test_txn(4), test_lsn(400), vec![]);
+        let mut committed = std::collections::HashSet::new();
+        committed.insert(test_txn(1));
+        // T2 and T3 are NOT committed
+
+        let visible = heap.scan_visible(&snapshot, &committed).unwrap();
+
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0], t1);
     }
 }
 

--- a/relvar-storage/src/storage/manager.rs
+++ b/relvar-storage/src/storage/manager.rs
@@ -313,6 +313,25 @@ impl StorageManager {
         }
         Ok(())
     }
+
+    /// Undoes changes made by specific transactions across all relations.
+    ///
+    /// This iterates through all relations in the database and removes/restores
+    /// versions modified by the specified transactions.
+    pub fn undo_transactions(
+        &mut self,
+        txn_ids: &HashSet<TransactionId>,
+    ) -> Result<(), StorageError> {
+        // Iterate all relations (not just cached ones)
+        let relations = self.list_relations();
+        for name in relations {
+            let heap_file = self.get_or_open_heap_file(&name)?;
+            heap_file
+                .undo_transactions(txn_ids)
+                .map_err(Self::convert_heap_error)?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/relvar-storage/src/wal/mod.rs
+++ b/relvar-storage/src/wal/mod.rs
@@ -55,4 +55,4 @@ pub(crate) use error::WalError;
 pub(crate) use lsn::{Lsn, TransactionId, TransactionIdGenerator};
 pub(crate) use manager::{DEFAULT_BUFFER_SIZE, WalManager};
 pub(crate) use record::{MAX_RECORD_SIZE, WalRecord, WalRecordError};
-pub(crate) use recovery::{AnalysisResult, UncommittedInsert, recover};
+pub(crate) use recovery::{AnalysisResult, RecoveryResult, recover};

--- a/relvar-storage/src/wal/recovery.rs
+++ b/relvar-storage/src/wal/recovery.rs
@@ -13,7 +13,7 @@
 //! - Tracks the maximum transaction ID seen
 //! - Returns all log records in order
 //! - Tracks the last checkpoint LSN (if any)
-//! - Exposes information about uncommitted inserts for caller-side undo
+//! - Exposes information about uncommitted transactions for caller-side undo
 //!
 //! # Redo and Undo
 //!
@@ -21,17 +21,16 @@
 //! on disk because we sync after each transaction commit. Future versions may
 //! implement explicit redo for better performance.
 //!
-//! **Undo:** Performed by the caller (PersistentEngine) which receives the list
-//! of uncommitted inserts and removes them from relations. This design allows
-//! undo to access the catalog and relation types.
+//! **Undo:** Performed by the caller (PersistentEngine/StorageManager) which
+//! receives the list of active/aborted transactions and removes their changes
+//! from relations. This design allows undo to be performed efficiently by
+//! filtering based on transaction ID.
 
 use super::error::WalError;
 use super::lsn::{Lsn, TransactionId};
 use super::manager::WalManager;
 use super::record::WalRecord;
-use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
+use std::collections::HashSet;
 
 /// Result of the analysis pass.
 #[derive(Debug)]
@@ -88,22 +87,15 @@ pub fn analyze(wal: &mut WalManager) -> Result<AnalysisResult, WalError> {
     })
 }
 
-/// Uncommitted insert information.
-#[derive(Debug)]
-pub struct UncommittedInsert {
-    /// Relation name.
-    pub relation_name: String,
-    /// Serialized tuple data.
-    pub tuple_data: Vec<u8>,
-}
-
 /// Result of recovery process.
 #[derive(Debug)]
 pub struct RecoveryResult {
     /// Set of committed transaction IDs (for MVCC visibility).
     pub committed_txns: HashSet<TransactionId>,
-    /// List of uncommitted inserts that need to be undone.
-    pub uncommitted_inserts: Vec<UncommittedInsert>,
+    /// Set of transactions that were active at crash time (neither committed nor aborted).
+    pub active_txns: HashSet<TransactionId>,
+    /// Set of transactions that were explicitly aborted.
+    pub aborted_txns: HashSet<TransactionId>,
     /// Maximum transaction ID seen in the WAL.
     /// Used to seed the transaction ID generator to avoid reusing IDs.
     pub max_txn_id: TransactionId,
@@ -126,7 +118,7 @@ pub fn recover(wal: &mut WalManager) -> Result<RecoveryResult, WalError> {
     // Analysis pass
     let analysis = analyze(wal)?;
 
-    // Find uncommitted transactions (those with BEGIN but no COMMIT/ABORT)
+    // Find active transactions (those with BEGIN but no COMMIT/ABORT)
     // Also track maximum transaction ID seen
     let mut active_txns = HashSet::new();
     let mut max_txn_id = TransactionId::new(0);
@@ -159,27 +151,10 @@ pub fn recover(wal: &mut WalManager) -> Result<RecoveryResult, WalError> {
         }
     }
 
-    // Collect uncommitted inserts
-    let mut uncommitted_inserts = Vec::new();
-
-    for (_, record) in &analysis.records {
-        if let WalRecord::Insert {
-            txn_id,
-            relation_name,
-            tuple_data,
-        } = record
-            && active_txns.contains(txn_id)
-        {
-            uncommitted_inserts.push(UncommittedInsert {
-                relation_name: relation_name.clone(),
-                tuple_data: tuple_data.clone(),
-            });
-        }
-    }
-
     Ok(RecoveryResult {
         committed_txns: analysis.committed,
-        uncommitted_inserts,
+        active_txns,
+        aborted_txns: analysis.aborted,
         max_txn_id,
     })
 }
@@ -200,8 +175,6 @@ mod tests {
         assert!(result.aborted.is_empty());
         assert!(result.records.is_empty());
     }
-
-    // Phase 4.2: Recovery with Versions tests
 
     #[test]
     fn test_recovery_populates_committed_set() {
@@ -237,10 +210,12 @@ mod tests {
         assert!(result.committed_txns.contains(&txn1));
         // T2 should NOT be in committed set (aborted)
         assert!(!result.committed_txns.contains(&txn2));
+        // T2 should be in aborted set
+        assert!(result.aborted_txns.contains(&txn2));
     }
 
     #[test]
-    fn test_recovery_removes_uncommitted_versions() {
+    fn test_recovery_identifies_active_txns() {
         let temp = NamedTempFile::new().unwrap();
         let mut wal = WalManager::create(temp.path()).unwrap();
 
@@ -268,21 +243,11 @@ mod tests {
 
         let result = recover(&mut wal).unwrap();
 
-        // T1's insert should NOT be in uncommitted list
-        assert!(
-            result
-                .uncommitted_inserts
-                .iter()
-                .all(|ui| ui.tuple_data != vec![1, 2, 3])
-        );
+        // T1 should NOT be active
+        assert!(!result.active_txns.contains(&txn1));
 
-        // T2's insert should be in uncommitted list
-        assert!(
-            result
-                .uncommitted_inserts
-                .iter()
-                .any(|ui| ui.tuple_data == vec![4, 5, 6])
-        );
+        // T2 should be active
+        assert!(result.active_txns.contains(&txn2));
     }
 
     #[test]
@@ -314,8 +279,8 @@ mod tests {
         assert!(result.committed_txns.contains(&txn2));
         assert!(result.committed_txns.contains(&txn3));
 
-        // None should be in uncommitted
-        assert!(result.uncommitted_inserts.is_empty());
+        // None should be active
+        assert!(result.active_txns.is_empty());
     }
 
     #[test]
@@ -347,10 +312,10 @@ mod tests {
         let result = recover(&mut wal).unwrap();
 
         assert!(result.committed_txns.contains(&t1));
-        assert!(!result.committed_txns.contains(&t2));
+        assert!(result.active_txns.contains(&t2));
         assert!(result.committed_txns.contains(&t3));
-
-        assert_eq!(result.uncommitted_inserts.len(), 1);
+        assert!(!result.active_txns.contains(&t1));
+        assert!(!result.active_txns.contains(&t3));
     }
 
     #[test]
@@ -371,9 +336,9 @@ mod tests {
 
         let result = recover(&mut wal).unwrap();
 
-        // Verify RecoveryResult has both fields
         assert!(!result.committed_txns.is_empty());
-        assert!(result.uncommitted_inserts.is_empty());
+        assert!(result.active_txns.is_empty());
+        assert!(result.aborted_txns.is_empty());
     }
 
     #[test]
@@ -384,11 +349,11 @@ mod tests {
         let result = recover(&mut wal).unwrap();
 
         assert!(result.committed_txns.is_empty());
-        assert!(result.uncommitted_inserts.is_empty());
+        assert!(result.active_txns.is_empty());
     }
 
     #[test]
-    fn test_recovery_aborted_not_in_committed() {
+    fn test_recovery_aborted_not_in_committed_but_in_aborted() {
         let temp = NamedTempFile::new().unwrap();
         let mut wal = WalManager::create(temp.path()).unwrap();
 
@@ -407,5 +372,9 @@ mod tests {
 
         // Aborted transaction should NOT be in committed set
         assert!(!result.committed_txns.contains(&txn1));
+        // Should be in aborted set
+        assert!(result.aborted_txns.contains(&txn1));
+        // Should NOT be in active set
+        assert!(!result.active_txns.contains(&txn1));
     }
 }


### PR DESCRIPTION
Refactored the crash recovery mechanism to implement a proper ARIES-style Undo phase.
Instead of rebuilding relations based on serialized tuple content (which was inefficient and prone to correctness issues with duplicate data), the new implementation identifies crashed or aborted transactions from the WAL and delegates cleanup to the `StorageManager`.

Changes:
- `wal::recovery`: Expose `active_txns` and `aborted_txns` in `RecoveryResult`; remove `uncommitted_inserts`.
- `storage::HeapFile`: Added `undo_transactions` to physically remove/restore versions based on transaction ID.
- `storage::StorageManager`: Added `undo_transactions` to iterate over all relations.
- `PersistentEngine`: Updated recovery logic to use `undo_transactions` instead of manual relation rebuilding.

This improves cohesion by moving storage cleanup logic into the storage layer and fixes potential data loss issues with the previous content-based filtering.

---
*PR created automatically by Jules for task [16575900802597537546](https://jules.google.com/task/16575900802597537546) started by @madmax983*