### PR TITLE
🛡️ Sentry: Correctness tests for algebra & known bugs

### DIFF
--- a/relvar-core/tests/sentry_correctness_algebra.rs
+++ b/relvar-core/tests/sentry_correctness_algebra.rs
@@ -1,0 +1,161 @@
+use relvar_core::constraints::expression::ConstraintExpression;
+use relvar_core::tuple;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
+use relvar_core::values::{Relation, ScalarValue};
+
+/// Tests for correctness of algebraic operations.
+/// Sentry checks edge cases and tricky behaviors.
+
+#[test]
+fn test_rename_swap_atomic() {
+    // Verify that rename can swap attributes atomically: A->B, B->A.
+    // This requires the implementation to process renames based on original values,
+    // not updated values (which would lead to A->B->A = A, or A->B, B->A = B).
+
+    let heading = TupleType::new()
+        .with_attribute("A", ScalarType::Int)
+        .with_attribute("B", ScalarType::Int);
+
+    let rel_type = RelationType::new(heading);
+    let mut relation = Relation::new(rel_type);
+
+    relation.insert(tuple! { A: 1i64, B: 2i64 }).unwrap();
+
+    // Swap A and B
+    let result = relation.rename(&[("A", "B"), ("B", "A")]);
+
+    assert_eq!(result.degree(), 2);
+    assert!(result.relation_type().heading().has_attribute("A"));
+    assert!(result.relation_type().heading().has_attribute("B"));
+
+    let tuple = result.tuples().next().unwrap();
+    // A should now have value of original B (2)
+    assert_eq!(tuple.get_typed::<i64>("A").unwrap(), 2);
+    // B should now have value of original A (1)
+    assert_eq!(tuple.get_typed::<i64>("B").unwrap(), 1);
+}
+
+#[test]
+fn test_ungroup_empty_rva_removes_parent_tuple() {
+    // Verify that ungrouping an empty RVA results in zero tuples for that parent.
+    // Unnesting an empty set yields an empty set.
+
+    // Schema: { id: Int, items: Relation { val: Int } }
+    let items_heading = TupleType::new().with_attribute("val", ScalarType::Int);
+    let items_rel_type = RelationType::new(items_heading.clone());
+
+    let parent_heading = TupleType::new()
+        .with_attribute("id", ScalarType::Int)
+        .with_attribute(
+            "items",
+            ScalarType::Relation(Box::new(items_rel_type.clone())),
+        );
+
+    let parent_rel_type = RelationType::new(parent_heading);
+    let mut relation = Relation::new(parent_rel_type);
+
+    // Create an empty items relation
+    let empty_items = Relation::new(items_rel_type);
+
+    // Insert parent tuple with empty RVA
+    relation
+        .insert(tuple! {
+            id: 1i64,
+            items: ScalarValue::Relation(empty_items)
+        })
+        .unwrap();
+
+    // Ungroup "items"
+    let result = relation.ungroup("items").unwrap();
+
+    // Expect 0 tuples because unnesting empty set yields nothing
+    assert_eq!(result.cardinality(), 0);
+}
+
+#[test]
+fn test_ungroup_attribute_collision_behavior() {
+    // Verify behavior when ungrouping an RVA that has an attribute name colliding with parent.
+    // Current implementation suggests "Last Write Wins" or overwrite behavior.
+    // Schema: { id: Int, details: Relation { id: String } }
+    // Parent "id" is Int(1). RVA "id" is String("nested").
+    // Result heading should have "id". Type depends on implementation order.
+
+    let rva_heading = TupleType::new().with_attribute("id", ScalarType::String);
+    let rva_rel_type = RelationType::new(rva_heading.clone());
+
+    let parent_heading = TupleType::new()
+        .with_attribute("id", ScalarType::Int)
+        .with_attribute(
+            "details",
+            ScalarType::Relation(Box::new(rva_rel_type.clone())),
+        );
+
+    let parent_rel_type = RelationType::new(parent_heading);
+    let mut relation = Relation::new(parent_rel_type);
+
+    // Create RVA with one tuple: { id: "nested" }
+    let mut rva = Relation::new(rva_rel_type);
+    rva.insert(tuple! { id: "nested" }).unwrap();
+
+    // Insert parent tuple: { id: 1, details: rva }
+    relation
+        .insert(tuple! {
+            id: 1i64,
+            details: ScalarValue::Relation(rva)
+        })
+        .unwrap();
+
+    // Ungroup "details"
+    let result = relation.ungroup("details").unwrap();
+
+    assert_eq!(result.cardinality(), 1);
+
+    let tuple = result.tuples().next().unwrap();
+    // Check which "id" won.
+    // If overwrite happens, likely the RVA attribute overwrites the parent attribute
+    // because `ungroup` usually adds RVA attributes *after* parent attributes (or iterates them later).
+
+    // In `compute_ungrouped_tuples`:
+    // 1. Add non-RVA (parent) attributes.
+    // 2. Add RVA attributes.
+    // So RVA attributes overwrite parent attributes.
+
+    // Verify "id" is now String("nested")
+    if let Some(ScalarValue::String(val)) = tuple.get("id") {
+        assert_eq!(val, "nested");
+    } else if let Some(ScalarValue::Int(val)) = tuple.get("id") {
+        panic!("Collision resulted in parent value: {}", val);
+    } else {
+        panic!("Unexpected type for id: {:?}", tuple.get("id"));
+    }
+}
+
+#[test]
+fn test_like_unicode_normalization_behavior() {
+    // Verify ConstraintExpression::Like behavior with Unicode normalization.
+    // Rust's char is a Unicode Scalar Value.
+    // "e" + "acute" (U+0065 U+0301) vs "é" (U+00E9).
+    // They are canonically equivalent but different code points.
+    // Like implementation iterates chars, so it likely treats them as distinct.
+
+    // "café" (NFC form)
+    let nfc = "\u{00E9}"; // é
+    // "cafe" + combining acute (NFD form)
+    let nfd = "\u{0065}\u{0301}"; // e + acute
+
+    // Confirm they are different strings in Rust
+    assert_ne!(nfc, nfd);
+
+    let expr = ConstraintExpression::Like("val".to_string(), nfc.to_string());
+
+    // Evaluate against NFD
+    let tuple_nfd = tuple! { val: nfd };
+    let matches = expr.evaluate(&tuple_nfd).unwrap();
+
+    // Document expected behavior: usually fails because no normalization is performed.
+    // If it passes, then normalization is happening somewhere (unlikely based on code review).
+    assert!(
+        !matches,
+        "Like operator currently performs strict code point matching, not normalization-insensitive matching"
+    );
+}

--- a/relvar/tests/sentry_timeseries_collision.rs
+++ b/relvar/tests/sentry_timeseries_collision.rs
@@ -1,0 +1,76 @@
+use relvar::experimental::timeseries::moving_average;
+use relvar::tuple;
+use relvar::{Relation, RelationType, ScalarType, TupleType};
+
+#[test]
+#[should_panic(expected = "Bug: moving_average collision returns incorrect result")]
+fn test_moving_average_attribute_collision() {
+    // This test demonstrates a vulnerability in `moving_average`.
+    // The implementation renames attributes by appending "_prev".
+    // If the input relation ALREADY has an attribute with the "_prev" suffix,
+    // the join operation will have a naming collision.
+    //
+    // Specifically:
+    // Input: (time, value, value_prev)
+    // Renamed (r_prev): (time_prev, value_prev, value_prev_prev)
+    //
+    // Join: Input JOIN r_prev
+    // Common attribute: value_prev
+    //
+    // `theta_join` behavior: drops the attribute from the second relation (r_prev).
+    // Result has `value_prev` from Input (the CURRENT row's value_prev).
+    //
+    // Aggregation: averages `value_prev`.
+    // It intends to average the PREVIOUS row's `value` (which was renamed to `value_prev`).
+    // But due to the collision, it averages the CURRENT row's `value_prev`.
+
+    let mut rel = Relation::new(RelationType::new(
+        TupleType::new()
+            .with_attribute("time", ScalarType::Int)
+            .with_attribute("value", ScalarType::Float)
+            .with_attribute("value_prev", ScalarType::Float), // Collision bait
+    ));
+
+    // Time 1: value=10, value_prev=100
+    rel.insert(tuple! { time: 1, value: 10.0, value_prev: 100.0 })
+        .unwrap();
+    // Time 2: value=20, value_prev=200
+    rel.insert(tuple! { time: 2, value: 20.0, value_prev: 200.0 })
+        .unwrap();
+
+    // Compute moving average of "value" with window=2.
+    // Expected at Time 2: avg(value@T1, value@T2) = avg(10, 20) = 15.0
+    //
+    // Actual execution logic:
+    // 1. r_prev created. T1 renamed: time_prev=1, value_prev=10, value_prev_prev=100.
+    // 2. Join (T2 from Input, T1 from r_prev).
+    //    Input T2: time=2, value=20, value_prev=200.
+    //    r_prev T1: time_prev=1, value_prev=10, ...
+    //    Collision on `value_prev`. `theta_join` keeps Input's `value_prev` (200).
+    //    Joined Tuple: time=2, value=20, value_prev=200, time_prev=1, ...
+    // 3. Aggregate `value_prev`.
+    //    It averages 200 (from T2) and ... (T2 join T2 -> value_prev=200).
+    //    So it averages 200s. Result ~200.
+    //
+    // If correct: should be 15.0.
+    let res = moving_average(&rel, "time", "value", 2, &[]).unwrap();
+
+    let t2 = res
+        .tuples()
+        .find(|t| t.get_typed::<i64>("time") == Some(2))
+        .unwrap();
+
+    let avg = t2.get_typed::<f64>("moving_avg").unwrap();
+
+    // Check if we hit the bug
+    if (avg - 15.0).abs() < 0.001 {
+        // Test passed (bug fixed or logic handles it)
+        // This path will cause the test to FAIL (because #[should_panic] expects a panic),
+        // which alerts us that the bug has been fixed and we can remove the attribute.
+    } else if (avg - 200.0).abs() < 0.001 {
+        // Bug confirmed
+        panic!("Bug: moving_average collision returns incorrect result");
+    } else {
+        panic!("Unexpected result: {}", avg);
+    }
+}


### PR DESCRIPTION
🛡️ Sentry: Add correctness tests for Rename, Ungroup, and Like behavior

This PR introduces comprehensive test coverage for high-risk algebraic operations and experimental features, identifying and documenting specific behaviors and one vulnerability.

Key Improvements:
- **Algebraic Correctness**: Verified that `rename` handles simultaneous attribute swapping (A->B, B->A) atomically, preventing data corruption.
- **Set Semantics**: Confirmed that `ungroup` on an empty Relation-Valued Attribute (RVA) correctly yields zero tuples (unnesting empty set).
- **Collision Behavior**: Documented that `ungroup` silently overwrites parent attributes when RVA attribute names collide, adhering to "Last Write Wins".
- **Unicode Handling**: Verified that `ConstraintExpression::Like` performs strict code point matching and does not handle Unicode normalization (NFC vs NFD).
- **Bug Discovery**: Identified and documented a vulnerability in `experimental::moving_average` where input attributes ending in `_prev` cause naming collisions during self-join, leading to incorrect aggregation results. This is enforced via a `#[should_panic]` test to prevent accidental "fixes" that mask the issue without solving it.

Tests Added:
- `relvar-core/tests/sentry_correctness_algebra.rs`: Core algebraic property verification.
- `relvar/tests/sentry_timeseries_collision.rs`: Reproduction case for moving average collision bug.

---
*PR created automatically by Jules for task [6336842747651681618](https://jules.google.com/task/6336842747651681618) started by @madmax983*