### PR TITLE
⚒️ Forge: Refactor `group` and `ungroup` operators

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,496 @@
+# Contributing to Relvar
+
+This document outlines the standards and practices for contributing to Relvar. These principles guide both human contributors and AI assistants working on the codebase.
+
+## Core Principles
+
+### 1. Strict Adherence to The Third Manifesto
+
+Relvar implements the relational model as defined by C.J. Date and Hugh Darwen in *The Third Manifesto*. All contributions must respect TTM principles:
+
+**✅ Required:**
+- No NULL values (Proscription 1)
+- No duplicate tuples (Proscription 2)
+- No ordering of tuples (Proscription 3)
+- No ordering of attributes (Proscription 4)
+- No tuple-level IDs exposed in public APIs (Proscription 6)
+- Type safety enforced
+- Relational algebra completeness
+
+**❌ Forbidden:**
+- Introducing NULL values in any form
+- Exposing physical storage details (TupleId, rowid, etc.)
+- Ordered collections where sets are required
+- SQL-isms that violate the relational model
+
+**See:** [TTM Compliance Tracker](https://github.com/madmax983/relvar/milestones) for current status and open issues.
+
+### 2. Test-Driven Development (Red-Green-Refactor)
+
+All code must follow the TDD cycle:
+
+**🔴 Red Phase:**
+- Write a failing test first
+- Test should be specific and focused
+- One test per behavior/requirement
+
+**🟢 Green Phase:**
+- Write minimal code to make the test pass
+- No extra features or optimizations yet
+- Code can be "ugly" at this stage
+
+**♻️ Refactor Phase:**
+- Clean up the code while keeping tests green
+- Extract common patterns
+- Optimize performance
+- Improve readability
+
+**Example workflow:**
+
+```bash
+# 1. Write test (Red)
+$ cargo test test_division_operator
+# Expected: test fails
+
+# 2. Implement minimal code (Green)
+$ cargo test test_division_operator
+# Expected: test passes
+
+# 3. Refactor while keeping tests green
+$ cargo test
+# Expected: all tests pass
+
+# 4. Run full quality checks
+$ cargo fmt && cargo clippy && cargo test
+```
+
+### 3. Performance-First Mindset
+
+While correctness and TTM compliance are paramount, performance matters:
+
+**Benchmarking:**
+- All new features require benchmarks
+- Benchmarks must use `iter_batched` to separate setup from measurement
+- Document performance characteristics
+- Compare against baselines
+
+**Optimization guidelines:**
+- Profile before optimizing
+- Focus on algorithmic improvements over micro-optimizations
+- Don't sacrifice TTM compliance for speed
+- Document trade-offs in comments
+
+**Performance targets:**
+- See [benches/README.md](benches/README.md) for target metrics
+- Regressions > 10% require explanation and approval
+
+## Pre-Commit Checklist
+
+Before committing, **all** of the following must pass:
+
+### 1. Code Formatting
+
+```bash
+cargo fmt --all
+```
+
+**Required:** Zero changes. Code must be formatted before commit.
+
+### 2. Linting
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+**Required:** Zero warnings. Use `#[allow(clippy::...)]` only when justified with a comment explaining why.
+
+### 3. Tests
+
+```bash
+cargo test --all-features
+```
+
+**Required:** All tests pass. No flaky tests allowed.
+
+### 4. Benchmarks (for performance-critical changes)
+
+```bash
+cargo bench --benches
+```
+
+**Required:** No regressions > 10% without justification.
+
+### Quick pre-commit command:
+
+```bash
+cargo fmt && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all-features
+```
+
+## Code Standards
+
+### Naming Conventions
+
+**Follow TTM terminology:**
+- Use "relation" not "table"
+- Use "tuple" not "row"
+- Use "attribute" not "column" or "field"
+- Use "relvar" not "table variable"
+- Use "heading" not "schema"
+- Use "body" not "rows" or "data"
+
+**Rust conventions:**
+- `snake_case` for functions and variables
+- `PascalCase` for types
+- `SCREAMING_SNAKE_CASE` for constants
+- Descriptive names over short names
+
+### Error Handling
+
+**Use `thiserror` for all errors:**
+
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum MyError {
+    #[error("Description: {0}")]
+    SomeError(String),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+```
+
+**Never use:**
+- `.unwrap()` in production code (tests are okay)
+- `.expect()` in production code (tests are okay)
+- Panics for recoverable errors
+
+### Type Safety
+
+**Leverage Rust's type system:**
+
+```rust
+// ✅ Good - distinct types
+struct WidgetId(i64);
+struct SupplierId(i64);
+
+// ❌ Bad - both are i64
+type WidgetId = i64;
+type SupplierId = i64;
+```
+
+**Use newtypes for semantic distinction:**
+- Even when backed by the same representation
+- Prevents accidental mixing of concepts
+- Critical for TTM compliance (see Issue #4)
+
+### Documentation
+
+**All public APIs require documentation:**
+
+```rust
+/// Brief one-line description.
+///
+/// Longer explanation if needed. Can include:
+/// - Use cases
+/// - Examples
+/// - Performance characteristics
+/// - TTM principles it implements
+///
+/// # Examples
+///
+/// ```
+/// let relation = Relation::new(rel_type);
+/// relation.insert(tuple)?;
+/// ```
+///
+/// # Errors
+///
+/// Returns `Err` if...
+pub fn my_function() -> Result<(), MyError> {
+    // ...
+}
+```
+
+**TTM compliance notes:**
+
+When implementing TTM features, reference the prescription/proscription:
+
+```rust
+/// Project operator (π) from relational algebra.
+///
+/// TTM: RM Prescription 7 - Relational algebra completeness.
+///
+/// Returns a relation with only the specified attributes.
+/// Duplicates are eliminated (set semantics).
+```
+
+### Testing
+
+**Test organization:**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper functions at top
+    fn create_test_relation() -> Relation {
+        // ...
+    }
+
+    // Tests grouped by feature
+    #[test]
+    fn test_basic_functionality() {
+        // Arrange
+        let relation = create_test_relation();
+
+        // Act
+        let result = relation.project(&["attr1"]);
+
+        // Assert
+        assert_eq!(result.degree(), 1);
+    }
+
+    #[test]
+    fn test_error_case() {
+        let relation = create_test_relation();
+        let result = relation.project(&["nonexistent"]);
+        assert!(result.is_err());
+    }
+}
+```
+
+**Test quality:**
+- One assertion per test when possible
+- Clear test names describing the scenario
+- Use `#[should_panic]` sparingly (prefer `assert!(result.is_err())`)
+- Test both success and failure cases
+- Test edge cases (empty relations, single tuple, etc.)
+
+### Benchmarking
+
+**All benchmarks must separate setup from measurement:**
+
+```rust
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+
+fn bench_operation(c: &mut Criterion) {
+    c.bench_function("operation", |b| {
+        b.iter_batched(
+            || {
+                // Setup (not measured)
+                create_test_data()
+            },
+            |data| {
+                // Operation being measured
+                perform_operation(black_box(data))
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+```
+
+**Why:** Including setup in the measurement loop skews results. We want to measure the operation, not file I/O or allocation.
+
+## Git Workflow
+
+### Commits
+
+**Commit message format:**
+
+```
+Brief summary (50 chars or less)
+
+Longer explanation if needed (wrap at 72 chars). Explain:
+- Why the change was made
+- What problem it solves
+- Any TTM principles it addresses
+
+Fixes #123
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+```
+
+**Commit granularity:**
+- One logical change per commit
+- Tests and implementation in the same commit
+- Don't commit broken code (all checks must pass)
+
+### Pull Requests
+
+**PR checklist:**
+
+- [ ] All pre-commit checks pass
+- [ ] New tests added for new functionality
+- [ ] Benchmarks added for performance-critical code
+- [ ] Documentation updated
+- [ ] TTM compliance verified
+- [ ] No regressions in existing tests or benchmarks
+
+**PR description should include:**
+- What changes were made
+- Why they were made
+- Which TTM principles are relevant
+- Performance impact (if any)
+- Breaking changes (if any)
+
+### Branches
+
+**Branch naming:**
+- `feature/short-description` - New features
+- `fix/issue-number-description` - Bug fixes
+- `ttm/issue-number-description` - TTM compliance work
+- `perf/short-description` - Performance improvements
+
+## TTM Compliance Workflow
+
+When working on TTM compliance issues:
+
+1. **Read the issue carefully**
+   - Understand which prescription/proscription is violated
+   - Review relevant TTM sections
+   - Check for related issues
+
+2. **Write tests that enforce TTM compliance**
+   - Tests should fail if TTM is violated
+   - Tests should pass when compliant
+
+3. **Implement the fix**
+   - Follow TDD (Red-Green-Refactor)
+   - May require significant refactoring
+   - Don't break existing functionality
+
+4. **Verify no new violations**
+   - Run full test suite
+   - Check that fix doesn't introduce new TTM violations
+   - Update compliance documentation if needed
+
+5. **Benchmark if relevant**
+   - Some TTM compliance work impacts performance
+   - Document any trade-offs
+
+## Performance Optimization Workflow
+
+When optimizing performance:
+
+1. **Profile first**
+   - Use `cargo flamegraph` or similar
+   - Identify actual bottlenecks
+   - Don't optimize based on guesses
+
+2. **Write benchmark**
+   - Establish baseline
+   - Use `iter_batched` to isolate measurement
+   - Document expected improvement
+
+3. **Optimize**
+   - Focus on algorithmic improvements
+   - Don't sacrifice correctness for speed
+   - Don't violate TTM principles
+
+4. **Verify**
+   - Re-run benchmarks
+   - Ensure tests still pass
+   - Document the optimization
+
+5. **Document trade-offs**
+   - If optimization adds complexity, explain why
+   - If it makes code less clear, add comments
+   - Quantify the performance gain
+
+## Common Patterns
+
+### Creating a new relational operator
+
+```rust
+// 1. Define trait in src/algebra/
+pub trait MyOperatorOps {
+    fn my_operator(&self, args: Args) -> Result<Relation, MyOpError>;
+}
+
+// 2. Implement for Relation
+impl MyOperatorOps for Relation {
+    fn my_operator(&self, args: Args) -> Result<Relation, MyOpError> {
+        // Implementation
+    }
+}
+
+// 3. Write comprehensive tests
+#[cfg(test)]
+mod tests {
+    // Test normal cases
+    // Test edge cases
+    // Test error cases
+    // Test TTM compliance
+}
+
+// 4. Add benchmarks
+// In benches/algebra.rs
+fn bench_my_operator(c: &mut Criterion) {
+    // Benchmark implementation
+}
+```
+
+### Adding a constraint type
+
+```rust
+// 1. Define error type
+#[derive(Debug, Error)]
+pub enum MyConstraintError {
+    #[error("Constraint violated: {0}")]
+    Violation(String),
+}
+
+// 2. Define constraint struct
+#[derive(Debug, Clone)]
+pub struct MyConstraint {
+    // Fields
+}
+
+impl MyConstraint {
+    pub fn new(params: Params) -> Result<Self, MyConstraintError> {
+        // Validation
+    }
+
+    pub fn is_satisfied_by(&self, value: &T) -> Result<bool, MyConstraintError> {
+        // Check logic
+    }
+}
+
+// 3. Integrate with Database
+// Add to constraint checking in insert/update/delete
+
+// 4. Test thoroughly
+#[cfg(test)]
+mod tests {
+    // Test validation
+    // Test enforcement
+    // Test error messages
+}
+```
+
+## Questions?
+
+- Check existing issues and PRs
+- Review TTM compliance documentation
+- Look at similar code in the codebase
+- Ask in discussions
+
+## Resources
+
+- [The Third Manifesto](http://www.thethirdmanifesto.com/)
+- [TTM Compliance Tracker](https://github.com/madmax983/relvar/milestones)
+- [Benchmark Documentation](benches/README.md)
+- [Database in Depth](https://www.oreilly.com/library/view/database-in-depth/0596100124/) by C.J. Date
+
+---
+
+**Remember:** Correctness > Performance > Cleverness
+
+Build it right, make it fast, keep it simple.
+
 ## 2024-05-22 - Database God Object and Inconsistent Validation
 **Learning:** `relvar-core/src/database.rs` is becoming a "God Object," handling all constraint logic (keys, FKs, checks, types) alongside transaction management and query execution. Additionally, `update` operations appear to bypass Type and Check constraints, unlike `insert`.
 **Action:** Future refactors should consider extracting constraint validation into a dedicated `ConstraintValidator` or `IntegrityManager` component.
@@ -29,3 +522,7 @@
 ## 2024-05-29 - Summarize Logic De-Duplication
 **Learning:** `relvar-core/src/algebra/summarize.rs` contained complex logic within `Aggregation::compute` (large match block) and `Relation::summarize` (validation, construction, execution). Extracting these into helper functions (`compute_sum`, `compute_avg`, `validate_grouping_attributes`, etc.) significantly improved readability and reduced cognitive load.
 **Action:** When a method performs multiple distinct phases (e.g., validate -> prepare -> execute) or contains a large `match` statement with complex arms, extract each phase or arm into a private helper method.
+
+## 2025-06-03 - Algebraic Operator Refactoring
+**Learning:** Complex algebraic operators like `group` and `ungroup` often mix validation, schema derivation, and tuple processing. Extracting these into distinct phases (`validate`, `build_heading`, `compute_tuples`) improves readability and testability.
+**Action:** Apply this "Three-Phase Operator" pattern when refactoring other complex operators like `join` or `summarize`.

--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -102,112 +102,22 @@ impl Relation {
     /// - [`GroupError::AllAttributesGrouped`] - No grouping key attributes remain
     /// - [`GroupError::ResultAttributeExists`] - RVA name conflicts
     pub fn group(&self, attrs_to_group: &[&str], rva_name: &str) -> Result<Relation, GroupError> {
-        if attrs_to_group.is_empty() {
-            return Err(GroupError::NoAttributesSpecified);
-        }
+        // 1. Validate request and determine grouping attributes
+        let grouping_attrs = validate_group_request(self, attrs_to_group, rva_name)?;
 
-        // Validate all attributes exist
-        for attr in attrs_to_group {
-            if !self.relation_type().has_attribute(attr) {
-                return Err(GroupError::AttributeNotFound(attr.to_string()));
-            }
-        }
+        // 2. Build result and RVA headings
+        let (result_heading, rva_heading) =
+            build_group_result_heading(self, &grouping_attrs, attrs_to_group, rva_name)?;
 
-        // Check that we're not grouping all attributes
-        if attrs_to_group.len() == self.relation_type().degree() {
-            return Err(GroupError::AllAttributesGrouped);
-        }
-
-        // Determine grouping attributes (the ones NOT being grouped into RVA)
-        let all_attrs: Vec<String> = self
-            .relation_type()
-            .tuple_type()
-            .attribute_names()
-            .map(|s| s.to_string())
-            .collect();
-        let grouping_attrs: Vec<String> = all_attrs
-            .iter()
-            .filter(|attr| !attrs_to_group.contains(&attr.as_str()))
-            .cloned()
-            .collect();
-
-        // Build result heading
-        let mut result_heading = TupleType::new();
-
-        // Add grouping attributes
-        for attr in &grouping_attrs {
-            let attr_type = self
-                .relation_type()
-                .tuple_type()
-                .get_attribute_type(attr)
-                .unwrap();
-            result_heading = result_heading.with_attribute(attr.clone(), attr_type.clone());
-        }
-
-        // Check RVA name doesn't conflict
-        if result_heading.has_attribute(rva_name) {
-            return Err(GroupError::ResultAttributeExists(rva_name.to_string()));
-        }
-
-        // Build RVA heading (from attributes being grouped)
-        let mut rva_heading = TupleType::new();
-        for attr in attrs_to_group {
-            let attr_type = self
-                .relation_type()
-                .tuple_type()
-                .get_attribute_type(attr)
-                .unwrap();
-            rva_heading = rva_heading.with_attribute(attr.to_string(), attr_type.clone());
-        }
-
-        // Add RVA to result heading
-        result_heading = result_heading.with_attribute(
-            rva_name.to_string(),
-            ScalarType::Relation(Box::new(RelationType::new(rva_heading.clone()))),
-        );
-
-        // Group tuples
-        let mut groups: HashMap<Vec<ScalarValue>, Vec<Tuple>> = HashMap::new();
-
-        for tuple in self.tuples() {
-            // Extract grouping key
-            let key: Vec<ScalarValue> = grouping_attrs
-                .iter()
-                .map(|attr| tuple.get(attr).unwrap().clone())
-                .collect();
-
-            // Extract grouped attributes for RVA
-            let mut rva_values = HashMap::new();
-            for attr in attrs_to_group {
-                rva_values.insert(attr.to_string(), tuple.get(attr).unwrap().clone());
-            }
-
-            let rva_tuple = Tuple::new(rva_heading.clone(), rva_values)
-                .map_err(|e| GroupError::TupleCreation(e.to_string()))?;
-
-            groups.entry(key).or_default().push(rva_tuple);
-        }
-
-        // Build result tuples
-        let mut result_tuples = Vec::new();
-        for (key, rva_tuples) in groups {
-            let mut values = HashMap::new();
-
-            // Add grouping attribute values
-            for (i, attr) in grouping_attrs.iter().enumerate() {
-                values.insert(attr.clone(), key[i].clone());
-            }
-
-            // Create RVA relation
-            let rva_relation =
-                Relation::from_tuples(RelationType::new(rva_heading.clone()), rva_tuples)
-                    .map_err(|e| GroupError::TupleCreation(e.to_string()))?;
-            values.insert(rva_name.to_string(), ScalarValue::Relation(rva_relation));
-
-            let tuple = Tuple::new(result_heading.clone(), values)
-                .map_err(|e| GroupError::TupleCreation(e.to_string()))?;
-            result_tuples.push(tuple);
-        }
+        // 3. Compute grouped tuples
+        let result_tuples = compute_grouped_tuples(
+            self,
+            &grouping_attrs,
+            attrs_to_group,
+            &result_heading,
+            &rva_heading,
+            rva_name,
+        )?;
 
         Ok(
             Relation::from_tuples(RelationType::new(result_heading), result_tuples)
@@ -234,89 +144,258 @@ impl Relation {
     /// - [`UngroupError::AttributeNotFound`] - The attribute doesn't exist
     /// - [`UngroupError::NotRelationValued`] - The attribute is not an RVA
     pub fn ungroup(&self, rva_name: &str) -> Result<Relation, UngroupError> {
-        // Check attribute exists
-        if !self.relation_type().has_attribute(rva_name) {
-            return Err(UngroupError::AttributeNotFound(rva_name.to_string()));
-        }
+        // 1. Validate request and get RVA type
+        let rva_relation_type = validate_ungroup_request(self, rva_name)?;
 
-        // Get the RVA type
-        let rva_type = self
-            .relation_type()
-            .tuple_type()
-            .get_attribute_type(rva_name)
-            .unwrap();
+        // 2. Build result heading
+        let result_heading = build_ungroup_result_heading(self, rva_name, &rva_relation_type)?;
 
-        let rva_relation_type = match rva_type {
-            ScalarType::Relation(rel_type) => rel_type.as_ref(),
-            _ => return Err(UngroupError::NotRelationValued(rva_name.to_string())),
-        };
-
-        // Build result heading (non-RVA attributes + RVA's attributes)
-        let mut result_heading = TupleType::new();
-
-        // Add non-RVA attributes
-        for attr_name in self.relation_type().tuple_type().attribute_names() {
-            if attr_name != rva_name {
-                let attr_type = self
-                    .relation_type()
-                    .tuple_type()
-                    .get_attribute_type(attr_name)
-                    .unwrap();
-                result_heading =
-                    result_heading.with_attribute(attr_name.to_string(), attr_type.clone());
-            }
-        }
-
-        // Add RVA's attributes
-        for attr_name in rva_relation_type.tuple_type().attribute_names() {
-            let attr_type = rva_relation_type
-                .tuple_type()
-                .get_attribute_type(attr_name)
-                .unwrap();
-            result_heading =
-                result_heading.with_attribute(attr_name.to_string(), attr_type.clone());
-        }
-
-        // Ungroup tuples
-        let mut result_tuples = Vec::new();
-
-        for tuple in self.tuples() {
-            // Get the RVA relation
-            let rva_relation = match tuple.get(rva_name).unwrap() {
-                ScalarValue::Relation(rel) => rel,
-                _ => return Err(UngroupError::NotRelationValued(rva_name.to_string())),
-            };
-
-            // For each tuple in the RVA, create a new tuple combining non-RVA and RVA attributes
-            for rva_tuple in rva_relation.tuples() {
-                let mut values = HashMap::new();
-
-                // Add non-RVA attribute values
-                for attr_name in self.relation_type().tuple_type().attribute_names() {
-                    if attr_name != rva_name {
-                        values.insert(attr_name.to_string(), tuple.get(attr_name).unwrap().clone());
-                    }
-                }
-
-                // Add RVA tuple's attribute values
-                for attr_name in rva_relation_type.tuple_type().attribute_names() {
-                    values.insert(
-                        attr_name.to_string(),
-                        rva_tuple.get(attr_name).unwrap().clone(),
-                    );
-                }
-
-                let result_tuple = Tuple::new(result_heading.clone(), values)
-                    .map_err(|e| UngroupError::TupleCreation(e.to_string()))?;
-                result_tuples.push(result_tuple);
-            }
-        }
+        // 3. Compute ungrouped tuples
+        let result_tuples =
+            compute_ungrouped_tuples(self, rva_name, &result_heading, &rva_relation_type)?;
 
         Ok(
             Relation::from_tuples(RelationType::new(result_heading), result_tuples)
                 .expect("Ungrouped tuples should conform to result relation type"),
         )
     }
+}
+
+// --- Private Helper Functions for Group ---
+
+fn validate_group_request(
+    relation: &Relation,
+    attrs_to_group: &[&str],
+    rva_name: &str,
+) -> Result<Vec<String>, GroupError> {
+    if attrs_to_group.is_empty() {
+        return Err(GroupError::NoAttributesSpecified);
+    }
+
+    // Validate all attributes exist
+    for attr in attrs_to_group {
+        if !relation.relation_type().has_attribute(attr) {
+            return Err(GroupError::AttributeNotFound(attr.to_string()));
+        }
+    }
+
+    // Check that we're not grouping all attributes
+    if attrs_to_group.len() == relation.relation_type().degree() {
+        return Err(GroupError::AllAttributesGrouped);
+    }
+
+    // Determine grouping attributes (the ones NOT being grouped into RVA)
+    let all_attrs: Vec<String> = relation
+        .relation_type()
+        .tuple_type()
+        .attribute_names()
+        .map(|s| s.to_string())
+        .collect();
+    let grouping_attrs: Vec<String> = all_attrs
+        .iter()
+        .filter(|attr| !attrs_to_group.contains(&attr.as_str()))
+        .cloned()
+        .collect();
+
+    // Check RVA name doesn't conflict with grouping attributes
+    // Note: We check against the resulting heading, which contains grouping attributes + RVA name
+    // If rva_name is one of the grouping attributes, that's a conflict.
+    if grouping_attrs.contains(&rva_name.to_string()) {
+        return Err(GroupError::ResultAttributeExists(rva_name.to_string()));
+    }
+
+    Ok(grouping_attrs)
+}
+
+fn build_group_result_heading(
+    relation: &Relation,
+    grouping_attrs: &[String],
+    attrs_to_group: &[&str],
+    rva_name: &str,
+) -> Result<(TupleType, TupleType), GroupError> {
+    // Build result heading
+    let mut result_heading = TupleType::new();
+
+    // Add grouping attributes
+    for attr in grouping_attrs {
+        let attr_type = relation
+            .relation_type()
+            .tuple_type()
+            .get_attribute_type(attr)
+            .unwrap();
+        result_heading = result_heading.with_attribute(attr.clone(), attr_type.clone());
+    }
+
+    // Build RVA heading (from attributes being grouped)
+    let mut rva_heading = TupleType::new();
+    for attr in attrs_to_group {
+        let attr_type = relation
+            .relation_type()
+            .tuple_type()
+            .get_attribute_type(attr)
+            .unwrap();
+        rva_heading = rva_heading.with_attribute(attr.to_string(), attr_type.clone());
+    }
+
+    // Add RVA to result heading
+    result_heading = result_heading.with_attribute(
+        rva_name.to_string(),
+        ScalarType::Relation(Box::new(RelationType::new(rva_heading.clone()))),
+    );
+
+    Ok((result_heading, rva_heading))
+}
+
+fn compute_grouped_tuples(
+    relation: &Relation,
+    grouping_attrs: &[String],
+    attrs_to_group: &[&str],
+    result_heading: &TupleType,
+    rva_heading: &TupleType,
+    rva_name: &str,
+) -> Result<Vec<Tuple>, GroupError> {
+    let mut groups: HashMap<Vec<ScalarValue>, Vec<Tuple>> = HashMap::new();
+
+    for tuple in relation.tuples() {
+        // Extract grouping key
+        let key: Vec<ScalarValue> = grouping_attrs
+            .iter()
+            .map(|attr| tuple.get(attr).unwrap().clone())
+            .collect();
+
+        // Extract grouped attributes for RVA
+        let mut rva_values = HashMap::new();
+        for attr in attrs_to_group {
+            rva_values.insert(attr.to_string(), tuple.get(attr).unwrap().clone());
+        }
+
+        let rva_tuple = Tuple::new(rva_heading.clone(), rva_values)
+            .map_err(|e| GroupError::TupleCreation(e.to_string()))?;
+
+        groups.entry(key).or_default().push(rva_tuple);
+    }
+
+    // Build result tuples
+    let mut result_tuples = Vec::new();
+    for (key, rva_tuples) in groups {
+        let mut values = HashMap::new();
+
+        // Add grouping attribute values
+        for (i, attr) in grouping_attrs.iter().enumerate() {
+            values.insert(attr.clone(), key[i].clone());
+        }
+
+        // Create RVA relation
+        let rva_relation =
+            Relation::from_tuples(RelationType::new(rva_heading.clone()), rva_tuples)
+                .map_err(|e| GroupError::TupleCreation(e.to_string()))?;
+        values.insert(rva_name.to_string(), ScalarValue::Relation(rva_relation));
+
+        let tuple = Tuple::new(result_heading.clone(), values)
+            .map_err(|e| GroupError::TupleCreation(e.to_string()))?;
+        result_tuples.push(tuple);
+    }
+
+    Ok(result_tuples)
+}
+
+// --- Private Helper Functions for Ungroup ---
+
+fn validate_ungroup_request(
+    relation: &Relation,
+    rva_name: &str,
+) -> Result<RelationType, UngroupError> {
+    // Check attribute exists
+    if !relation.relation_type().has_attribute(rva_name) {
+        return Err(UngroupError::AttributeNotFound(rva_name.to_string()));
+    }
+
+    // Get the RVA type
+    let rva_type = relation
+        .relation_type()
+        .tuple_type()
+        .get_attribute_type(rva_name)
+        .unwrap();
+
+    match rva_type {
+        ScalarType::Relation(rel_type) => Ok(*rel_type.clone()),
+        _ => Err(UngroupError::NotRelationValued(rva_name.to_string())),
+    }
+}
+
+fn build_ungroup_result_heading(
+    relation: &Relation,
+    rva_name: &str,
+    rva_relation_type: &RelationType,
+) -> Result<TupleType, UngroupError> {
+    let mut result_heading = TupleType::new();
+
+    // Add non-RVA attributes
+    for attr_name in relation.relation_type().tuple_type().attribute_names() {
+        if attr_name != rva_name {
+            let attr_type = relation
+                .relation_type()
+                .tuple_type()
+                .get_attribute_type(attr_name)
+                .unwrap();
+            result_heading =
+                result_heading.with_attribute(attr_name.to_string(), attr_type.clone());
+        }
+    }
+
+    // Add RVA's attributes
+    for attr_name in rva_relation_type.tuple_type().attribute_names() {
+        let attr_type = rva_relation_type
+            .tuple_type()
+            .get_attribute_type(attr_name)
+            .unwrap();
+        result_heading = result_heading.with_attribute(attr_name.to_string(), attr_type.clone());
+    }
+
+    Ok(result_heading)
+}
+
+fn compute_ungrouped_tuples(
+    relation: &Relation,
+    rva_name: &str,
+    result_heading: &TupleType,
+    rva_relation_type: &RelationType,
+) -> Result<Vec<Tuple>, UngroupError> {
+    let mut result_tuples = Vec::new();
+
+    for tuple in relation.tuples() {
+        // Get the RVA relation
+        let rva_relation = match tuple.get(rva_name).unwrap() {
+            ScalarValue::Relation(rel) => rel,
+            _ => return Err(UngroupError::NotRelationValued(rva_name.to_string())),
+        };
+
+        // For each tuple in the RVA, create a new tuple combining non-RVA and RVA attributes
+        for rva_tuple in rva_relation.tuples() {
+            let mut values = HashMap::new();
+
+            // Add non-RVA attribute values
+            for attr_name in relation.relation_type().tuple_type().attribute_names() {
+                if attr_name != rva_name {
+                    values.insert(attr_name.to_string(), tuple.get(attr_name).unwrap().clone());
+                }
+            }
+
+            // Add RVA tuple's attribute values
+            for attr_name in rva_relation_type.tuple_type().attribute_names() {
+                values.insert(
+                    attr_name.to_string(),
+                    rva_tuple.get(attr_name).unwrap().clone(),
+                );
+            }
+
+            let result_tuple = Tuple::new(result_heading.clone(), values)
+                .map_err(|e| UngroupError::TupleCreation(e.to_string()))?;
+            result_tuples.push(result_tuple);
+        }
+    }
+
+    Ok(result_tuples)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
*   🚮 **Smell:** The `group` and `ungroup` methods in `relvar-core/src/algebra/group.rs` were becoming "God Functions", mixing validation, schema construction, and tuple processing logic.
*   ✨ **Solution:** Extracted logic into private helper functions: `validate_group_request`, `build_group_result_heading`, `compute_grouped_tuples`, and their `ungroup` counterparts.
*   🧼 **Benefit:** Improves readability by separating concerns (Validation vs Construction vs Execution) and flattening the structure.
*   🛡️ **Verification:** Tests passed. No logic changed. Checked with `cargo fmt` and `cargo clippy`.
*   TTM: Maintains strict adherence to set semantics and type safety.

---
*PR created automatically by Jules for task [5313364526854822047](https://jules.google.com/task/5313364526854822047) started by @madmax983*