### PR TITLE
feat(security): enforce MAX_TYPE_DEPTH in ScalarType deserialization

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -115,3 +115,14 @@ Since `ScalarType` variants are public and `serde` deserialization bypasses cons
 2. Implemented recursive `depth()` method for `ScalarType`, `TupleType`, and `RelationType`.
 3. Added panic checks in `ScalarType::user_defined`, `TupleType::with_attribute`, and `RelationType::new` to enforce the depth limit during construction.
 4. While this primarily protects programmatic construction, it establishes a clear limit that should be respected by all future parsers and deserializers.
+
+## 2026-02-11 - ScalarType Deserialization Stack Overflow
+**Threat:**
+Although `ScalarType::user_defined` constructor enforced `MAX_TYPE_DEPTH`, `ScalarType`'s enum variants were public, and it relied on the default `#[derive(Deserialize)]`. This allowed an attacker to construct a deeply nested `ScalarType` (e.g., via a JSON payload) bypassing the constructor checks, leading to a stack overflow or DoS when the type was subsequently used (e.g., hashed or dropped). `serde_json`'s recursion limit provided partial protection but was not guaranteed for all formats.
+
+**Defense:**
+1. Introduced a private `ScalarTypeUnchecked` enum mirroring `ScalarType` to intercept raw deserialization.
+2. Implemented `TryFrom<ScalarTypeUnchecked> for ScalarType`, which recursively rebuilds the type and enforces the `MAX_TYPE_DEPTH` (64) limit.
+3. Updated `ScalarType` to use `#[serde(try_from = "ScalarTypeUnchecked")]`.
+4. This ensures that *any* deserialization of `ScalarType` must pass the depth check, regardless of the underlying format or its limits.
+5. Added verification test `relvar-core/tests/warden_exploit_serde_stack_overflow.rs`.

--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -29,6 +29,7 @@
 //! ```
 
 use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 use thiserror::Error;
 
 /// Errors that can occur during scalar type operations.
@@ -93,6 +94,7 @@ pub enum ScalarTypeError {
 /// assert_ne!(employee_id, department_id);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "ScalarTypeUnchecked")]
 pub enum ScalarType {
     /// 64-bit signed integer.
     ///
@@ -654,5 +656,56 @@ mod tests {
         assert_eq!(types[2], ScalarType::String);
         assert_eq!(types[3], ScalarType::Bool);
         assert_eq!(types[4], ScalarType::Bytes);
+    }
+}
+
+// Private structure to assist with deserialization and validation.
+// This allows us to intercept deserialization and enforce invariants (MAX_TYPE_DEPTH)
+// that could be bypassed by serde if we derived Deserialize directly on ScalarType.
+#[derive(Debug, Deserialize)]
+enum ScalarTypeUnchecked {
+    Int,
+    Float,
+    String,
+    Bool,
+    Bytes,
+    Relation(Box<crate::types::RelationType>),
+    UserDefined {
+        name: String,
+        representation: Box<ScalarTypeUnchecked>,
+    },
+}
+
+impl TryFrom<ScalarTypeUnchecked> for ScalarType {
+    type Error = String;
+
+    fn try_from(unchecked: ScalarTypeUnchecked) -> Result<Self, Self::Error> {
+        let ty = match unchecked {
+            ScalarTypeUnchecked::Int => ScalarType::Int,
+            ScalarTypeUnchecked::Float => ScalarType::Float,
+            ScalarTypeUnchecked::String => ScalarType::String,
+            ScalarTypeUnchecked::Bool => ScalarType::Bool,
+            ScalarTypeUnchecked::Bytes => ScalarType::Bytes,
+            ScalarTypeUnchecked::Relation(rel) => ScalarType::Relation(rel),
+            ScalarTypeUnchecked::UserDefined {
+                name,
+                representation,
+            } => {
+                let inner = ScalarType::try_from(*representation)?;
+                ScalarType::UserDefined {
+                    name,
+                    representation: Box::new(inner),
+                }
+            }
+        };
+
+        if ty.depth() > crate::types::MAX_TYPE_DEPTH {
+            return Err(format!(
+                "Type nesting too deep: {} (limit: {})",
+                ty.depth(),
+                crate::types::MAX_TYPE_DEPTH
+            ));
+        }
+        Ok(ty)
     }
 }

--- a/relvar-core/tests/warden_exploit_serde_stack_overflow.rs
+++ b/relvar-core/tests/warden_exploit_serde_stack_overflow.rs
@@ -1,5 +1,4 @@
 use relvar_core::types::ScalarType;
-use serde_json;
 
 #[test]
 fn test_serde_depth_check() {

--- a/relvar-core/tests/warden_exploit_serde_stack_overflow.rs
+++ b/relvar-core/tests/warden_exploit_serde_stack_overflow.rs
@@ -1,0 +1,33 @@
+use relvar_core::types::ScalarType;
+use serde_json;
+
+#[test]
+fn test_serde_depth_check() {
+    let depth = 65; // Just over MAX_TYPE_DEPTH (64)
+    let mut json = String::new();
+
+    // Open nested objects
+    for i in 0..depth {
+        json.push_str(&format!(r#"{{"UserDefined":{{"name":"T{}","representation":"#, i));
+    }
+
+    // Base case: Int
+    json.push_str(r#""Int""#);
+
+    // Close objects
+    for _ in 0..depth {
+        json.push_str("}}");
+    }
+
+    // Attempt to deserialize
+    let result: Result<ScalarType, _> = serde_json::from_str(&json);
+
+    match result {
+        Ok(_) => panic!("Deserialization should have failed!"),
+        Err(e) => {
+            let msg = e.to_string();
+            println!("Deserialization failed: {}", msg);
+            assert!(msg.contains("Type nesting too deep") || msg.contains("recursion limit exceeded"));
+        }
+    }
+}

--- a/relvar-core/tests/warden_exploit_serde_stack_overflow.rs
+++ b/relvar-core/tests/warden_exploit_serde_stack_overflow.rs
@@ -8,7 +8,10 @@ fn test_serde_depth_check() {
 
     // Open nested objects
     for i in 0..depth {
-        json.push_str(&format!(r#"{{"UserDefined":{{"name":"T{}","representation":"#, i));
+        json.push_str(&format!(
+            r#"{{"UserDefined":{{"name":"T{}","representation":"#,
+            i
+        ));
     }
 
     // Base case: Int
@@ -27,7 +30,9 @@ fn test_serde_depth_check() {
         Err(e) => {
             let msg = e.to_string();
             println!("Deserialization failed: {}", msg);
-            assert!(msg.contains("Type nesting too deep") || msg.contains("recursion limit exceeded"));
+            assert!(
+                msg.contains("Type nesting too deep") || msg.contains("recursion limit exceeded")
+            );
         }
     }
 }

--- a/relvar-core/tests/warden_scalar_type_coverage.rs
+++ b/relvar-core/tests/warden_scalar_type_coverage.rs
@@ -34,7 +34,11 @@ fn test_scalar_type_deserialization_coverage() {
     }
 
     // UserDefined type check
-    if let ScalarType::UserDefined { name, representation } = &types[6] {
+    if let ScalarType::UserDefined {
+        name,
+        representation,
+    } = &types[6]
+    {
         assert_eq!(name, "MyType");
         assert_eq!(**representation, ScalarType::Int);
     } else {

--- a/relvar-core/tests/warden_scalar_type_coverage.rs
+++ b/relvar-core/tests/warden_scalar_type_coverage.rs
@@ -1,5 +1,4 @@
 use relvar_core::types::ScalarType;
-use serde_json;
 
 #[test]
 fn test_scalar_type_deserialization_coverage() {

--- a/relvar-core/tests/warden_scalar_type_coverage.rs
+++ b/relvar-core/tests/warden_scalar_type_coverage.rs
@@ -1,0 +1,43 @@
+use relvar_core::types::ScalarType;
+use serde_json;
+
+#[test]
+fn test_scalar_type_deserialization_coverage() {
+    // Construct a JSON array containing all variants of ScalarTypeUnchecked
+    let json = r#"[
+        "Int",
+        "Float",
+        "String",
+        "Bool",
+        "Bytes",
+        {"Relation": {"heading": {"attributes": {}}}},
+        {"UserDefined": {"name": "MyType", "representation": "Int"}}
+    ]"#;
+
+    // Deserialize into Vec<ScalarType>
+    // This will trigger TryFrom<ScalarTypeUnchecked> for each element
+    let types: Vec<ScalarType> = serde_json::from_str(json).expect("Deserialization failed");
+
+    // Verify correct types were created
+    assert_eq!(types.len(), 7);
+    assert_eq!(types[0], ScalarType::Int);
+    assert_eq!(types[1], ScalarType::Float);
+    assert_eq!(types[2], ScalarType::String);
+    assert_eq!(types[3], ScalarType::Bool);
+    assert_eq!(types[4], ScalarType::Bytes);
+
+    // Relation type check
+    if let ScalarType::Relation(rel_type) = &types[5] {
+        assert_eq!(rel_type.heading().degree(), 0);
+    } else {
+        panic!("Expected Relation type at index 5");
+    }
+
+    // UserDefined type check
+    if let ScalarType::UserDefined { name, representation } = &types[6] {
+        assert_eq!(name, "MyType");
+        assert_eq!(**representation, ScalarType::Int);
+    } else {
+        panic!("Expected UserDefined type at index 6");
+    }
+}


### PR DESCRIPTION
Enforce MAX_TYPE_DEPTH in ScalarType deserialization to prevent stack overflow DoS.

---
*PR created automatically by Jules for task [17398036683458008088](https://jules.google.com/task/17398036683458008088) started by @madmax983*