### PR TITLE
🗺️ Atlas: Structural Improvements (Query Decoupling & Feature Promotion)

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -5,3 +5,13 @@
 ## 2025-05-24 - Unify Database Error Handling
 **Tangle:** `DatabaseError` duplicated `ConstraintManagerError` variants (violating DRY) and required manual synchronization.
 **Blueprint:** Nested `ConstraintManagerError` within `DatabaseError` via a `Constraint(#[from] ConstraintManagerError)` variant. This enforces hierarchy and removes code duplication.
+
+## 2025-05-24 - Decouple Query from Database
+**Tangle:** Potential circular dependency between `Query` AST (in `relvar-core/src/query.rs`) and `Database` (in `relvar-core/src/database.rs`). `Query` depended on `Database` to execute, preventing `Database` from depending on `Query` (e.g. for stored view definitions).
+**Blueprint:** Introduced `RelationSource` trait in `relvar-core/src/traits.rs`. `Query::execute` now depends on `RelationSource`, and `Database` implements it. This inverts the dependency, allowing `Database` to depend on `Query` in the future.
+
+## 2025-05-24 - Promote Experimental Features
+**Tangle:** Core relational features (`Delta`) and useful utilities (`Importer`, `Exporter`) were buried in `relvar/src/experimental`.
+**Blueprint:**
+- Moved `Delta` to `relvar-core/src/algebra/delta.rs` (high cohesion with other operators).
+- Moved `Importer` and `Exporter` to `relvar/src/data/` (clear domain boundary for I/O).

--- a/relvar-core/src/algebra/delta.rs
+++ b/relvar-core/src/algebra/delta.rs
@@ -13,7 +13,7 @@
 //! use relvar_core::values::Relation;
 //! use relvar_core::types::{RelationType, TupleType, ScalarType};
 //! use relvar_core::tuple;
-//! use relvar::experimental::delta::Delta;
+//! use relvar_core::algebra::delta::Delta;
 //!
 //! let heading = TupleType::new().with_attribute("x", ScalarType::Int);
 //! let rel_type = RelationType::new(heading);
@@ -33,8 +33,8 @@
 //! assert_eq!(r3, r2);
 //! ```
 
-use relvar_core::error::DatabaseError;
-use relvar_core::values::Relation;
+use crate::error::DatabaseError;
+use crate::values::Relation;
 
 /// Represents the difference between two relations.
 ///
@@ -194,8 +194,8 @@ impl Delta {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use relvar_core::tuple;
-    use relvar_core::types::{RelationType, ScalarType, TupleType};
+    use crate::tuple;
+    use crate::types::{RelationType, ScalarType, TupleType};
 
     fn test_type() -> RelationType {
         RelationType::new(TupleType::new().with_attribute("x", ScalarType::Int))

--- a/relvar-core/src/algebra/mod.rs
+++ b/relvar-core/src/algebra/mod.rs
@@ -77,6 +77,9 @@
 //! - Tuple ordering is not guaranteed
 //! - Results are always valid relations
 
+/// Relational Delta operator.
+pub mod delta;
+
 /// Set difference operator (A MINUS B).
 pub mod difference;
 

--- a/relvar-core/src/database.rs
+++ b/relvar-core/src/database.rs
@@ -42,6 +42,7 @@ use crate::constraints::{
 };
 pub use crate::error::DatabaseError;
 use crate::storage_engine::StorageEngine;
+use crate::traits::RelationSource;
 use crate::types::RelationType;
 use crate::values::{Relation, Tuple};
 
@@ -797,6 +798,12 @@ impl<E: StorageEngine> Database<E> {
         )?;
 
         Ok(())
+    }
+}
+
+impl<S: StorageEngine> RelationSource for Database<S> {
+    fn query(&self, name: &str) -> Result<Relation, DatabaseError> {
+        self.query(name)
     }
 }
 

--- a/relvar-core/src/lib.rs
+++ b/relvar-core/src/lib.rs
@@ -19,11 +19,13 @@ pub mod database;
 pub mod error;
 pub mod query;
 pub mod storage_engine;
+pub mod traits;
 pub mod types;
 pub mod values;
 
 pub use database::{Database, DatabaseError};
 pub use query::{Query, QueryError};
+pub use traits::RelationSource;
 pub use types::{RelationType, ScalarType, TupleType};
 pub use values::{Relation, ScalarValue, Tuple};
 

--- a/relvar-core/src/query.rs
+++ b/relvar-core/src/query.rs
@@ -41,9 +41,8 @@
 
 use crate::algebra::summarize::Aggregation;
 use crate::constraints::{ConstraintExpression, ExpressionError};
-use crate::database::Database;
 use crate::error::DatabaseError;
-use crate::storage_engine::StorageEngine;
+use crate::traits::RelationSource;
 use crate::values::Relation;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -117,12 +116,12 @@ pub enum QueryError {
 }
 
 impl Query {
-    /// Executes the query plan against the given database.
-    pub fn execute<S: StorageEngine>(&self, db: &Database<S>) -> Result<Relation, QueryError> {
+    /// Executes the query plan against the given relation source (e.g., Database).
+    pub fn execute(&self, source: &impl RelationSource) -> Result<Relation, QueryError> {
         match self {
-            Query::Scan(table_name) => Ok(db.query(table_name)?),
+            Query::Scan(table_name) => Ok(source.query(table_name)?),
             Query::Restrict { input, predicate } => {
-                let relation = input.execute(db)?;
+                let relation = input.execute(source)?;
                 // Note: Relation::restrict takes a closure that returns bool.
                 // We use evaluate() inside, but we must handle errors.
                 // Currently, we treat evaluation errors as false (exclude tuple).
@@ -135,12 +134,12 @@ impl Query {
                 Ok(result)
             }
             Query::Project { input, attributes } => {
-                let relation = input.execute(db)?;
+                let relation = input.execute(source)?;
                 let attrs_ref: Vec<&str> = attributes.iter().map(|s| s.as_str()).collect();
                 Ok(relation.project(&attrs_ref))
             }
             Query::Rename { input, mappings } => {
-                let relation = input.execute(db)?;
+                let relation = input.execute(source)?;
                 let mappings_ref: Vec<(&str, &str)> = mappings
                     .iter()
                     .map(|(a, b)| (a.as_str(), b.as_str()))
@@ -148,8 +147,8 @@ impl Query {
                 Ok(relation.rename(&mappings_ref))
             }
             Query::Join { left, right } => {
-                let left_rel = left.execute(db)?;
-                let right_rel = right.execute(db)?;
+                let left_rel = left.execute(source)?;
+                let right_rel = right.execute(source)?;
                 Ok(left_rel.join(&right_rel)?)
             }
             Query::Summarize {
@@ -157,7 +156,7 @@ impl Query {
                 group_by,
                 aggregations,
             } => {
-                let relation = input.execute(db)?;
+                let relation = input.execute(source)?;
                 // aggregations is already Vec<Aggregation>, so no conversion needed
                 let group_by_ref: Vec<&str> = group_by.iter().map(|s| s.as_str()).collect();
                 Ok(relation

--- a/relvar-core/src/traits.rs
+++ b/relvar-core/src/traits.rs
@@ -1,0 +1,18 @@
+//! Core traits for Relvar.
+
+use crate::error::DatabaseError;
+use crate::values::Relation;
+
+/// A trait for entities that can provide relations by name.
+///
+/// This abstracts the [`crate::database::Database`] to allow the [`crate::query::Query`]
+/// AST to execute without depending on the full Database struct, breaking potential
+/// circular dependencies.
+pub trait RelationSource {
+    /// Retrieve a relation by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DatabaseError` if the relation cannot be found or loaded.
+    fn query(&self, name: &str) -> Result<Relation, DatabaseError>;
+}

--- a/relvar/src/data/exporter.rs
+++ b/relvar/src/data/exporter.rs
@@ -21,7 +21,7 @@
 //! use relvar_core::values::Relation;
 //! use relvar_core::types::{RelationType, TupleType, ScalarType};
 //! use relvar_core::tuple;
-//! use relvar::experimental::exporter;
+//! use relvar::data::exporter;
 //!
 //! // Create a sample relation
 //! let heading = TupleType::new()
@@ -104,7 +104,7 @@ impl<'a> Ord for SortableTuple<'a> {
 /// use relvar_core::values::Relation;
 /// use relvar_core::types::{RelationType, TupleType, ScalarType};
 /// use relvar_core::tuple;
-/// use relvar::experimental::exporter::to_csv;
+/// use relvar::data::exporter::to_csv;
 ///
 /// let heading = TupleType::new()
 ///     .with_attribute("col1", ScalarType::Int)
@@ -178,7 +178,7 @@ pub fn to_csv(relation: &Relation, delimiter: char) -> Result<String, ExporterEr
 /// use relvar_core::values::Relation;
 /// use relvar_core::types::{RelationType, TupleType, ScalarType};
 /// use relvar_core::tuple;
-/// use relvar::experimental::exporter::to_json;
+/// use relvar::data::exporter::to_json;
 ///
 /// let heading = TupleType::new().with_attribute("id", ScalarType::Int);
 /// let mut relation = Relation::new(RelationType::new(heading));
@@ -230,7 +230,7 @@ pub fn to_json(relation: &Relation) -> Result<String, ExporterError> {
 /// use relvar_core::values::Relation;
 /// use relvar_core::types::{RelationType, TupleType, ScalarType};
 /// use relvar_core::tuple;
-/// use relvar::experimental::exporter::to_ascii_table;
+/// use relvar::data::exporter::to_ascii_table;
 ///
 /// let heading = TupleType::new()
 ///     .with_attribute("name", ScalarType::String)

--- a/relvar/src/data/importer.rs
+++ b/relvar/src/data/importer.rs
@@ -19,7 +19,7 @@
 //!
 //! ```
 //! use relvar_core::types::{RelationType, TupleType, ScalarType};
-//! use relvar::experimental::importer;
+//! use relvar::data::importer;
 //!
 //! let heading = TupleType::new()
 //!     .with_attribute("id", ScalarType::Int)

--- a/relvar/src/data/mod.rs
+++ b/relvar/src/data/mod.rs
@@ -1,0 +1,6 @@
+//! Data import and export functionality.
+//!
+//! This module provides tools for moving data in and out of Relvar relations.
+
+pub mod exporter;
+pub mod importer;

--- a/relvar/src/experimental/mod.rs
+++ b/relvar/src/experimental/mod.rs
@@ -5,36 +5,10 @@
 //!
 //! # Included Features
 //!
-//! - **Delta**: Tools for computing and applying differences between relations.
-//! - **Exporter**: Tools for exporting relations to CSV, JSON, and ASCII tables.
-//! - **Importer**: Tools for importing relations from CSV and JSON.
 //! - **Pivot**: Operator to rotate unique values from one column into multiple columns.
 //! - **Mock**: Tools for generating random relations for testing.
-//! - **Query**: A serializable AST and query builder for relational queries.
-//!
-//! # Example: Using the Exporter
-//!
-//! ```
-//! use relvar::{Database, InMemoryEngine, tuple};
-//! use relvar::types::{TupleType, RelationType, ScalarType};
-//! use relvar::experimental::exporter;
-//!
-//! let mut db = Database::new(InMemoryEngine::new());
-//! let rel_type = RelationType::new(
-//!     TupleType::new().with_attribute("name", ScalarType::String)
-//! );
-//! db.create_relvar("TEST", rel_type).unwrap();
-//! db.insert("TEST", tuple! { name: "Alice" }).unwrap();
-//!
-//! let relation = db.query("TEST").unwrap();
-//!
-//! println!("CSV:\n{}", exporter::to_csv(&relation, ',').unwrap());
-//! println!("JSON:\n{}", exporter::to_json(&relation).unwrap());
-//! ```
+//! - **Spatial**: Spatial data types.
 
-pub mod delta;
-pub mod exporter;
-pub mod importer;
 pub mod mock;
 pub mod pivot;
 pub mod spatial;

--- a/relvar/src/lib.rs
+++ b/relvar/src/lib.rs
@@ -130,6 +130,9 @@ pub use relvar_storage::PersistentEngine;
 pub mod experimental;
 pub mod visualizer;
 
+/// Data import and export functionality.
+pub mod data;
+
 /// Create an in-memory database.
 ///
 /// This is a convenience function for creating a database with an in-memory storage engine.


### PR DESCRIPTION
This PR implements structural improvements identified by Atlas:

1.  **Decouple `Query` from `Database`**:
    *   **Problem**: `Query` depended on `Database` to execute, which prevented `Database` from depending on `Query` (e.g., for storing view definitions as ASTs) without creating a circular dependency.
    *   **Solution**: Introduced `RelationSource` trait in `relvar-core/src/traits.rs`. `Query` now depends on this trait, and `Database` implements it. Dependency inverted!

2.  **Promote `Delta` to Core Algebra**:
    *   **Problem**: `Delta` (calculating differences between relations) is a fundamental relational operation but was hidden in `experimental`.
    *   **Solution**: Moved to `relvar-core/src/algebra/delta.rs`.

3.  **Organize Data I/O**:
    *   **Problem**: `Importer` and `Exporter` were also in `experimental`.
    *   **Solution**: Moved to a new `relvar/src/data` module.

All tests pass. No functional changes, purely structural refactoring.

---
*PR created automatically by Jules for task [17108663040106047427](https://jules.google.com/task/17108663040106047427) started by @madmax983*