### PR TITLE
docs: enhance experimental module documentation with examples and context

### DIFF
--- a/relvar/src/experimental/pivot.rs
+++ b/relvar/src/experimental/pivot.rs
@@ -1,6 +1,35 @@
 //! Pivot operator implementation.
 //!
 //! PIVOT transforms row values into column headers.
+//!
+//! # Visual Example
+//!
+//! ```text
+//! Before Pivot:
+//! +-------+-------+-------+
+//! | Item  | Color | Count |
+//! +-------+-------+-------+
+//! | Shirt | Red   | 10    |
+//! | Shirt | Blue  | 5     |
+//! | Pants | Blue  | 20    |
+//! +-------+-------+-------+
+//!
+//! After Pivot (on Color, value Count):
+//! +-------+-----+------+
+//! | Item  | Red | Blue |
+//! +-------+-----+------+
+//! | Shirt | 10  | 5    |
+//! | Pants | 0   | 20   |
+//! +-------+-----+------+
+//! ```
+//!
+//! The `pivot` operator is useful for transforming "tall" data (normalized) into "wide" data (denormalized/report format).
+//!
+//! # Conflict Resolution
+//!
+//! If multiple tuples map to the same cell (e.g., same `Item` and same `Color` in the example above),
+//! the operator uses a **Last Write Wins** strategy based on the lexicographical order of the source tuples.
+//! The tuple that sorts last determines the final cell value.
 
 use relvar_core::error::DatabaseError;
 use relvar_core::types::{RelationType, TupleType};
@@ -11,14 +40,49 @@ use std::collections::{BTreeMap, BTreeSet};
 pub trait Pivot {
     /// Pivots a relation.
     ///
-    /// Transforms unique values from `on_attr` into new columns,
-    /// filling cells with values from `value_attr`.
+    /// Transforms unique values from the `on_attr` column into new column headers,
+    /// filling the cells with values from the `value_attr` column. All other attributes
+    /// become grouping keys.
     ///
     /// # Arguments
     ///
-    /// * `on_attr` - Attribute for new column headers.
-    /// * `value_attr` - Attribute for cell values.
-    /// * `default_value` - Value for missing cells (must match `value_attr` type).
+    /// * `on_attr` - The attribute whose values will become new column headers.
+    /// * `value_attr` - The attribute whose values will populate the cells.
+    /// * `default_value` - The value to use when a cell is missing (e.g., `0` or `false`).
+    ///   Must match the type of `value_attr`.
+    ///
+    /// # Conflict Resolution
+    ///
+    /// If multiple source tuples map to the same target cell (i.e., they have the same
+    /// grouping attributes and the same `on_attr` value), the **Last Write Wins** strategy
+    /// is applied. The source tuples are sorted, and the value from the last tuple is used.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::types::{TupleType, RelationType, ScalarType};
+    /// use relvar_core::values::{Relation, ScalarValue};
+    /// use relvar_core::tuple;
+    /// use relvar::experimental::pivot::Pivot;
+    ///
+    /// // Create a relation: (Item, Color, Count)
+    /// let heading = TupleType::new()
+    ///     .with_attribute("Item", ScalarType::String)
+    ///     .with_attribute("Color", ScalarType::String)
+    ///     .with_attribute("Count", ScalarType::Int);
+    /// let mut relation = Relation::new(RelationType::new(heading));
+    ///
+    /// relation.insert(tuple! { Item: "Shirt", Color: "Red", Count: 10 }).unwrap();
+    /// relation.insert(tuple! { Item: "Shirt", Color: "Blue", Count: 5 }).unwrap();
+    /// relation.insert(tuple! { Item: "Pants", Color: "Blue", Count: 20 }).unwrap();
+    ///
+    /// // Pivot on 'Color', using 'Count' as values, default to 0
+    /// let pivoted = relation.pivot("Color", "Count", ScalarValue::Int(0)).unwrap();
+    ///
+    /// // Result: (Item, Red, Blue)
+    /// // Shirt: Red=10, Blue=5
+    /// // Pants: Red=0 (default), Blue=20
+    /// ```
     fn pivot(
         &self,
         on_attr: &str,

--- a/relvar/src/experimental/search.rs
+++ b/relvar/src/experimental/search.rs
@@ -4,6 +4,12 @@
 //! It demonstrates that an inverted index is simply a relation, and search queries
 //! can be expressed as relational operations (Restrict, Join, Summarize).
 //!
+//! # Disclaimer
+//!
+//! This is an **experimental demonstration** of relational principles. It is not intended
+//! for production use as a high-performance search engine. It lacks advanced features
+//! like stemming, stop-word removal (mostly), and TF-IDF scoring.
+//!
 //! # How it works
 //!
 //! 1. **Indexing**: Text is tokenized into words.
@@ -47,6 +53,36 @@ impl Tokenizer {
 }
 
 /// A full-text search index backed by a relation.
+///
+/// # Examples
+///
+/// ```
+/// use relvar::experimental::search::FullTextIndex;
+/// use relvar_core::Database;
+/// use relvar_core::storage_engine::InMemoryEngine;
+/// use relvar_core::types::ScalarType;
+/// use relvar_core::values::ScalarValue;
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let mut db = Database::new(InMemoryEngine::new());
+///     let index = FullTextIndex::new("idx_docs", ScalarType::Int);
+///
+///     // 1. Initialize the index relation
+///     index.create(&mut db)?;
+///
+///     // 2. Index some documents
+///     index.index_document(&mut db, ScalarValue::Int(1), "The quick brown fox")?;
+///     index.index_document(&mut db, ScalarValue::Int(2), "The quick blue fox")?;
+///
+///     // 3. Search for terms
+///     let results = index.search(&db, "quick fox")?;
+///
+///     // Both documents match "quick" and "fox" (score 2)
+///     assert_eq!(results.cardinality(), 2);
+///
+///     Ok(())
+/// }
+/// ```
 pub struct FullTextIndex {
     /// The name of the relation storing the index.
     index_name: String,

--- a/relvar/src/experimental/spatial.rs
+++ b/relvar/src/experimental/spatial.rs
@@ -4,9 +4,25 @@
 //! the Relational Model's support for Relation-Valued Attributes (RVAs) and
 //! User-Defined Types (UDTs).
 //!
-//! A `Point` is defined as a relation with a heading `{x: Float, y: Float}`
-//! and cardinality 1. This "pure" representation allows points to be treated
-//! as first-class relational values without opaque binary blobs.
+//! # Philosophy: Pure Relational Types
+//!
+//! Instead of introducing an opaque binary `Point` type (as in PostGIS), we define
+//! a `Point` as a **User-Defined Type (UDT)** that wraps a **Relation** with a specific heading:
+//!
+//! ```text
+//! Point Type Definition:
+//! POSSREP {
+//!     x: Float,
+//!     y: Float
+//! }
+//! ```
+//!
+//! Internally, this is represented as a relation with heading `{x: Float, y: Float}`
+//! constrained to have exactly **cardinality 1**.
+//!
+//! This approach ensures that the internal structure of the type is visible to the
+//! relational engine, allowing us to query components (e.g., `p.x`) using standard
+//! relational operators like `UNGROUP` or `EXTEND`.
 
 use relvar_core::tuple;
 use relvar_core::types::{RelationType, ScalarType, TupleType};
@@ -32,6 +48,16 @@ pub fn point_type() -> ScalarType {
 ///
 /// Creates a relation with a single tuple `{x: x, y: y}` and wraps it in the
 /// Point user-defined type.
+///
+/// # Examples
+///
+/// ```
+/// use relvar::experimental::spatial::point;
+/// use relvar_core::values::ScalarValue;
+///
+/// let p = point(3.0, 4.0);
+/// assert_eq!(p.scalar_type().name(), "Point");
+/// ```
 pub fn point(x: f64, y: f64) -> ScalarValue {
     let pt_type = point_type();
 
@@ -56,6 +82,18 @@ pub fn point(x: f64, y: f64) -> ScalarValue {
 }
 
 /// Calculates the Euclidean distance between two Points.
+///
+/// # Examples
+///
+/// ```
+/// use relvar::experimental::spatial::{point, distance};
+///
+/// let p1 = point(0.0, 0.0);
+/// let p2 = point(3.0, 4.0);
+///
+/// let dist = distance(&p1, &p2).unwrap();
+/// assert_eq!(dist, 5.0);
+/// ```
 pub fn distance(p1: &ScalarValue, p2: &ScalarValue) -> Result<f64, String> {
     let pt_type = point_type();
 
@@ -75,6 +113,18 @@ pub fn distance(p1: &ScalarValue, p2: &ScalarValue) -> Result<f64, String> {
 }
 
 /// Checks if a point is within a given radius of a center point.
+///
+/// # Examples
+///
+/// ```
+/// use relvar::experimental::spatial::{point, within};
+///
+/// let center = point(0.0, 0.0);
+/// let p = point(3.0, 4.0);
+///
+/// assert!(within(&p, &center, 5.0).unwrap());
+/// assert!(!within(&p, &center, 4.0).unwrap());
+/// ```
 pub fn within(p: &ScalarValue, center: &ScalarValue, radius: f64) -> Result<bool, String> {
     let dist = distance(p, center)?;
     Ok(dist <= radius)


### PR DESCRIPTION
This PR enhances the documentation for the `experimental` modules in the `relvar` crate, following the "Bard" persona guidelines.

Changes:
- **`relvar/src/experimental/pivot.rs`**: Added a "Visual Example" using ASCII art to explain the pivot transformation. Documented the "Last Write Wins" conflict resolution strategy. Added executable doctests.
- **`relvar/src/experimental/spatial.rs`**: Added module-level documentation explaining the architectural decision to model `Point` as a User-Defined Type wrapping a Relation (RVA). Added executable doctests for `point`, `distance`, and `within`.
- **`relvar/src/experimental/search.rs`**: Added a disclaimer that this is a demonstration of relational principles, not a production search engine. Added executable doctests for `FullTextIndex`.

All changes were verified with `cargo test` and `cargo test --doc`.

---
*PR created automatically by Jules for task [3589675980851086192](https://jules.google.com/task/3589675980851086192) started by @madmax983*