### PR TITLE
🎻 Bard: Clarify Ghost Variants and Add Examples

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -30,3 +30,7 @@ This ensures the map matches the territory.
 ## 2024-05-25 - Implemented Features Hidden in Roadmap
 **Confusion:** The README listed "Views (virtual relvars)" and "Derived types (POSSREP)" as "Future Enhancements", but they are fully implemented and functional in `relvar-core`.
 **Clarification:** I verified these features with executable examples and moved them to the "Implemented Features" section of the README to accurately reflect the project's capabilities.
+
+## 2024-05-27 - The Ghost Variants
+**Confusion:** The `ScalarValueError` and `RelationError` enums had variants that were technically public but lacked documentation explaining *when* they occur or *what* they mean. This forced users to guess based on the variant name.
+**Clarification:** I've added detailed documentation to these enum variants, explaining the specific conditions that trigger them (e.g., `NotUserDefined` only happens when calling `observer()` on a built-in type).

--- a/relvar-core/src/constraints/prepared.rs
+++ b/relvar-core/src/constraints/prepared.rs
@@ -32,7 +32,7 @@ pub enum PreparedConstraintExpression {
     /// Logical NOT: inverts the expression
     Not(Box<PreparedConstraintExpression>),
 
-    /// Set membership: attribute IN (HashSet<ScalarValue>)
+    /// Set membership: attribute IN (`HashSet<ScalarValue>`)
     /// Optimized for O(1) lookup.
     In(String, HashSet<ScalarValue>),
 

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -45,14 +45,18 @@ pub enum RelationError {
     /// A tuple doesn't conform to the relation's type (heading).
     ///
     /// This occurs when attempting to insert a tuple with a different
-    /// structure than what the relation expects.
+    /// structure (different attribute names or types) than what the
+    /// relation expects. The tuple must have exactly the same attributes
+    /// with the same types as defined in the relation's heading.
     #[error("Tuple does not conform to relation type")]
     TypeMismatch,
 
     /// A duplicate tuple was detected.
     ///
-    /// Note: This error is not typically returned during insert operations
-    /// since duplicates are silently ignored per set semantics.
+    /// This error is used in contexts where uniqueness is strictly enforced
+    /// and silent deduplication is not desired (e.g., bulk loading with strict validation).
+    /// Standard insert operations typically return `Ok(false)` for duplicates
+    /// rather than this error, adhering to set semantics.
     #[error("Duplicate tuple")]
     DuplicateTuple,
 }

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -35,7 +35,9 @@ use thiserror::Error;
 pub enum ScalarValueError {
     /// Attempted to use an observer on a built-in type.
     ///
-    /// The observer operation is only valid for user-defined types.
+    /// The observer operation is only valid for user-defined types (POSSREP pattern).
+    /// Built-in types like `Int`, `String`, etc., do not have observers because
+    /// their representation is their value.
     #[error("Cannot extract observer from built-in type")]
     NotUserDefined,
 }
@@ -98,7 +100,8 @@ pub enum ScalarValue {
 
     /// Relation value (for relation-valued attributes).
     ///
-    /// Enables nested relations within tuples.
+    /// Enables nested relations within tuples, allowing attributes to contain
+    /// entire relations as their values (RVA).
     Relation(crate::values::Relation),
 
     /// User-defined type value.
@@ -147,7 +150,18 @@ impl ScalarValue {
         }
     }
 
-    /// Checks if this value is of the given type
+    /// Checks if this value is of the given type.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use relvar_core::values::ScalarValue;
+    /// use relvar_core::types::ScalarType;
+    ///
+    /// let value = ScalarValue::Int(42);
+    /// assert!(value.is_type(&ScalarType::Int));
+    /// assert!(!value.is_type(&ScalarType::String));
+    /// ```
     pub fn is_type(&self, ty: &ScalarType) -> bool {
         &self.scalar_type() == ty
     }


### PR DESCRIPTION
📖 Chapter: The Ghost Variants
🔦 Insight: Clarified ambiguous error variants in `ScalarValueError` and `RelationError` that were forcing users to guess their meaning. Added missing doc tests for type checking.
🧪 Example: Added executable doctests for `ScalarValue::is_type`.


---
*PR created automatically by Jules for task [8215510577285949538](https://jules.google.com/task/8215510577285949538) started by @madmax983*