### PR TITLE
Decouple Query from Database using QueryExecutor trait

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -15,3 +15,7 @@
 **Blueprint:**
 - Moved `Delta` to `relvar-core/src/algebra/delta.rs` (high cohesion with other operators).
 - Moved `Importer` and `Exporter` to `relvar/src/data/` (clear domain boundary for I/O).
+
+## 2025-05-24 - Decouple Query from Database (Again)
+**Tangle:** `Query` depended on `Database` concrete type, creating a hard coupling. `Database` implementation of `QueryExecutor` existed but wasn't used by `Query`.
+**Blueprint:** Updated `Query::execute` to depend on `QueryExecutor` trait instead of `Database` struct. This reuses the existing abstraction used by virtual relvars and fully decouples the query definition from the database implementation.

--- a/relvar-core/src/query.rs
+++ b/relvar-core/src/query.rs
@@ -41,9 +41,8 @@
 
 use crate::algebra::summarize::Aggregation;
 use crate::constraints::{ConstraintExpression, ExpressionError};
-use crate::database::Database;
 use crate::error::DatabaseError;
-use crate::storage_engine::StorageEngine;
+use crate::traits::QueryExecutor;
 use crate::values::Relation;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -118,11 +117,11 @@ pub enum QueryError {
 
 impl Query {
     /// Executes the query plan against the given relation source (e.g., Database).
-    pub fn execute<S: StorageEngine>(&self, db: &Database<S>) -> Result<Relation, QueryError> {
+    pub fn execute(&self, executor: &impl QueryExecutor) -> Result<Relation, QueryError> {
         match self {
-            Query::Scan(table_name) => Ok(db.query(table_name)?),
+            Query::Scan(table_name) => Ok(executor.query(table_name)?),
             Query::Restrict { input, predicate } => {
-                let relation = input.execute(db)?;
+                let relation = input.execute(executor)?;
                 // Note: Relation::restrict takes a closure that returns bool.
                 // We use evaluate() inside, but we must handle errors.
                 // Currently, we treat evaluation errors as false (exclude tuple).
@@ -135,12 +134,12 @@ impl Query {
                 Ok(result)
             }
             Query::Project { input, attributes } => {
-                let relation = input.execute(db)?;
+                let relation = input.execute(executor)?;
                 let attrs_ref: Vec<&str> = attributes.iter().map(|s| s.as_str()).collect();
                 Ok(relation.project(&attrs_ref))
             }
             Query::Rename { input, mappings } => {
-                let relation = input.execute(db)?;
+                let relation = input.execute(executor)?;
                 let mappings_ref: Vec<(&str, &str)> = mappings
                     .iter()
                     .map(|(a, b)| (a.as_str(), b.as_str()))
@@ -148,8 +147,8 @@ impl Query {
                 Ok(relation.rename(&mappings_ref))
             }
             Query::Join { left, right } => {
-                let left_rel = left.execute(db)?;
-                let right_rel = right.execute(db)?;
+                let left_rel = left.execute(executor)?;
+                let right_rel = right.execute(executor)?;
                 Ok(left_rel.join(&right_rel)?)
             }
             Query::Summarize {
@@ -157,7 +156,7 @@ impl Query {
                 group_by,
                 aggregations,
             } => {
-                let relation = input.execute(db)?;
+                let relation = input.execute(executor)?;
                 // aggregations is already Vec<Aggregation>, so no conversion needed
                 let group_by_ref: Vec<&str> = group_by.iter().map(|s| s.as_str()).collect();
                 Ok(relation


### PR DESCRIPTION
Decoupled `Query` from `Database` to fix potential circular dependencies and improve modularity. `Query::execute` now accepts any `impl QueryExecutor`.

---
*PR created automatically by Jules for task [8512877444321178308](https://jules.google.com/task/8512877444321178308) started by @madmax983*