### PR TITLE
⚡ Bolt: Reuse key buffer in join probe phase

### DIFF
--- a/relvar-core/src/algebra/join.rs
+++ b/relvar-core/src/algebra/join.rs
@@ -279,11 +279,12 @@ fn probe_and_combine<'a>(
     result_heading: &Arc<TupleType>,
 ) -> Result<Vec<Tuple>, DatabaseError> {
     let mut joined_tuples = Vec::new();
+    let mut key_buffer = Vec::with_capacity(common_attrs.len());
 
     for probe_tuple in probe_rel.tuples() {
-        let key = extract_join_key(probe_tuple, common_attrs, "probe relation")?;
+        extract_join_key_into(probe_tuple, common_attrs, "probe relation", &mut key_buffer)?;
 
-        if let Some(matching_tuples) = build_map.get(&key) {
+        if let Some(matching_tuples) = build_map.get(key_buffer.as_slice()) {
             for build_tuple in matching_tuples {
                 joined_tuples.push(combine_tuples(build_tuple, probe_tuple, result_heading)?);
             }
@@ -299,12 +300,24 @@ fn extract_join_key<'a>(
     source_name: &str,
 ) -> Result<Vec<&'a ScalarValue>, DatabaseError> {
     let mut key = Vec::with_capacity(attrs.len());
+    extract_join_key_into(tuple, attrs, source_name, &mut key)?;
+    Ok(key)
+}
+
+/// Helper to extract key values into a provided buffer.
+fn extract_join_key_into<'a>(
+    tuple: &'a Tuple,
+    attrs: &[String],
+    source_name: &str,
+    key: &mut Vec<&'a ScalarValue>,
+) -> Result<(), DatabaseError> {
+    key.clear();
     for attr in attrs {
         key.push(tuple.get(attr).ok_or_else(|| {
             DatabaseError::AttributeNotFound(attr.clone(), source_name.to_string())
         })?);
     }
-    Ok(key)
+    Ok(())
 }
 
 /// Helper to combine two tuples into a single tuple.


### PR DESCRIPTION
⚡ Bolt: [performance improvement]

💡 What: The optimization implemented (e.g., "Switched `HashMap` to `BTreeMap`").
Refactored `probe_and_combine` in `relvar-core/src/algebra/join.rs` to reuse a single `Vec` buffer for join key extraction instead of allocating a new `Vec` for every tuple.

🎯 Why: The bottleneck (e.g., "Hashing overhead was too high for small dataset").
The probe phase of the Hash Join algorithm was allocating a temporary `Vec<&ScalarValue>` for every tuple in the probe relation just to look it up in the hash map. For large relations, this resulted in millions of unnecessary small heap allocations and deallocations.

📊 Impact: Expected gain (e.g., "Reduces heap allocs by 40%").
Eliminates N allocations per join operation, where N is the cardinality of the probe relation. This reduces allocator pressure and improves cache locality.

🔬 Measurement: How to verify (e.g., "Run bench `process_data`").
Verify by running `cargo test` to ensure no regression in join logic.


---
*PR created automatically by Jules for task [5243801342812850906](https://jules.google.com/task/5243801342812850906) started by @madmax983*