### PR TITLE
🛡️ Sentry: Enforce immutability in Virtual Relvars

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -33,3 +33,7 @@
 ## 2027-02-27 - Slot Reuse Data Corruption
 **Learning:** `HeapFile::try_insert_into_page` (and versioned variants) caused data corruption when reusing a freed slot (e.g. from deletion). It was calling `vec.insert()` which shifts subsequent elements, but the `slots` vector was not shifted (since we reused an index). This misaligned slots and tuple data, causing subsequent tuples to be lost or corrupted during page repack.
 **Action:** When managing parallel vectors (slots and data), ensure modifications are symmetric. If reusing a slot index, use index assignment (`vec[i] = val`) instead of insertion (`vec.insert(i, val)`).
+
+## 2027-05-22 - Virtual Relvar Side-Effect Vulnerability
+**Learning:** `VirtualRelvarDefinition` passes `&mut Database` to the evaluator closure, allowing "read-only" views to perform writes (insert/update/delete) as side effects.
+**Action:** When designing extension points or callback APIs, strictly enforce immutability (`&self`) if the operation is conceptually read-only. Avoid passing mutable context unless mutation is the explicit goal.

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -59,8 +59,8 @@ pub struct VirtualRelvarDefinition<E: StorageEngine> {
     pub relation_type: RelationType,
     /// The evaluation function that computes the virtual relvar's contents.
     ///
-    /// Takes a mutable reference to the database and returns the computed relation.
-    pub evaluator: fn(&mut Database<E>) -> Result<Relation, DatabaseError>,
+    /// Takes an immutable reference to the database and returns the computed relation.
+    pub evaluator: fn(&Database<E>) -> Result<Relation, DatabaseError>,
 }
 
 /// A relational database instance.
@@ -442,7 +442,7 @@ impl<E: StorageEngine> Database<E> {
     /// # Errors
     ///
     /// Returns `DatabaseError::RelationNotFound` if the relation doesn't exist.
-    pub fn query(&mut self, relation_name: &str) -> Result<Relation, DatabaseError> {
+    pub fn query(&self, relation_name: &str) -> Result<Relation, DatabaseError> {
         // Check if this is a virtual relvar
         if let Some(virtual_relvar) = self.virtual_relvars.get(relation_name) {
             return (virtual_relvar.evaluator)(self);
@@ -673,7 +673,7 @@ impl<E: StorageEngine> Database<E> {
         &mut self,
         name: &str,
         relation_type: RelationType,
-        evaluator: fn(&mut Database<E>) -> Result<Relation, DatabaseError>,
+        evaluator: fn(&Database<E>) -> Result<Relation, DatabaseError>,
     ) -> Result<(), DatabaseError> {
         if self.relvar_exists(name) {
             return Err(DatabaseError::RelationAlreadyExists(name.to_string()));
@@ -1100,7 +1100,7 @@ mod tests {
         db.define_virtual_relvar(
             "NAMES",
             RelationType::new(TupleType::new().with_attribute("name", ScalarType::String)),
-            |db: &mut Database<InMemoryEngine>| {
+            |db: &Database<InMemoryEngine>| {
                 let test = db.query("TEST")?;
                 Ok(test.project(&["name"]))
             },
@@ -1357,7 +1357,7 @@ mod tests {
         db.define_virtual_relvar(
             "VIRT",
             RelationType::new(TupleType::new().with_attribute("name", ScalarType::String)),
-            |db: &mut Database<InMemoryEngine>| {
+            |db: &Database<InMemoryEngine>| {
                 let test = db.query("TEST")?;
                 Ok(test.project(&["name"]))
             },
@@ -1393,7 +1393,7 @@ mod tests {
         db.define_virtual_relvar(
             "VIRT",
             RelationType::new(TupleType::new().with_attribute("name", ScalarType::String)),
-            |db: &mut Database<InMemoryEngine>| {
+            |db: &Database<InMemoryEngine>| {
                 let test = db.query("TEST")?;
                 Ok(test.project(&["name"]))
             },
@@ -1417,7 +1417,7 @@ mod tests {
         db.define_virtual_relvar(
             "VIRT",
             test_rel_type(),
-            |db: &mut Database<InMemoryEngine>| db.query("TEST"),
+            |db: &Database<InMemoryEngine>| db.query("TEST"),
         )
         .unwrap();
 
@@ -1438,7 +1438,7 @@ mod tests {
         db.define_virtual_relvar(
             "VIRT",
             test_rel_type(),
-            |db: &mut Database<InMemoryEngine>| db.query("TEST"),
+            |db: &Database<InMemoryEngine>| db.query("TEST"),
         )
         .unwrap();
 
@@ -1465,7 +1465,7 @@ mod tests {
         db.define_virtual_relvar(
             "VIRT",
             test_rel_type(),
-            |db: &mut Database<InMemoryEngine>| db.query("NONEXISTENT"),
+            |db: &Database<InMemoryEngine>| db.query("NONEXISTENT"),
         )
         .unwrap();
 
@@ -1918,5 +1918,34 @@ mod tests {
                 ConstraintManagerError::CheckConstraintViolation(_)
             ))
         ));
+    }
+
+    #[test]
+    fn test_virtual_relvar_immutability_enforcement() {
+        let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
+
+        // Create a log relation
+        let log_type = RelationType::new(
+            TupleType::new().with_attribute("count", ScalarType::Int)
+        );
+        db.create_relvar("LOG", log_type).unwrap();
+
+        // Define a view. The compiler enforces that we cannot call mutable methods
+        // like insert() inside the evaluator because it receives &Database, not &mut Database.
+        db.define_virtual_relvar(
+            "SAFE_VIEW",
+            test_rel_type(),
+            |db: &Database<InMemoryEngine>| {
+                // db.insert("LOG", ...); // This would cause compilation error!
+
+                // Read operations are allowed
+                let _ = db.query("LOG")?;
+
+                Ok(Relation::new(test_rel_type()))
+            },
+        ).unwrap();
+
+        // Query the view
+        assert!(db.query("SAFE_VIEW").is_ok());
     }
 }

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -1414,11 +1414,9 @@ mod tests {
         let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
         db.create_relvar("TEST", test_rel_type()).unwrap();
 
-        db.define_virtual_relvar(
-            "VIRT",
-            test_rel_type(),
-            |db: &Database<InMemoryEngine>| db.query("TEST"),
-        )
+        db.define_virtual_relvar("VIRT", test_rel_type(), |db: &Database<InMemoryEngine>| {
+            db.query("TEST")
+        })
         .unwrap();
 
         // Try to delete
@@ -1435,11 +1433,9 @@ mod tests {
         let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
         db.create_relvar("TEST", test_rel_type()).unwrap();
 
-        db.define_virtual_relvar(
-            "VIRT",
-            test_rel_type(),
-            |db: &Database<InMemoryEngine>| db.query("TEST"),
-        )
+        db.define_virtual_relvar("VIRT", test_rel_type(), |db: &Database<InMemoryEngine>| {
+            db.query("TEST")
+        })
         .unwrap();
 
         // Try to update
@@ -1462,11 +1458,9 @@ mod tests {
         let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
 
         // Define virtual relvar that queries nonexistent base
-        db.define_virtual_relvar(
-            "VIRT",
-            test_rel_type(),
-            |db: &Database<InMemoryEngine>| db.query("NONEXISTENT"),
-        )
+        db.define_virtual_relvar("VIRT", test_rel_type(), |db: &Database<InMemoryEngine>| {
+            db.query("NONEXISTENT")
+        })
         .unwrap();
 
         // Querying it should fail
@@ -1925,9 +1919,7 @@ mod tests {
         let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
 
         // Create a log relation
-        let log_type = RelationType::new(
-            TupleType::new().with_attribute("count", ScalarType::Int)
-        );
+        let log_type = RelationType::new(TupleType::new().with_attribute("count", ScalarType::Int));
         db.create_relvar("LOG", log_type).unwrap();
 
         // Define a view. The compiler enforces that we cannot call mutable methods
@@ -1943,7 +1935,8 @@ mod tests {
 
                 Ok(Relation::new(test_rel_type()))
             },
-        ).unwrap();
+        )
+        .unwrap();
 
         // Query the view
         assert!(db.query("SAFE_VIEW").is_ok());

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -1233,7 +1233,7 @@ mod tests {
 
     #[test]
     fn test_error_relvar_not_found() {
-        let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
+        let db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
 
         let result = db.query("NONEXISTENT");
         assert!(result.is_err());

--- a/relvar/benches/database.rs
+++ b/relvar/benches/database.rs
@@ -428,7 +428,7 @@ fn bench_virtual_relvar_creation(c: &mut Criterion) {
                 let emp_type = create_employee_type();
 
                 fn evaluator(
-                    db: &mut relvar::Database<relvar::PersistentEngine>,
+                    db: &relvar::Database<relvar::PersistentEngine>,
                 ) -> Result<relvar::Relation, relvar::DatabaseError> {
                     Ok(db
                         .query("EMP")?
@@ -465,7 +465,7 @@ fn bench_virtual_relvar_query(c: &mut Criterion) {
                         let emp_type = create_employee_type();
 
                         fn high_earners_evaluator(
-                            db: &mut relvar::Database<relvar::PersistentEngine>,
+                            db: &relvar::Database<relvar::PersistentEngine>,
                         ) -> Result<relvar::Relation, relvar::DatabaseError>
                         {
                             Ok(db
@@ -477,7 +477,7 @@ fn bench_virtual_relvar_query(c: &mut Criterion) {
                             .unwrap();
                         (_temp_dir, db)
                     },
-                    |(_temp_dir, mut db)| {
+                    |(_temp_dir, db)| {
                         // Measured: just the virtual relvar query
                         let result = db.query("HIGH_EARNERS").unwrap();
                         black_box(result);


### PR DESCRIPTION
This PR addresses a vulnerability where virtual relvars (views) could modify the database state. By changing the `evaluator` signature to take `&Database` instead of `&mut Database`, and consequently changing `Database::query` to take `&self`, we enforce read-only semantics for views at the compiler level.

This is a breaking change for internal APIs but critical for correctness and safety.

Verified with `cargo test` (all tests pass) and `cargo clippy`.

---
*PR created automatically by Jules for task [6811938839384410279](https://jules.google.com/task/6811938839384410279) started by @madmax983*