### PR TITLE
🛡️ Sentry: Verify Foreign Key Type Safety & Edge Cases

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -37,3 +37,7 @@
 ## 2027-05-22 - Virtual Relvar Side-Effect Vulnerability
 **Learning:** `VirtualRelvarDefinition` passes `&mut Database` to the evaluator closure, allowing "read-only" views to perform writes (insert/update/delete) as side effects.
 **Action:** When designing extension points or callback APIs, strictly enforce immutability (`&self`) if the operation is conceptually read-only. Avoid passing mutable context unless mutation is the explicit goal.
+
+## 2026-02-17 - Strict Float Equality in Foreign Keys
+**Learning:** Foreign Keys on floating-point columns enforce strict bit-pattern equality (e.g., `-0.0` != `0.0`), rejecting references even if numerically equal.
+**Action:** Avoid using floating-point columns as foreign keys unless strict bitwise identity is guaranteed, or implement fuzzy matching logic explicitly.

--- a/relvar-core/src/constraints/foreign_key.rs
+++ b/relvar-core/src/constraints/foreign_key.rs
@@ -657,12 +657,9 @@ mod tests {
     #[test]
     fn test_foreign_key_float_strictness() {
         // Referenced relation has Float ID with 0.0
-        let dept_heading = TupleType::new()
-            .with_attribute("dept_id", ScalarType::Float);
+        let dept_heading = TupleType::new().with_attribute("dept_id", ScalarType::Float);
         let mut departments = Relation::new(RelationType::new(dept_heading));
-        departments
-            .insert(tuple! { dept_id: 0.0 })
-            .unwrap();
+        departments.insert(tuple! { dept_id: 0.0 }).unwrap();
 
         // Referencing relation has Float ID with -0.0
         let emp_heading = TupleType::new()

--- a/relvar-core/src/constraints/foreign_key.rs
+++ b/relvar-core/src/constraints/foreign_key.rs
@@ -589,4 +589,99 @@ mod tests {
             ForeignKeyError::InvalidReferencedAttributes(_)
         ));
     }
+
+    #[test]
+    fn test_foreign_key_type_mismatch_int_string() {
+        // Referenced relation has String ID
+        let dept_heading = TupleType::new()
+            .with_attribute("dept_id", ScalarType::String)
+            .with_attribute("dept_name", ScalarType::String);
+        let mut departments = Relation::new(RelationType::new(dept_heading));
+        departments
+            .insert(tuple! { dept_id: "10", dept_name: "Engineering" })
+            .unwrap();
+
+        // Referencing relation has Int ID
+        let emp_heading = TupleType::new()
+            .with_attribute("emp_id", ScalarType::Int)
+            .with_attribute("dept_id", ScalarType::Int);
+        let mut employees = Relation::new(RelationType::new(emp_heading));
+        employees
+            .insert(tuple! { emp_id: 1i64, dept_id: 10i64 })
+            .unwrap();
+
+        let fk = ForeignKey::new(
+            vec!["dept_id".to_string()],
+            "DEPT".to_string(),
+            vec!["dept_id".to_string()],
+        )
+        .unwrap();
+
+        // Should fail because Int(10) != String("10")
+        // Currently returns Ok(false) (Violation), but ideally should be Err(TypeMismatch)
+        // For now, we assert the current behavior (Violation) to prevent regression/undefined behavior
+        assert!(!fk.is_satisfied_by(&employees, &departments).unwrap());
+    }
+
+    #[test]
+    fn test_foreign_key_type_mismatch_int_float() {
+        // Referenced relation has Float ID
+        let dept_heading = TupleType::new()
+            .with_attribute("dept_id", ScalarType::Float)
+            .with_attribute("dept_name", ScalarType::String);
+        let mut departments = Relation::new(RelationType::new(dept_heading));
+        departments
+            .insert(tuple! { dept_id: 10.0, dept_name: "Engineering" })
+            .unwrap();
+
+        // Referencing relation has Int ID
+        let emp_heading = TupleType::new()
+            .with_attribute("emp_id", ScalarType::Int)
+            .with_attribute("dept_id", ScalarType::Int);
+        let mut employees = Relation::new(RelationType::new(emp_heading));
+        employees
+            .insert(tuple! { emp_id: 1i64, dept_id: 10i64 })
+            .unwrap();
+
+        let fk = ForeignKey::new(
+            vec!["dept_id".to_string()],
+            "DEPT".to_string(),
+            vec!["dept_id".to_string()],
+        )
+        .unwrap();
+
+        // Should fail because Int(10) != Float(10.0)
+        assert!(!fk.is_satisfied_by(&employees, &departments).unwrap());
+    }
+
+    #[test]
+    fn test_foreign_key_float_strictness() {
+        // Referenced relation has Float ID with 0.0
+        let dept_heading = TupleType::new()
+            .with_attribute("dept_id", ScalarType::Float);
+        let mut departments = Relation::new(RelationType::new(dept_heading));
+        departments
+            .insert(tuple! { dept_id: 0.0 })
+            .unwrap();
+
+        // Referencing relation has Float ID with -0.0
+        let emp_heading = TupleType::new()
+            .with_attribute("emp_id", ScalarType::Int)
+            .with_attribute("dept_id", ScalarType::Float);
+        let mut employees = Relation::new(RelationType::new(emp_heading));
+        employees
+            .insert(tuple! { emp_id: 1i64, dept_id: -0.0 })
+            .unwrap();
+
+        let fk = ForeignKey::new(
+            vec!["dept_id".to_string()],
+            "DEPT".to_string(),
+            vec!["dept_id".to_string()],
+        )
+        .unwrap();
+
+        // Should fail because -0.0 != 0.0 in ScalarValue equality logic
+        // This confirms strict bit-pattern matching for FKs on floats
+        assert!(!fk.is_satisfied_by(&employees, &departments).unwrap());
+    }
 }


### PR DESCRIPTION
🛡️ Sentry: Verify Foreign Key Type Safety & Edge Cases

**Target:** `relvar-core/src/constraints/foreign_key.rs`

**Risk:** 
- Users might assume Foreign Keys implicitly cast types (e.g., Int 1 matches String "1").
- Users might assume standard float equality (`-0.0 == 0.0`) applies to Keys, but `ScalarValue` enforces strict bit-pattern equality for set semantics.

**Strategy:**
- Added `test_foreign_key_type_mismatch_int_string`: Verifies Int -> String FK fails.
- Added `test_foreign_key_type_mismatch_int_float`: Verifies Int -> Float FK fails.
- Added `test_foreign_key_float_strictness`: Verifies `-0.0` -> `0.0` FK fails.

**Verification:**
`cargo test -p relvar-core --lib constraints::foreign_key` passes with new tests.

---
*PR created automatically by Jules for task [264297941112002987](https://jules.google.com/task/264297941112002987) started by @madmax983*