### PR TITLE
⚒️ Forge: Fix broken Ord implementation for Relation and Refactor ScalarType

### DIFF
--- a/relvar-core/src/types/relation_type.rs
+++ b/relvar-core/src/types/relation_type.rs
@@ -60,7 +60,7 @@ use serde::{Deserialize, Serialize};
 /// assert!(employee_type.has_attribute("emp_id"));
 /// assert!(!employee_type.has_attribute("salary"));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct RelationType {
     /// The heading (tuple type) that defines this relation type.
     heading: TupleType,

--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -306,80 +306,45 @@ impl Ord for ScalarType {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         use std::cmp::Ordering;
 
-        // Helper to get a discriminant value for ordering
-        let disc_value = |t: &ScalarType| match t {
-            ScalarType::Int => 0,
-            ScalarType::Float => 1,
-            ScalarType::String => 2,
-            ScalarType::Bool => 3,
-            ScalarType::Bytes => 4,
-            ScalarType::Relation(_) => 5,
-            ScalarType::UserDefined { .. } => 6,
-        };
-
-        match disc_value(self).cmp(&disc_value(other)) {
-            Ordering::Equal => {
-                // Same variant, compare data
-                match (self, other) {
-                    (ScalarType::Int, ScalarType::Int)
-                    | (ScalarType::Float, ScalarType::Float)
-                    | (ScalarType::String, ScalarType::String)
-                    | (ScalarType::Bool, ScalarType::Bool)
-                    | (ScalarType::Bytes, ScalarType::Bytes) => Ordering::Equal,
-                    (ScalarType::Relation(a), ScalarType::Relation(b)) => {
-                        // Compare relation types by their headings
-                        // Since TupleType doesn't have Ord, we need a custom comparison
-                        let a_attrs: Vec<_> = a
-                            .heading()
-                            .attribute_names()
-                            .map(|n| (n, a.heading().get_attribute_type(n).unwrap()))
-                            .collect();
-                        let b_attrs: Vec<_> = b
-                            .heading()
-                            .attribute_names()
-                            .map(|n| (n, b.heading().get_attribute_type(n).unwrap()))
-                            .collect();
-
-                        // Compare by count first, then by sorted attributes
-                        match a_attrs.len().cmp(&b_attrs.len()) {
-                            Ordering::Equal => {
-                                let mut a_sorted = a_attrs;
-                                let mut b_sorted = b_attrs;
-                                a_sorted.sort_by_key(|(name, _)| *name);
-                                b_sorted.sort_by_key(|(name, _)| *name);
-
-                                for ((a_name, a_ty), (b_name, b_ty)) in
-                                    a_sorted.iter().zip(b_sorted.iter())
-                                {
-                                    match a_name.cmp(b_name) {
-                                        Ordering::Equal => match a_ty.cmp(b_ty) {
-                                            Ordering::Equal => continue,
-                                            other => return other,
-                                        },
-                                        other => return other,
-                                    }
-                                }
-                                Ordering::Equal
-                            }
-                            other => other,
-                        }
-                    }
-                    (
-                        ScalarType::UserDefined {
-                            name: a_name,
-                            representation: a_rep,
-                        },
-                        ScalarType::UserDefined {
-                            name: b_name,
-                            representation: b_rep,
-                        },
-                    ) => match a_name.cmp(b_name) {
-                        Ordering::Equal => a_rep.cmp(b_rep),
-                        other => other,
-                    },
-                    _ => unreachable!("Discriminants matched but variants don't"),
-                }
+        // Determine ordering of variants
+        fn variant_ordinal(t: &ScalarType) -> u8 {
+            match t {
+                ScalarType::Int => 0,
+                ScalarType::Float => 1,
+                ScalarType::String => 2,
+                ScalarType::Bool => 3,
+                ScalarType::Bytes => 4,
+                ScalarType::Relation(_) => 5,
+                ScalarType::UserDefined { .. } => 6,
             }
+        }
+
+        match variant_ordinal(self).cmp(&variant_ordinal(other)) {
+            Ordering::Equal => match (self, other) {
+                // Variants with no data are equal
+                (ScalarType::Int, _)
+                | (ScalarType::Float, _)
+                | (ScalarType::String, _)
+                | (ScalarType::Bool, _)
+                | (ScalarType::Bytes, _) => Ordering::Equal,
+
+                // Compare inner data for variants with data
+                (ScalarType::Relation(a), ScalarType::Relation(b)) => a.cmp(b),
+                (
+                    ScalarType::UserDefined {
+                        name: a_name,
+                        representation: a_rep,
+                    },
+                    ScalarType::UserDefined {
+                        name: b_name,
+                        representation: b_rep,
+                    },
+                ) => match a_name.cmp(b_name) {
+                    Ordering::Equal => a_rep.cmp(b_rep),
+                    other => other,
+                },
+                _ => unreachable!("Discriminants matched but variants don't"),
+            },
             other => other,
         }
     }

--- a/relvar-core/src/types/tuple_type.rs
+++ b/relvar-core/src/types/tuple_type.rs
@@ -64,7 +64,7 @@ use std::collections::BTreeMap;
 /// assert_eq!(person_type.get_attribute_type("id"), Some(&ScalarType::Int));
 /// assert!(!person_type.has_attribute("nonexistent"));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct TupleType {
     /// The attributes of this tuple type, mapping names to scalar types.
     attributes: BTreeMap<String, ScalarType>,

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -169,6 +169,39 @@ impl IntoIterator for Relation {
     }
 }
 
+impl PartialOrd for Relation {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Relation {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // First compare types
+        match self.relation_type.cmp(&other.relation_type) {
+            std::cmp::Ordering::Equal => {
+                // Then compare cardinality
+                match self.cardinality().cmp(&other.cardinality()) {
+                    std::cmp::Ordering::Equal => {
+                        // Then compare sorted tuples
+                        // Note: This is O(N log N) which is expensive but necessary for deterministic ordering
+                        // independent of HashSet iteration order.
+                        let mut self_tuples: Vec<_> = self.tuples().collect();
+                        let mut other_tuples: Vec<_> = other.tuples().collect();
+
+                        self_tuples.sort();
+                        other_tuples.sort();
+
+                        self_tuples.cmp(&other_tuples)
+                    }
+                    other => other,
+                }
+            }
+            other => other,
+        }
+    }
+}
+
 impl Relation {
     /// Creates a new empty relation with the given type.
     ///

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -308,8 +308,8 @@ impl Ord for ScalarValue {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         use std::cmp::Ordering;
 
-        // Helper to get type ordering
-        fn type_order(val: &ScalarValue) -> u8 {
+        // Determine ordering of variants
+        fn variant_ordinal(val: &ScalarValue) -> u8 {
             match val {
                 ScalarValue::Int(_) => 0,
                 ScalarValue::Float(_) => 1,
@@ -322,7 +322,7 @@ impl Ord for ScalarValue {
         }
 
         // Compare types first
-        match type_order(self).cmp(&type_order(other)) {
+        match variant_ordinal(self).cmp(&variant_ordinal(other)) {
             Ordering::Equal => {
                 // Same type: order by value
                 match (self, other) {
@@ -365,13 +365,7 @@ impl Ord for ScalarValue {
                     (ScalarValue::String(a), ScalarValue::String(b)) => a.cmp(b),
                     (ScalarValue::Bool(a), ScalarValue::Bool(b)) => a.cmp(b),
                     (ScalarValue::Bytes(a), ScalarValue::Bytes(b)) => a.cmp(b),
-                    (ScalarValue::Relation(a), ScalarValue::Relation(b)) => {
-                        // For relations, order by cardinality first, then degree
-                        match a.cardinality().cmp(&b.cardinality()) {
-                            Ordering::Equal => a.degree().cmp(&b.degree()),
-                            other => other,
-                        }
-                    }
+                    (ScalarValue::Relation(a), ScalarValue::Relation(b)) => a.cmp(b),
                     (
                         ScalarValue::UserDefined {
                             type_def: type_a,

--- a/relvar-core/src/values/tuple.rs
+++ b/relvar-core/src/values/tuple.rs
@@ -111,7 +111,7 @@ pub enum TupleError {
 /// let age: i64 = person.get_typed("age").unwrap();
 /// assert_eq!(age, 30);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Tuple {
     /// The tuple type (heading) that this tuple conforms to.
     #[serde(with = "arc_serde")]

--- a/relvar-core/tests/sentry_ord_correctness.rs
+++ b/relvar-core/tests/sentry_ord_correctness.rs
@@ -1,0 +1,36 @@
+use relvar_core::tuple;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
+use relvar_core::values::{Relation, ScalarValue};
+use std::collections::BTreeSet;
+
+#[test]
+fn test_relation_ord_fixed() {
+    let heading = TupleType::new().with_attribute("a", ScalarType::Int);
+    let rel_type = RelationType::new(heading);
+
+    let mut r1 = Relation::new(rel_type.clone());
+    r1.insert(tuple! { a: 1i64 }).unwrap();
+
+    let mut r2 = Relation::new(rel_type.clone());
+    r2.insert(tuple! { a: 2i64 }).unwrap();
+
+    let v1 = ScalarValue::Relation(r1);
+    let v2 = ScalarValue::Relation(r2);
+
+    // They are NOT equal
+    assert_ne!(v1, v2);
+
+    // With the fix, they should NOT compare equal
+    assert_ne!(v1.cmp(&v2), std::cmp::Ordering::Equal);
+
+    // If we put them in a BTreeSet, both should be kept.
+    let mut set = BTreeSet::new();
+    set.insert(v1.clone());
+    set.insert(v2.clone());
+
+    assert_eq!(
+        set.len(),
+        2,
+        "BTreeSet should keep both values as they are distinct"
+    );
+}


### PR DESCRIPTION

🚮 Smell: `ScalarValue::cmp` for `Relation` only compared cardinality and degree, treating distinct relations as equal. This violated the `Ord` contract relative to `Eq`, causing `BTreeSet` to drop distinct relations. Also, `ScalarType::cmp` contained manual logic for comparing `RelationType`.

✨ Solution:
1. Implemented `Ord` for `TupleType` and `RelationType` (derived).
2. Refactored `ScalarType::cmp` to use `RelationType::cmp` and a cleaner variant ordinal helper.
3. Implemented `Ord` for `Tuple` (derived).
4. Implemented `Ord` for `Relation` by sorting tuples to ensure deterministic ordering (O(N log N)).
5. Refactored `ScalarValue::cmp` to delegate to `Relation::cmp`.
6. Added `sentry_ord_correctness.rs` to verify the fix and prevent regression.

🧼 Benefit: `Relation` and `ScalarValue` now have correct total ordering consistent with `Eq`, preventing data loss in ordered collections. Code is more idiomatic and maintainable.

🛡️ Verification: Tests passed. No logic changed for other variants.


---
*PR created automatically by Jules for task [13569749485559049062](https://jules.google.com/task/13569749485559049062) started by @madmax983*