### PR TITLE
🔒 Warden: Fix ScalarValue Deserialization DoS

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -136,3 +136,18 @@ Although `ScalarType::user_defined` constructor enforced `MAX_TYPE_DEPTH`, `Scal
 2. Enforced strict limits `MAX_STRING_LEN` (1MB) and `MAX_BYTES_LEN` (1MB) during streaming parsing.
 3. Added `ImporterError::LimitExceeded` to report violations.
 4. Added `relvar/tests/warden_json_import.rs` to verify limits and recursion safety.
+
+## 2026-02-13 - ScalarValue Inconsistency and Stack Overflow
+**Threat:**
+`ScalarValue` deserialization blindly trusted the input structure without validating type consistency. This allowed constructing:
+1. Inconsistent values: `UserDefined(Int)` containing `String`.
+2. Invalid recursion: `UserDefined(Int)` containing `UserDefined(...)` (which claims to be `Int` but is structurally recursive).
+This bypassed `ScalarType` depth limits, enabling stack overflow attacks via deep recursion in `Drop`, `PartialEq`, etc.
+
+**Defense:**
+1. Implemented `ScalarValueUnchecked` private enum for raw deserialization.
+2. Implemented `TryFrom<ScalarValueUnchecked> for ScalarValue` which enforces:
+   - `UserDefined` values must have a `UserDefined` type definition.
+   - The inner `value` must match the `type_def` representation.
+3. Updated `ScalarValue` to use `#[serde(try_from = ...)]`.
+This ensures all deserialized values are structurally sound and respect the depth limits inherent in their type definitions.

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -28,6 +28,7 @@
 
 use crate::types::ScalarType;
 use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 use thiserror::Error;
 
 /// Errors that can occur during scalar value operations.
@@ -80,6 +81,7 @@ pub enum ScalarValueError {
 /// assert!(value.is_type(&ScalarType::Int));
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "ScalarValueUnchecked")]
 pub enum ScalarValue {
     /// 64-bit signed integer value.
     Int(i64),
@@ -390,6 +392,68 @@ impl Ord for ScalarValue {
                 }
             }
             other => other,
+        }
+    }
+}
+
+// Private structure to assist with deserialization and validation.
+// This allows us to intercept deserialization and enforce type consistency and depth limits.
+#[derive(Debug, Deserialize)]
+enum ScalarValueUnchecked {
+    Int(i64),
+    Float(f64),
+    String(String),
+    Bool(bool),
+    Bytes(Vec<u8>),
+    Relation(crate::values::Relation),
+    UserDefined {
+        type_def: ScalarType,
+        value: Box<ScalarValueUnchecked>,
+    },
+}
+
+impl TryFrom<ScalarValueUnchecked> for ScalarValue {
+    type Error = String;
+
+    fn try_from(unchecked: ScalarValueUnchecked) -> Result<Self, Self::Error> {
+        match unchecked {
+            ScalarValueUnchecked::Int(v) => Ok(ScalarValue::Int(v)),
+            ScalarValueUnchecked::Float(v) => Ok(ScalarValue::Float(v)),
+            ScalarValueUnchecked::String(v) => Ok(ScalarValue::String(v)),
+            ScalarValueUnchecked::Bool(v) => Ok(ScalarValue::Bool(v)),
+            ScalarValueUnchecked::Bytes(v) => Ok(ScalarValue::Bytes(v)),
+            ScalarValueUnchecked::Relation(v) => Ok(ScalarValue::Relation(v)),
+            ScalarValueUnchecked::UserDefined { type_def, value } => {
+                // First, ensure the type definition itself is a UserDefined type.
+                // A ScalarValue::UserDefined variant must have a ScalarType::UserDefined type definition.
+                // It makes no sense to have ScalarValue::UserDefined { type_def: Int, ... }.
+                let representation = match &type_def {
+                    ScalarType::UserDefined { representation, .. } => representation,
+                    _ => {
+                        return Err(format!(
+                            "Invalid UserDefined value: type definition must be UserDefined, got {}",
+                            type_def.name()
+                        ));
+                    }
+                };
+
+                // Recursively convert and validate the inner value
+                let inner_value = ScalarValue::try_from(*value)?;
+
+                // Enforce type consistency: inner value MUST match the representation type
+                if !inner_value.is_type(representation) {
+                    return Err(format!(
+                        "Type mismatch in UserDefined value: type definition expects {}, but value is {}",
+                        representation.name(),
+                        inner_value.scalar_type().name()
+                    ));
+                }
+
+                Ok(ScalarValue::UserDefined {
+                    type_def,
+                    value: Box::new(inner_value),
+                })
+            }
         }
     }
 }

--- a/relvar-core/tests/warden_exploit_scalar_value_deserialization.rs
+++ b/relvar-core/tests/warden_exploit_scalar_value_deserialization.rs
@@ -7,8 +7,8 @@ fn test_scalar_value_deserialization_stack_overflow() {
     // { "UserDefined": { "type_def": "Int", "value": { "UserDefined": ... } } }
 
     let depth = 200; // Enough to potential stack overflow if deserializer is naive,
-                     // but small enough to build quickly for this test.
-                     // Real exploit would use much larger depth.
+    // but small enough to build quickly for this test.
+    // Real exploit would use much larger depth.
 
     let mut current = json!({"Int": 42});
 
@@ -33,6 +33,9 @@ fn test_scalar_value_deserialization_stack_overflow() {
         // Verify depth is actually deep
         // We can't easily check depth without a method, but we can assert we got a value
         // The fix should make this return Err.
-        panic!("Deserialization succeeded for deeply nested value (depth {})", depth);
+        panic!(
+            "Deserialization succeeded for deeply nested value (depth {})",
+            depth
+        );
     }
 }

--- a/relvar-core/tests/warden_exploit_scalar_value_deserialization.rs
+++ b/relvar-core/tests/warden_exploit_scalar_value_deserialization.rs
@@ -1,0 +1,38 @@
+use relvar_core::values::ScalarValue;
+use serde_json::json;
+
+#[test]
+fn test_scalar_value_deserialization_stack_overflow() {
+    // Construct a deeply nested JSON that mimics ScalarValue::UserDefined
+    // { "UserDefined": { "type_def": "Int", "value": { "UserDefined": ... } } }
+
+    let depth = 200; // Enough to potential stack overflow if deserializer is naive,
+                     // but small enough to build quickly for this test.
+                     // Real exploit would use much larger depth.
+
+    let mut current = json!({"Int": 42});
+
+    for _ in 0..depth {
+        current = json!({
+            "UserDefined": {
+                "type_def": "Int", // Valid type def
+                "value": current   // Recursive nesting ignoring type def
+            }
+        });
+    }
+
+    let json_str = current.to_string();
+
+    // This should fail or error out if we have depth protection.
+    // If not, it might succeed (creating an invalid value) or panic/overflow.
+    let result: Result<ScalarValue, _> = serde_json::from_str(&json_str);
+
+    // If it succeeds, we have a problem because we created a value with depth > MAX_TYPE_DEPTH (64)
+    // and which violates the type system (UserDefined(Int) wrapping UserDefined...)
+    if let Ok(_val) = result {
+        // Verify depth is actually deep
+        // We can't easily check depth without a method, but we can assert we got a value
+        // The fix should make this return Err.
+        panic!("Deserialization succeeded for deeply nested value (depth {})", depth);
+    }
+}

--- a/relvar-core/tests/warden_exploit_scalar_value_inconsistency.rs
+++ b/relvar-core/tests/warden_exploit_scalar_value_inconsistency.rs
@@ -27,7 +27,11 @@ fn test_scalar_value_inconsistency() {
 
             // The current error for this specific payload:
             // "Invalid UserDefined value: type definition must be UserDefined, got Int"
-            assert!(msg.contains("Invalid UserDefined value") || msg.contains("Type mismatch"), "Unexpected error message: {}", msg);
+            assert!(
+                msg.contains("Invalid UserDefined value") || msg.contains("Type mismatch"),
+                "Unexpected error message: {}",
+                msg
+            );
         }
     }
 }

--- a/relvar-core/tests/warden_exploit_scalar_value_inconsistency.rs
+++ b/relvar-core/tests/warden_exploit_scalar_value_inconsistency.rs
@@ -1,0 +1,33 @@
+use relvar_core::values::ScalarValue;
+use serde_json::json;
+
+#[test]
+fn test_scalar_value_inconsistency() {
+    // Construct a UserDefined value where the type says "Int"
+    // but the value is actually a "String".
+    // { "UserDefined": { "type_def": "Int", "value": { "String": "Not an Int" } } }
+
+    let json_val = json!({
+        "UserDefined": {
+            "type_def": "Int",
+            "value": { "String": "Not an Int" }
+        }
+    });
+
+    let result: Result<ScalarValue, _> = serde_json::from_value(json_val);
+
+    // This MUST fail now due to ScalarValue::try_from validation
+    match result {
+        Ok(_) => panic!("Deserialization should have failed due to type mismatch"),
+        Err(e) => {
+            let msg = e.to_string();
+            // We verify the error message contains the expected reason.
+            // Since type_def is "Int" (not UserDefined), it should fail with "Invalid UserDefined value".
+            // If type_def was a valid UserDefined type wrapping Int, it would fail with "Type mismatch".
+
+            // The current error for this specific payload:
+            // "Invalid UserDefined value: type definition must be UserDefined, got Int"
+            assert!(msg.contains("Invalid UserDefined value") || msg.contains("Type mismatch"), "Unexpected error message: {}", msg);
+        }
+    }
+}

--- a/relvar-core/tests/warden_exploit_scalar_value_mismatch.rs
+++ b/relvar-core/tests/warden_exploit_scalar_value_mismatch.rs
@@ -1,0 +1,33 @@
+use relvar_core::values::ScalarValue;
+use serde_json::json;
+
+#[test]
+fn test_scalar_value_mismatch() {
+    // Construct a UserDefined value where the type is properly defined (UserDefined(Int))
+    // but the value does not match (String).
+
+    let json_val = json!({
+        "UserDefined": {
+            "type_def": {
+                "UserDefined": {
+                    "name": "MyType",
+                    "representation": "Int"
+                }
+            },
+            "value": { "String": "Not an Int" }
+        }
+    });
+
+    let result: Result<ScalarValue, _> = serde_json::from_value(json_val);
+
+    match result {
+        Ok(_) => panic!("Deserialization should have failed due to type mismatch"),
+        Err(e) => {
+            let msg = e.to_string();
+            // Expected: "Type mismatch in UserDefined value: type definition expects Int, but value is String"
+            assert!(msg.contains("Type mismatch"), "Unexpected error message: {}", msg);
+            assert!(msg.contains("expects Int"), "Error should mention expected type");
+            assert!(msg.contains("value is String"), "Error should mention actual type");
+        }
+    }
+}

--- a/relvar-core/tests/warden_exploit_scalar_value_mismatch.rs
+++ b/relvar-core/tests/warden_exploit_scalar_value_mismatch.rs
@@ -25,9 +25,19 @@ fn test_scalar_value_mismatch() {
         Err(e) => {
             let msg = e.to_string();
             // Expected: "Type mismatch in UserDefined value: type definition expects Int, but value is String"
-            assert!(msg.contains("Type mismatch"), "Unexpected error message: {}", msg);
-            assert!(msg.contains("expects Int"), "Error should mention expected type");
-            assert!(msg.contains("value is String"), "Error should mention actual type");
+            assert!(
+                msg.contains("Type mismatch"),
+                "Unexpected error message: {}",
+                msg
+            );
+            assert!(
+                msg.contains("expects Int"),
+                "Error should mention expected type"
+            );
+            assert!(
+                msg.contains("value is String"),
+                "Error should mention actual type"
+            );
         }
     }
 }


### PR DESCRIPTION
This PR addresses a security vulnerability where `ScalarValue` could be deserialized into an invalid or deeply nested state, bypassing the type system's depth limits.

**Threat:**
An attacker could craft a malicious JSON/Bincode payload that constructs a `ScalarValue` with infinite recursion (e.g., a `UserDefined` value wrapping another `UserDefined` value ad infinitum, even if the type definition claims it wraps an `Int`). This would cause a stack overflow (DoS) when the value is dropped or compared. Alternatively, inconsistent types (e.g., `Int` type wrapping a `String` value) could cause logic errors or panics in consumers.

**Defense:**
- Introduced a private `ScalarValueUnchecked` enum for raw deserialization.
- Implemented `TryFrom<ScalarValueUnchecked> for ScalarValue` to validate the structure.
- Enforced that `UserDefined` values must have a `UserDefined` type definition.
- Enforced that the inner value of a `UserDefined` type strictly matches the type definition's representation.
- This leverages the existing `MAX_TYPE_DEPTH` check in `ScalarType` to effectively bound the depth of `ScalarValue`.

**Verification:**
- Added `relvar-core/tests/warden_exploit_scalar_value_inconsistency.rs`: Verifies that inconsistent types (Int vs String) are rejected.
- Added `relvar-core/tests/warden_exploit_scalar_value_mismatch.rs`: Verifies that valid UserDefined types with wrong value types are rejected.
- Validated that deeply nested recursive structures are rejected or caught by `serde` limits.

---
*PR created automatically by Jules for task [16889016256559285881](https://jules.google.com/task/16889016256559285881) started by @madmax983*