### PR TITLE
🔒 Warden: Fix recursive type stack overflow vulnerability

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -103,3 +103,15 @@ Added verification test `relvar-core/tests/warden_exploit_like_memory.rs`.
 1. Replaced `from_json` implementation with a streaming parser using `serde::de::DeserializeSeed` and `Visitor`.
 2. The new implementation iterates over the JSON array element-by-element, processing and inserting each tuple individually.
 3. This ensures memory usage is proportional to the size of a single tuple (plus the accumulating `Relation` result), preventing the "double memory usage" (DOM + Result) and allowing for future optimizations (e.g. streaming to disk).
+
+## 2026-02-10 - Recursive Type Definition Stack Overflow
+**Threat:**
+`ScalarType` and `TupleType` definitions allow for infinite recursion in type definitions (e.g., a user-defined type wrapping itself, or a tuple containing a relation of itself).
+An attacker could define a deeply nested type structure programmatically or via API, causing the application to crash with a stack overflow during type comparison, hashing, or dropping (DoS).
+Since `ScalarType` variants are public and `serde` deserialization bypasses constructors, this vulnerability could also be exploited via malicious payloads if strict depth limits aren't enforced during deserialization or usage.
+
+**Defense:**
+1. Added `MAX_TYPE_DEPTH` constant (64) to `relvar-core/src/types/mod.rs`.
+2. Implemented recursive `depth()` method for `ScalarType`, `TupleType`, and `RelationType`.
+3. Added panic checks in `ScalarType::user_defined`, `TupleType::with_attribute`, and `RelationType::new` to enforce the depth limit during construction.
+4. While this primarily protects programmatic construction, it establishes a clear limit that should be respected by all future parsers and deserializers.

--- a/relvar-core/src/types/mod.rs
+++ b/relvar-core/src/types/mod.rs
@@ -49,3 +49,8 @@ pub mod tuple_type;
 pub use relation_type::RelationType;
 pub use scalar::ScalarType;
 pub use tuple_type::TupleType;
+
+/// Maximum nesting depth for types to prevent stack overflow.
+/// This limits recursion in type definitions (UserDefined, Relation)
+/// and prevents Denial of Service attacks via deep nesting.
+pub const MAX_TYPE_DEPTH: usize = 64;

--- a/relvar-core/src/types/relation_type.rs
+++ b/relvar-core/src/types/relation_type.rs
@@ -87,7 +87,21 @@ impl RelationType {
     /// let rel_type = RelationType::new(heading);
     /// ```
     pub fn new(heading: TupleType) -> Self {
+        if heading.depth() + 1 > crate::types::MAX_TYPE_DEPTH {
+            panic!(
+                "Type nesting too deep: {} (limit: {})",
+                heading.depth() + 1,
+                crate::types::MAX_TYPE_DEPTH
+            );
+        }
         Self { heading }
+    }
+
+    /// Returns the nesting depth of this relation type.
+    ///
+    /// This is 1 + the depth of its heading.
+    pub fn depth(&self) -> usize {
+        1 + self.heading.depth()
     }
 
     /// Returns the heading (tuple type) of this relation type.

--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -161,6 +161,20 @@ impl ScalarType {
         }
     }
 
+    /// Returns the nesting depth of this type.
+    ///
+    /// - Primitive types have depth 1.
+    /// - Recursive types (UserDefined, Relation) have 1 + depth of inner type.
+    ///
+    /// This is used to enforce `MAX_TYPE_DEPTH` to prevent stack overflow.
+    pub fn depth(&self) -> usize {
+        match self {
+            ScalarType::Relation(rel_type) => 1 + rel_type.depth(),
+            ScalarType::UserDefined { representation, .. } => 1 + representation.depth(),
+            _ => 1,
+        }
+    }
+
     /// Creates a user-defined type with the given name and representation type.
     ///
     /// TTM Prescription 1: Users can define their own scalar types.
@@ -179,6 +193,13 @@ impl ScalarType {
     /// assert_ne!(widget_id, supplier_id);
     /// ```
     pub fn user_defined(name: impl Into<String>, representation: ScalarType) -> Self {
+        if representation.depth() + 1 > crate::types::MAX_TYPE_DEPTH {
+            panic!(
+                "Type nesting too deep: {} (limit: {})",
+                representation.depth() + 1,
+                crate::types::MAX_TYPE_DEPTH
+            );
+        }
         ScalarType::UserDefined {
             name: name.into(),
             representation: Box::new(representation),

--- a/relvar-core/src/types/tuple_type.rs
+++ b/relvar-core/src/types/tuple_type.rs
@@ -114,6 +114,13 @@ impl TupleType {
     /// assert_eq!(person_type.degree(), 2);
     /// ```
     pub fn with_attribute(mut self, name: impl Into<String>, ty: ScalarType) -> Self {
+        if ty.depth() + 1 > crate::types::MAX_TYPE_DEPTH {
+            panic!(
+                "Type nesting too deep: {} (limit: {})",
+                ty.depth() + 1,
+                crate::types::MAX_TYPE_DEPTH
+            );
+        }
         self.attributes.insert(name.into(), ty);
         self
     }
@@ -181,6 +188,18 @@ impl TupleType {
     /// ```
     pub fn attribute_names(&self) -> impl Iterator<Item = &String> {
         self.attributes.keys()
+    }
+
+    /// Returns the maximum depth of any attribute type + 1.
+    ///
+    /// If there are no attributes, returns 1.
+    pub fn depth(&self) -> usize {
+        self.attributes
+            .values()
+            .map(|ty| ty.depth())
+            .max()
+            .unwrap_or(0)
+            + 1
     }
 
     /// Returns the degree (number of attributes) of this tuple type.

--- a/relvar-core/tests/warden_exploit_stack_overflow.rs
+++ b/relvar-core/tests/warden_exploit_stack_overflow.rs
@@ -38,7 +38,7 @@ fn test_tuple_type_depth_check() {
         // ...
         // i=62 -> t=UserDefined(...(Int)) (Depth 64)
         for i in 0..63 {
-             t = ScalarType::user_defined(format!("T{}", i), t);
+            t = ScalarType::user_defined(format!("T{}", i), t);
         }
 
         assert_eq!(t.depth(), 64);
@@ -49,5 +49,8 @@ fn test_tuple_type_depth_check() {
         TupleType::new().with_attribute("deep_attr", t);
     });
 
-    assert!(result.is_err(), "TupleType::with_attribute should have panicked");
+    assert!(
+        result.is_err(),
+        "TupleType::with_attribute should have panicked"
+    );
 }

--- a/relvar-core/tests/warden_exploit_stack_overflow.rs
+++ b/relvar-core/tests/warden_exploit_stack_overflow.rs
@@ -1,0 +1,53 @@
+use relvar_core::types::ScalarType;
+use std::panic;
+
+#[test]
+fn test_deeply_nested_type_panics_safely() {
+    // This test attempts to create a deeply nested ScalarType.
+    // It should panic with "Type nesting too deep" before causing a stack overflow.
+
+    let result = panic::catch_unwind(|| {
+        let mut t = ScalarType::Int;
+        // Try to go deeper than MAX_TYPE_DEPTH (64)
+        for i in 0..100 {
+            t = ScalarType::user_defined(format!("T{}", i), t);
+        }
+    });
+
+    assert!(result.is_err(), "Should have panicked due to depth limit");
+
+    // Optional: Verify panic message if possible, but catch_unwind returns Any
+    // which is hard to inspect safely without downcasting to String or &str.
+    let err = result.unwrap_err();
+    if let Some(msg) = err.downcast_ref::<&str>() {
+        assert!(msg.contains("Type nesting too deep"));
+    } else if let Some(msg) = err.downcast_ref::<String>() {
+        assert!(msg.contains("Type nesting too deep"));
+    }
+}
+
+#[test]
+fn test_tuple_type_depth_check() {
+    use relvar_core::types::TupleType;
+
+    let result = panic::catch_unwind(|| {
+        let mut t = ScalarType::Int; // Depth 1
+
+        // Build a type with depth 64 (MAX_TYPE_DEPTH)
+        // i=0 -> t=UserDefined(Int) (Depth 2)
+        // ...
+        // i=62 -> t=UserDefined(...(Int)) (Depth 64)
+        for i in 0..63 {
+             t = ScalarType::user_defined(format!("T{}", i), t);
+        }
+
+        assert_eq!(t.depth(), 64);
+
+        // Try to add it to a TupleType.
+        // TupleType depth would be 1 + 64 = 65.
+        // This should panic.
+        TupleType::new().with_attribute("deep_attr", t);
+    });
+
+    assert!(result.is_err(), "TupleType::with_attribute should have panicked");
+}


### PR DESCRIPTION
This PR addresses a potential Denial of Service (DoS) vulnerability where deeply nested recursive type definitions (e.g., `UserDefined` wrapping itself) could cause a stack overflow and crash the application.

Changes:
- Added `MAX_TYPE_DEPTH` constant (64) in `relvar-core/src/types/mod.rs`.
- Implemented `depth()` method for `ScalarType`, `TupleType`, and `RelationType`.
- Added panic checks in `ScalarType::user_defined`, `TupleType::with_attribute`, and `RelationType::new` to enforce the depth limit.
- Added `relvar-core/tests/warden_exploit_stack_overflow.rs` to verify that exceeding the limit triggers a panic (safe unwind) instead of a process abort.

This protects against programmatic construction of malicious types. While `serde` deserialization bypasses these constructors, this change establishes the domain logic necessary for future deserialization hardening.

---
*PR created automatically by Jules for task [7805293615185150293](https://jules.google.com/task/7805293615185150293) started by @madmax983*