### PR TITLE
🗺️ Atlas: Decouple Database from Views and Queries

### DIFF
--- a/relvar-core/src/database/mod.rs
+++ b/relvar-core/src/database/mod.rs
@@ -74,6 +74,7 @@ use crate::constraints::{
 };
 pub use crate::error::DatabaseError;
 use crate::storage_engine::StorageEngine;
+use crate::traits::QueryExecutor;
 use crate::types::RelationType;
 use crate::values::{Relation, Tuple};
 
@@ -132,7 +133,13 @@ pub struct Database<E: StorageEngine> {
     /// Transaction savepoint.
     transaction_snapshot: Option<E::Snapshot>,
     /// Virtual relvars defined by expressions.
-    virtual_relvars: HashMap<String, VirtualRelvarDefinition<E>>,
+    virtual_relvars: HashMap<String, VirtualRelvarDefinition>,
+}
+
+impl<E: StorageEngine> QueryExecutor for Database<E> {
+    fn query(&self, relation_name: &str) -> Result<Relation, DatabaseError> {
+        self.query(relation_name)
+    }
 }
 
 impl<E: StorageEngine> Database<E> {
@@ -723,7 +730,7 @@ impl<E: StorageEngine> Database<E> {
         &mut self,
         name: &str,
         relation_type: RelationType,
-        evaluator: fn(&Database<E>) -> Result<Relation, DatabaseError>,
+        evaluator: fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError>,
     ) -> Result<(), DatabaseError> {
         if self.relvar_exists(name) {
             return Err(DatabaseError::RelationAlreadyExists(name.to_string()));
@@ -877,7 +884,7 @@ impl<E: StorageEngine> Database<E> {
 ///
 /// Stores the metadata required to evaluate a virtual relvar on demand.
 #[derive(Debug, Clone)]
-pub struct VirtualRelvarDefinition<E: StorageEngine> {
+pub struct VirtualRelvarDefinition {
     /// The unique name of the virtual relvar.
     pub name: String,
 
@@ -892,9 +899,9 @@ pub struct VirtualRelvarDefinition<E: StorageEngine> {
     ///
     /// # Signature
     ///
-    /// `fn(&Database<E>) -> Result<Relation, DatabaseError>`
+    /// `fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError>`
     ///
-    /// - **Input**: A `&Database<E>`, which allows the view
+    /// - **Input**: A `&dyn QueryExecutor`, which allows the view
     ///   to query other relvars (base or virtual) in the database.
     /// - **Output**: A `Result` containing the computed `Relation`.
     ///
@@ -902,7 +909,7 @@ pub struct VirtualRelvarDefinition<E: StorageEngine> {
     ///
     /// The evaluator is passed a read-only reference (`&`), ensuring that
     /// viewing a relation cannot cause side effects (mutations) in the database.
-    pub evaluator: fn(&Database<E>) -> Result<Relation, DatabaseError>,
+    pub evaluator: fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError>,
 }
 
 #[cfg(test)]

--- a/relvar-core/src/database/tests.rs
+++ b/relvar-core/src/database/tests.rs
@@ -610,10 +610,8 @@ fn test_cannot_delete_from_virtual_relvar() {
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
     db.create_relvar("TEST", test_rel_type()).unwrap();
 
-    db.define_virtual_relvar("VIRT", test_rel_type(), |db| {
-        db.query("TEST")
-    })
-    .unwrap();
+    db.define_virtual_relvar("VIRT", test_rel_type(), |db| db.query("TEST"))
+        .unwrap();
 
     // Try to delete
     let result = db.delete("VIRT", |_| true);
@@ -629,10 +627,8 @@ fn test_cannot_update_virtual_relvar() {
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
     db.create_relvar("TEST", test_rel_type()).unwrap();
 
-    db.define_virtual_relvar("VIRT", test_rel_type(), |db| {
-        db.query("TEST")
-    })
-    .unwrap();
+    db.define_virtual_relvar("VIRT", test_rel_type(), |db| db.query("TEST"))
+        .unwrap();
 
     // Try to update
     let result = db.update("VIRT", |_| true, |_| tuple! { id: 99i64, name: "X" });
@@ -654,10 +650,8 @@ fn test_virtual_relvar_error_propagation() {
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
 
     // Define virtual relvar that queries nonexistent base
-    db.define_virtual_relvar("VIRT", test_rel_type(), |db| {
-        db.query("NONEXISTENT")
-    })
-    .unwrap();
+    db.define_virtual_relvar("VIRT", test_rel_type(), |db| db.query("NONEXISTENT"))
+        .unwrap();
 
     // Querying it should fail
     let result = db.query("VIRT");
@@ -1120,18 +1114,14 @@ fn test_virtual_relvar_immutability_enforcement() {
 
     // Define a view. The compiler enforces that we cannot call mutable methods
     // like insert() inside the evaluator because it receives &Database<E>, not &mut Database.
-    db.define_virtual_relvar(
-        "SAFE_VIEW",
-        test_rel_type(),
-        |db| {
-            // db.insert("LOG", ...); // This would cause compilation error!
+    db.define_virtual_relvar("SAFE_VIEW", test_rel_type(), |db| {
+        // db.insert("LOG", ...); // This would cause compilation error!
 
-            // Read operations are allowed
-            let _ = db.query("LOG")?;
+        // Read operations are allowed
+        let _ = db.query("LOG")?;
 
-            Ok(Relation::new(test_rel_type()))
-        },
-    )
+        Ok(Relation::new(test_rel_type()))
+    })
     .unwrap();
 
     // Query the view

--- a/relvar-core/src/database/tests.rs
+++ b/relvar-core/src/database/tests.rs
@@ -296,7 +296,7 @@ fn test_virtual_relvar() {
     db.define_virtual_relvar(
         "NAMES",
         RelationType::new(TupleType::new().with_attribute("name", ScalarType::String)),
-        |db: &Database<InMemoryEngine>| {
+        |db| {
             let test = db.query("TEST")?;
             Ok(test.project(&["name"]))
         },
@@ -553,7 +553,7 @@ fn test_drop_virtual_relvar() {
     db.define_virtual_relvar(
         "VIRT",
         RelationType::new(TupleType::new().with_attribute("name", ScalarType::String)),
-        |db: &Database<InMemoryEngine>| {
+        |db| {
             let test = db.query("TEST")?;
             Ok(test.project(&["name"]))
         },
@@ -589,7 +589,7 @@ fn test_cannot_insert_into_virtual_relvar() {
     db.define_virtual_relvar(
         "VIRT",
         RelationType::new(TupleType::new().with_attribute("name", ScalarType::String)),
-        |db: &Database<InMemoryEngine>| {
+        |db| {
             let test = db.query("TEST")?;
             Ok(test.project(&["name"]))
         },
@@ -610,7 +610,7 @@ fn test_cannot_delete_from_virtual_relvar() {
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
     db.create_relvar("TEST", test_rel_type()).unwrap();
 
-    db.define_virtual_relvar("VIRT", test_rel_type(), |db: &Database<InMemoryEngine>| {
+    db.define_virtual_relvar("VIRT", test_rel_type(), |db| {
         db.query("TEST")
     })
     .unwrap();
@@ -629,7 +629,7 @@ fn test_cannot_update_virtual_relvar() {
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
     db.create_relvar("TEST", test_rel_type()).unwrap();
 
-    db.define_virtual_relvar("VIRT", test_rel_type(), |db: &Database<InMemoryEngine>| {
+    db.define_virtual_relvar("VIRT", test_rel_type(), |db| {
         db.query("TEST")
     })
     .unwrap();
@@ -654,7 +654,7 @@ fn test_virtual_relvar_error_propagation() {
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
 
     // Define virtual relvar that queries nonexistent base
-    db.define_virtual_relvar("VIRT", test_rel_type(), |db: &Database<InMemoryEngine>| {
+    db.define_virtual_relvar("VIRT", test_rel_type(), |db| {
         db.query("NONEXISTENT")
     })
     .unwrap();
@@ -1123,7 +1123,7 @@ fn test_virtual_relvar_immutability_enforcement() {
     db.define_virtual_relvar(
         "SAFE_VIEW",
         test_rel_type(),
-        |db: &Database<InMemoryEngine>| {
+        |db| {
             // db.insert("LOG", ...); // This would cause compilation error!
 
             // Read operations are allowed

--- a/relvar-core/src/lib.rs
+++ b/relvar-core/src/lib.rs
@@ -103,6 +103,8 @@ pub mod database;
 pub mod error;
 pub mod query;
 pub mod storage_engine;
+/// Core traits for decoupling components.
+pub mod traits;
 pub mod types;
 pub mod values;
 
@@ -121,3 +123,6 @@ pub use constraints::{
 
 // Re-export storage engine types
 pub use storage_engine::{InMemoryEngine, StorageEngine, StorageError};
+
+// Re-export core traits
+pub use traits::QueryExecutor;

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -41,9 +41,8 @@
 
 use crate::algebra::summarize::Aggregation;
 use crate::constraints::{ConstraintExpression, ExpressionError};
-use crate::database::Database;
 use crate::error::DatabaseError;
-use crate::storage_engine::StorageEngine;
+use crate::traits::QueryExecutor;
 use crate::values::Relation;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -167,7 +166,7 @@ impl Query {
     /// - A referenced relation does not exist.
     /// - A constraint expression is invalid (e.g., type mismatch).
     /// - An algebraic operation fails (e.g., joining incompatible types).
-    pub fn execute<E: StorageEngine>(&self, db: &Database<E>) -> Result<Relation, QueryError> {
+    pub fn execute(&self, db: &impl QueryExecutor) -> Result<Relation, QueryError> {
         match self {
             Query::Scan(table_name) => Ok(db.query(table_name)?),
             Query::Restrict { input, predicate } => {

--- a/relvar-core/src/traits.rs
+++ b/relvar-core/src/traits.rs
@@ -1,0 +1,14 @@
+use crate::error::DatabaseError;
+use crate::values::Relation;
+
+/// Trait for executing queries against a database or other data source.
+///
+/// This trait abstracts the query execution capability, allowing components
+/// like virtual relvars (views) and query ASTs to operate without depending
+/// on the concrete `Database` struct or specific storage engines.
+pub trait QueryExecutor {
+    /// Execute a query for a named relation.
+    ///
+    /// This may return a base relation from storage or evaluate a virtual relvar.
+    fn query(&self, relation_name: &str) -> Result<Relation, DatabaseError>;
+}

--- a/relvar/benches/database.rs
+++ b/relvar/benches/database.rs
@@ -428,7 +428,7 @@ fn bench_virtual_relvar_creation(c: &mut Criterion) {
                 let emp_type = create_employee_type();
 
                 fn evaluator(
-                    db: &relvar::Database<relvar::PersistentEngine>,
+                    db: &dyn relvar::QueryExecutor,
                 ) -> Result<relvar::Relation, relvar::DatabaseError> {
                     Ok(db
                         .query("EMP")?
@@ -465,7 +465,7 @@ fn bench_virtual_relvar_query(c: &mut Criterion) {
                         let emp_type = create_employee_type();
 
                         fn high_earners_evaluator(
-                            db: &relvar::Database<relvar::PersistentEngine>,
+                            db: &dyn relvar::QueryExecutor,
                         ) -> Result<relvar::Relation, relvar::DatabaseError>
                         {
                             Ok(db

--- a/relvar/src/lib.rs
+++ b/relvar/src/lib.rs
@@ -127,6 +127,7 @@ pub use relvar_core::database::{Database, DatabaseError};
 pub use relvar_core::query::{Query, QueryError};
 pub use relvar_core::types::{RelationType, ScalarType, TupleType};
 pub use relvar_core::values::{Relation, ScalarValue, Tuple};
+pub use relvar_core::QueryExecutor;
 
 // Storage
 pub use relvar_core::storage_engine::{InMemoryEngine, StorageEngine, StorageError};

--- a/relvar/src/lib.rs
+++ b/relvar/src/lib.rs
@@ -123,11 +123,11 @@
 pub mod prelude;
 
 // Core Components
+pub use relvar_core::QueryExecutor;
 pub use relvar_core::database::{Database, DatabaseError};
 pub use relvar_core::query::{Query, QueryError};
 pub use relvar_core::types::{RelationType, ScalarType, TupleType};
 pub use relvar_core::values::{Relation, ScalarValue, Tuple};
-pub use relvar_core::QueryExecutor;
 
 // Storage
 pub use relvar_core::storage_engine::{InMemoryEngine, StorageEngine, StorageError};


### PR DESCRIPTION
**🕸️ Tangle:**
Circular dependency between `Database` and `VirtualRelvarDefinition` (via generic `E`), and tight coupling of `Query` AST to `Database` struct. This made the system harder to test in isolation and created a "God Struct" dependency on `Database`.

**📐 Blueprint:**
1.  Introduced `QueryExecutor` trait in `relvar-core/src/traits.rs` with a single `query` method.
2.  Implemented `QueryExecutor` for `Database<E>`.
3.  Refactored `VirtualRelvarDefinition` to hold a function pointer `fn(&dyn QueryExecutor)` instead of `fn(&Database<E>)`. This removed the need for the generic `<E>` parameter on the struct.
4.  Updated `Query::execute` to accept `&impl QueryExecutor`, allowing it to run against any compliant provider.

**🧱 Stability:**
Reduced coupling. `VirtualRelvarDefinition` is no longer generic over storage engine. `Query` no longer depends on `Database` struct.

**🔬 Verification:**
- `cargo check -p relvar-core` passes.
- `cargo test -p relvar-core` passes.
- `cargo check --workspace` passes.
- `cargo test --workspace` passes.

---
*PR created automatically by Jules for task [17026829795559305468](https://jules.google.com/task/17026829795559305468) started by @madmax983*