### PR TITLE
🛡️ Sentry: Prevent integer truncation vulnerabilities in storage layer

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -41,3 +41,7 @@
 ## 2026-02-17 - Strict Float Equality in Foreign Keys
 **Learning:** Foreign Keys on floating-point columns enforce strict bit-pattern equality (e.g., `-0.0` != `0.0`), rejecting references even if numerically equal.
 **Action:** Avoid using floating-point columns as foreign keys unless strict bitwise identity is guaranteed, or implement fuzzy matching logic explicitly.
+
+## 2027-08-15 - Integer Truncation and Overflow in Storage Layers
+**Learning:** `WalManager` and `PageFile` were casting `u64` length prefixes to `usize` without checking for truncation (on 32-bit systems) or overflow during offset calculation. This allowed malicious payloads to cause panics or potentially bypass size checks.
+**Action:** Always validate `u64` values from external sources (disk/network) using `checked_add` and `usize::try_from` before using them for memory indexing or allocation.

--- a/relvar-storage/src/storage/page.rs
+++ b/relvar-storage/src/storage/page.rs
@@ -309,12 +309,24 @@ impl PageFile {
             )));
         }
 
-        let data_len = u64::from_le_bytes(buffer[0..8].try_into().unwrap()) as usize;
+        let data_len_u64 = u64::from_le_bytes(buffer[0..8].try_into().unwrap());
 
-        // Check if declared length fits in the buffer
-        let required_len = data_len
-            .checked_add(8)
-            .ok_or_else(|| PageError::Serialization("Page length overflow".to_string()))?;
+        // Check if data length exceeds PAGE_SIZE - 8 (maximum possible data)
+        // We check this using u64 arithmetic BEFORE casting to usize to prevent
+        // truncation vulnerabilities on 32-bit systems (e.g., 4GB+1 -> 1).
+        if data_len_u64 > (PAGE_SIZE - 8) as u64 {
+            return Err(PageError::Serialization(format!(
+                "Page data length {} exceeds maximum {}",
+                data_len_u64,
+                PAGE_SIZE - 8
+            )));
+        }
+
+        // Safe cast: we've already verified it's <= PAGE_SIZE - 8, which fits in usize
+        let data_len = data_len_u64 as usize;
+
+        // Check if declared length fits in the buffer (which might be smaller than PAGE_SIZE if read was short)
+        let required_len = data_len + 8; // No overflow possible (checked above)
 
         if required_len > buffer.len() {
             return Err(PageError::Serialization(format!(
@@ -743,6 +755,99 @@ mod tests {
                 "Expected Serialization error with overflow message, got {:?}",
                 result
             ),
+        }
+    }
+
+    #[test]
+    fn test_page_file_length_boundary() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+
+        let mut page_file = PageFile::create(path).unwrap();
+        let max_data = PAGE_SIZE - 8;
+
+        // Test Case 1: Max allowed length (PAGE_SIZE - 8)
+        {
+            let len = max_data as u64;
+            let mut buffer = Vec::new();
+            buffer.extend_from_slice(&len.to_le_bytes());
+            buffer.resize(PAGE_SIZE, 0); // Fill with valid data
+
+            // Write directly
+            let mut file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+            use std::io::Seek;
+            use std::io::SeekFrom;
+            use std::io::Write;
+            file.seek(SeekFrom::Start(0)).unwrap();
+            file.write_all(&buffer).unwrap();
+        }
+
+        // Should succeed
+        let result = page_file.read_page(0);
+        assert!(result.is_ok());
+        let page = result.unwrap();
+        assert_eq!(page.data().len(), max_data);
+
+        // Test Case 2: Max allowed length + 1 (PAGE_SIZE - 7)
+        {
+            let len = (max_data + 1) as u64;
+            let mut buffer = Vec::new();
+            buffer.extend_from_slice(&len.to_le_bytes());
+            buffer.resize(PAGE_SIZE, 0);
+
+            // Write directly
+            let mut file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+            use std::io::Seek;
+            use std::io::SeekFrom;
+            use std::io::Write;
+            file.seek(SeekFrom::Start(0)).unwrap();
+            file.write_all(&buffer).unwrap();
+        }
+
+        // Should fail
+        let result = page_file.read_page(0);
+        assert!(result.is_err());
+        match result {
+            Err(PageError::Serialization(msg)) => {
+                assert!(msg.contains("Page data length"), "Unexpected: {}", msg);
+                assert!(msg.contains("exceeds maximum"), "Unexpected: {}", msg);
+            }
+            _ => panic!("Expected Serialization error, got {:?}", result),
+        }
+
+        // Test Case 3: 4GB + 1 (Simulate 32-bit truncation vulnerability)
+        // 0x100000001 = 4294967297
+        // On 32-bit, this casts to 1. If we don't check u64 first, it might pass.
+        {
+            let len: u64 = 0x100000001;
+            let mut buffer = Vec::new();
+            buffer.extend_from_slice(&len.to_le_bytes());
+            buffer.resize(PAGE_SIZE, 0);
+
+            // Write directly
+            let mut file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+            use std::io::Seek;
+            use std::io::SeekFrom;
+            use std::io::Write;
+            file.seek(SeekFrom::Start(0)).unwrap();
+            file.write_all(&buffer).unwrap();
+        }
+
+        // Should fail cleanly with our new check
+        let result = page_file.read_page(0);
+        assert!(result.is_err());
+        match result {
+            Err(PageError::Serialization(msg)) => {
+                assert!(msg.contains("Page data length"), "Unexpected: {}", msg);
+                assert!(msg.contains("exceeds maximum"), "Unexpected: {}", msg);
+                // Verify it actually printed the huge number, not the truncated one
+                assert!(
+                    msg.contains("4294967297"),
+                    "Did not detect full u64 length: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected Serialization error, got {:?}", result),
         }
     }
 }

--- a/relvar-storage/src/storage/page.rs
+++ b/relvar-storage/src/storage/page.rs
@@ -685,7 +685,8 @@ mod tests {
         assert!(result.is_err());
         match result {
             Err(PageError::Serialization(msg)) => {
-                assert!(msg.contains("Corrupted page"));
+                // 9999 > 4088 (PAGE_SIZE-8), so it hits the max size check first
+                assert!(msg.contains("exceeds maximum"));
             }
             _ => panic!("Expected Serialization error"),
         }
@@ -745,8 +746,9 @@ mod tests {
         assert!(result.is_err());
         match result {
             Err(PageError::Serialization(msg)) => {
+                // u64::MAX > PAGE_SIZE-8, so it hits the max size check first
                 assert!(
-                    msg.contains("Page length overflow"),
+                    msg.contains("exceeds maximum"),
                     "Unexpected message: {}",
                     msg
                 );

--- a/relvar-storage/src/wal/manager.rs
+++ b/relvar-storage/src/wal/manager.rs
@@ -243,18 +243,28 @@ impl WalManager {
             let len_bytes: [u8; 8] = buffer[offset..offset + 8]
                 .try_into()
                 .map_err(|_| WalError::Corrupted(lsn, "Invalid length".to_string()))?;
-            let record_len = u64::from_le_bytes(len_bytes) as usize;
+            let record_len_u64 = u64::from_le_bytes(len_bytes);
+            let record_len = usize::try_from(record_len_u64).map_err(|_| {
+                WalError::Corrupted(
+                    lsn,
+                    format!("Record length {} exceeds memory limits", record_len_u64),
+                )
+            })?;
             offset += 8;
 
             // Read record data
-            if offset + record_len > buffer.len() {
+            let end_offset = offset.checked_add(record_len).ok_or_else(|| {
+                WalError::Corrupted(lsn, "Record length causes offset overflow".to_string())
+            })?;
+
+            if end_offset > buffer.len() {
                 return Err(WalError::Corrupted(
                     lsn,
                     "Record extends beyond file".to_string(),
                 ));
             }
 
-            let record_bytes = &buffer[offset..offset + record_len];
+            let record_bytes = &buffer[offset..end_offset];
             let record = WalRecord::deserialize(record_bytes)
                 .map_err(|e| WalError::Corrupted(lsn, format!("Deserialization failed: {}", e)))?;
 
@@ -302,15 +312,26 @@ impl WalManager {
             let len_bytes: [u8; 8] = buffer[offset..offset + 8]
                 .try_into()
                 .map_err(|_| WalError::Corrupted(lsn, "Invalid length".to_string()))?;
-            let record_len = u64::from_le_bytes(len_bytes) as usize;
+            let record_len_u64 = u64::from_le_bytes(len_bytes);
+            let record_len = usize::try_from(record_len_u64).map_err(|_| {
+                WalError::Corrupted(
+                    lsn,
+                    format!("Record length {} exceeds memory limits", record_len_u64),
+                )
+            })?;
             offset += 8;
 
             // Skip record data
-            if offset + record_len > buffer.len() {
+            let end_offset = match offset.checked_add(record_len) {
+                Some(end) => end,
+                None => break, // Overflow means invalid/corrupted, treat as end of valid log
+            };
+
+            if end_offset > buffer.len() {
                 // Partial record at end - ignore it
                 break;
             }
-            offset += record_len;
+            offset = end_offset;
         }
 
         // Next LSN is last_lsn + 1
@@ -467,5 +488,68 @@ mod tests {
         assert!(matches!(records[0].1, WalRecord::Begin { .. }));
         assert!(matches!(records[1].1, WalRecord::Insert { .. }));
         assert!(matches!(records[2].1, WalRecord::Commit { .. }));
+    }
+
+    #[test]
+    fn test_wal_record_length_overflow() {
+        let temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_path_buf();
+
+        // Create a WAL file with a malicious record length
+        {
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&path)
+                .unwrap();
+
+            use std::io::Write; // Import Write trait
+
+            // Write magic header
+            file.write_all(WAL_MAGIC).unwrap();
+
+            // Write a record: LSN=1, Len=u64::MAX
+            // On 64-bit systems, u64::MAX fits in usize, but offset + len overflows.
+            // On 32-bit systems, u64::MAX exceeds usize::MAX, so try_from fails early.
+            let lsn = 1u64;
+            let bad_len = u64::MAX;
+
+            file.write_all(&lsn.to_le_bytes()).unwrap();
+            file.write_all(&bad_len.to_le_bytes()).unwrap();
+
+            // Write a few bytes of "data"
+            file.write_all(&[1, 2, 3]).unwrap();
+        }
+
+        // Open calls scan_for_last_lsn internally.
+        // It handles tail corruption by stopping, so it might return Ok.
+        let result = WalManager::open(&path);
+
+        let mut wal = match result {
+            Ok(w) => w,
+            Err(_) => return, // If it fails, that's also acceptable for this test
+        };
+
+        // However, explicit scan() should catch the corruption and return Error
+        let scan_result = wal.scan();
+
+        assert!(scan_result.is_err());
+        match scan_result {
+            Err(WalError::Corrupted(_, msg)) => {
+                // We expect "exceeds memory limits" (32-bit)
+                // OR "Record length causes offset overflow" (64-bit checked)
+                // OR "Record extends beyond file"
+                assert!(
+                    msg.contains("exceeds memory limits")
+                        || msg.contains("Record length causes offset overflow")
+                        || msg.contains("Record extends beyond file"),
+                    "Unexpected error message: {}",
+                    msg
+                );
+            }
+            Ok(_) => panic!("Expected WalError::Corrupted, got Ok"),
+            Err(e) => panic!("Expected WalError::Corrupted, got {:?}", e),
+        }
     }
 }


### PR DESCRIPTION
This PR addresses potential integer truncation and overflow vulnerabilities in the storage layer.

**Changes:**
1.  **`relvar-storage/src/storage/page.rs`**: Modified `read_page` to validate that the `u64` length prefix fits within `PAGE_SIZE - 8` *before* casting it to `usize`. This prevents a vulnerability on 32-bit systems where a length like `0x100000001` (4GB + 1) would be truncated to `1`, bypassing the buffer size check.
2.  **`relvar-storage/src/wal/manager.rs`**: Modified `scan` and `scan_for_last_lsn` to:
    - Use `usize::try_from` when converting `u64` lengths to `usize`, returning `WalError::Corrupted` on failure.
    - Use `checked_add` when calculating offsets to prevent panics (DoS) or wrap-around logic errors if a malicious record length causes overflow.

**Verification:**
- Added `test_page_file_length_boundary` to verify that `read_page` correctly rejects lengths slightly above the maximum valid payload, and specifically rejects `0x100000001` which targets 32-bit truncation.
- Added `test_wal_record_length_overflow` to verify that `WalManager` handles `u64::MAX` length prefixes by returning an error instead of panicking.


---
*PR created automatically by Jules for task [6192273975331766418](https://jules.google.com/task/6192273975331766418) started by @madmax983*