### PR TITLE
🔒 Warden: Enforce global row limit for nested relations in JSON import

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -100,7 +100,7 @@ Added verification test `relvar-core/tests/warden_exploit_like_memory.rs`.
 `importer::from_json` used `serde_json::from_reader` which deserialized the entire JSON input into a DOM (`Value`) before processing. An attacker could supply a very large JSON array (e.g., 10GB), causing the server to exhaust memory (OOM DoS) trying to represent the entire structure in memory.
 
 **Defense:**
-1. Replaced `from_json` implementation with a streaming parser using `serde::de::DeserializeSeed` and `Visitor`.
+1. Replaced `from_json` implementation with a streaming parser using `serde::de::DeserializeSeed` and `Visitor` traits, eliminating `JsonValue` usage.
 2. The new implementation iterates over the JSON array element-by-element, processing and inserting each tuple individually.
 3. This ensures memory usage is proportional to the size of a single tuple (plus the accumulating `Relation` result), preventing the "double memory usage" (DOM + Result) and allowing for future optimizations (e.g. streaming to disk).
 
@@ -151,3 +151,13 @@ This bypassed `ScalarType` depth limits, enabling stack overflow attacks via dee
    - The inner `value` must match the `type_def` representation.
 3. Updated `ScalarValue` to use `#[serde(try_from = ...)]`.
 This ensures all deserialized values are structurally sound and respect the depth limits inherent in their type definitions.
+
+## 2026-02-14 - Nested Relation Import DoS
+**Threat:**
+The JSON importer (`relvar::tools::importer`) enforced `MAX_IMPORT_ROWS` (100,000) only on the top-level relation. An attacker could construct a malicious JSON payload with a Relation-Valued Attribute (RVA) containing an unlimited number of nested tuples (e.g., 1 billion), causing memory exhaustion (DoS) or CPU lockup. The nested relation deserialization loop did not check any row limits.
+
+**Defense:**
+1. Modified `importer::from_json` to initialize a `Rc<RefCell<usize>>` global row counter.
+2. Propagated this counter to all `Visitor` and `Seed` implementations (`RelationVisitor`, `TupleVisitor`, `ScalarValueVisitor`).
+3. Enforced `MAX_IMPORT_ROWS` check and increment logic within `RelationVisitor::visit_seq` (top-level) and `ScalarValueVisitor::visit_seq` (nested relations).
+4. This ensures the total number of tuples imported across all nesting levels cannot exceed the limit.

--- a/relvar/src/tools/importer.rs
+++ b/relvar/src/tools/importer.rs
@@ -38,9 +38,11 @@
 use relvar_core::types::{RelationType, ScalarType, TupleType};
 use relvar_core::values::{Relation, ScalarValue, Tuple};
 use serde::de::{DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::io::BufRead;
+use std::rc::Rc;
 use thiserror::Error;
 
 /// Errors that can occur during import.
@@ -94,7 +96,11 @@ pub fn from_json<R: std::io::Read>(
     relation_type: RelationType,
 ) -> Result<Relation, ImporterError> {
     let mut deserializer = serde_json::Deserializer::from_reader(reader);
-    let seed = RelationSeed { relation_type };
+    let counter = Rc::new(RefCell::new(0usize));
+    let seed = RelationSeed {
+        relation_type,
+        counter,
+    };
     seed.deserialize(&mut deserializer).map_err(|e| {
         if e.to_string().contains("Size limit exceeded") {
             ImporterError::LimitExceeded(e.to_string())
@@ -106,6 +112,7 @@ pub fn from_json<R: std::io::Read>(
 
 struct RelationSeed {
     relation_type: RelationType,
+    counter: Rc<RefCell<usize>>,
 }
 
 impl<'de> DeserializeSeed<'de> for RelationSeed {
@@ -117,12 +124,14 @@ impl<'de> DeserializeSeed<'de> for RelationSeed {
     {
         deserializer.deserialize_seq(RelationVisitor {
             relation_type: self.relation_type,
+            counter: self.counter,
         })
     }
 }
 
 struct RelationVisitor {
     relation_type: RelationType,
+    counter: Rc<RefCell<usize>>,
 }
 
 impl<'de> Visitor<'de> for RelationVisitor {
@@ -138,15 +147,22 @@ impl<'de> Visitor<'de> for RelationVisitor {
     {
         let mut relation = Relation::new(self.relation_type.clone());
         let heading = self.relation_type.heading().clone();
-        let tuple_seed = TupleSeed { heading };
+        let tuple_seed = TupleSeed {
+            heading,
+            counter: self.counter.clone(),
+        };
 
         while let Some(tuple) = seq.next_element_seed(tuple_seed.clone())? {
-            if relation.cardinality() >= MAX_IMPORT_ROWS {
+            let mut count = self.counter.borrow_mut();
+            if *count >= MAX_IMPORT_ROWS {
                 return Err(serde::de::Error::custom(format!(
                     "Size limit exceeded: Max rows: {}",
                     MAX_IMPORT_ROWS
                 )));
             }
+            *count += 1;
+            drop(count);
+
             let _ = relation
                 .insert(tuple)
                 .map_err(|e| serde::de::Error::custom(format!("Relvar error: {}", e)))?;
@@ -159,6 +175,7 @@ impl<'de> Visitor<'de> for RelationVisitor {
 #[derive(Clone)]
 struct TupleSeed {
     heading: TupleType,
+    counter: Rc<RefCell<usize>>,
 }
 
 impl<'de> DeserializeSeed<'de> for TupleSeed {
@@ -170,12 +187,14 @@ impl<'de> DeserializeSeed<'de> for TupleSeed {
     {
         deserializer.deserialize_map(TupleVisitor {
             heading: self.heading,
+            counter: self.counter,
         })
     }
 }
 
 struct TupleVisitor {
     heading: TupleType,
+    counter: Rc<RefCell<usize>>,
 }
 
 impl<'de> Visitor<'de> for TupleVisitor {
@@ -196,6 +215,7 @@ impl<'de> Visitor<'de> for TupleVisitor {
             if let Some(attr_type) = heading.get_attribute_type(&key) {
                 let seed = ScalarValueSeed {
                     scalar_type: attr_type.clone(),
+                    counter: self.counter.clone(),
                 };
                 let val = map.next_value_seed(seed)?;
                 values.insert(key, val);
@@ -211,6 +231,7 @@ impl<'de> Visitor<'de> for TupleVisitor {
 
 struct ScalarValueSeed {
     scalar_type: ScalarType,
+    counter: Rc<RefCell<usize>>,
 }
 
 impl<'de> DeserializeSeed<'de> for ScalarValueSeed {
@@ -224,6 +245,7 @@ impl<'de> DeserializeSeed<'de> for ScalarValueSeed {
             ScalarType::UserDefined { representation, .. } => {
                 let inner_seed = ScalarValueSeed {
                     scalar_type: *representation.clone(),
+                    counter: self.counter,
                 };
                 let inner_val = inner_seed.deserialize(deserializer)?;
                 self.scalar_type
@@ -232,6 +254,7 @@ impl<'de> DeserializeSeed<'de> for ScalarValueSeed {
             }
             _ => deserializer.deserialize_any(ScalarValueVisitor {
                 scalar_type: self.scalar_type,
+                counter: self.counter,
             }),
         }
     }
@@ -239,6 +262,7 @@ impl<'de> DeserializeSeed<'de> for ScalarValueSeed {
 
 struct ScalarValueVisitor {
     scalar_type: ScalarType,
+    counter: Rc<RefCell<usize>>,
 }
 
 impl<'de> Visitor<'de> for ScalarValueVisitor {
@@ -348,9 +372,20 @@ impl<'de> Visitor<'de> for ScalarValueVisitor {
                 let mut relation = Relation::new(*inner_type.clone()); // Need to deref Box
                 let tuple_seed = TupleSeed {
                     heading: inner_type.heading().clone(),
+                    counter: self.counter.clone(),
                 };
 
                 while let Some(tuple) = seq.next_element_seed(tuple_seed.clone())? {
+                    let mut count = self.counter.borrow_mut();
+                    if *count >= MAX_IMPORT_ROWS {
+                        return Err(serde::de::Error::custom(format!(
+                            "Size limit exceeded: Max rows: {}",
+                            MAX_IMPORT_ROWS
+                        )));
+                    }
+                    *count += 1;
+                    drop(count);
+
                     relation
                         .insert(tuple)
                         .map_err(|e| serde::de::Error::custom(format!("Relvar error: {}", e)))?;

--- a/relvar/tests/warden_exploit_nested_limit.rs
+++ b/relvar/tests/warden_exploit_nested_limit.rs
@@ -1,0 +1,55 @@
+use relvar::tools::importer;
+use relvar::{RelationType, ScalarType, TupleType};
+use relvar::ScalarValue;
+
+#[test]
+fn test_exploit_nested_relation_limit() {
+    // 1. Define a schema with a Relation-Valued Attribute (RVA)
+    // RVA: "items" -> Relation { val: Int }
+    let inner_heading = TupleType::new().with_attribute("val", ScalarType::Int);
+    let inner_rel_type = RelationType::new(inner_heading);
+
+    let outer_heading = TupleType::new()
+        .with_attribute("id", ScalarType::Int)
+        .with_attribute("items", ScalarType::Relation(Box::new(inner_rel_type)));
+    let outer_rel_type = RelationType::new(outer_heading);
+
+    // 2. Construct a JSON payload with > MAX_IMPORT_ROWS (100,000) in the nested relation
+    // The outer relation has only 1 tuple.
+    let max_rows = 100_001;
+    let mut json = String::new();
+    json.push_str(r#"[{"id": 1, "items": ["#);
+    for i in 0..max_rows {
+        if i > 0 {
+            json.push(',');
+        }
+        json.push_str(&format!(r#"{{"val": {}}}"#, i));
+    }
+    json.push_str(r#"]}]"#);
+
+    // 3. Attempt import
+    // This should fail if we are enforcing limits on RVAs.
+    // If it succeeds, we have a DoS vector (unbounded memory allocation).
+    let result = importer::from_json(json.as_bytes(), outer_rel_type);
+
+    match result {
+        Ok(rel) => {
+            // If we get here, the exploit worked (bad!)
+            let tuple = rel.tuples().next().unwrap();
+            if let Some(ScalarValue::Relation(inner)) = tuple.get("items") {
+                println!(
+                    "Exploit successful: Created RVA with {} rows",
+                    inner.cardinality()
+                );
+                assert!(
+                    inner.cardinality() <= 100_000,
+                    "Security limits bypassed! RVA has {} rows",
+                    inner.cardinality()
+                );
+            }
+        }
+        Err(e) => {
+            println!("Exploit failed (good): {}", e);
+        }
+    }
+}

--- a/relvar/tests/warden_exploit_nested_limit.rs
+++ b/relvar/tests/warden_exploit_nested_limit.rs
@@ -1,6 +1,6 @@
+use relvar::ScalarValue;
 use relvar::tools::importer;
 use relvar::{RelationType, ScalarType, TupleType};
-use relvar::ScalarValue;
 
 #[test]
 fn test_exploit_nested_relation_limit() {


### PR DESCRIPTION
**Threat:**
The JSON importer (`relvar::tools::importer`) enforced `MAX_IMPORT_ROWS` (100,000) only on the top-level relation. An attacker could construct a malicious JSON payload with a Relation-Valued Attribute (RVA) containing an unlimited number of nested tuples (e.g., 1 billion), causing memory exhaustion (DoS) or CPU lockup. The nested relation deserialization loop did not check any row limits.

**Defense:**
1. Modified `importer::from_json` to initialize a `Rc<RefCell<usize>>` global row counter.
2. Propagated this counter to all `Visitor` and `Seed` implementations (`RelationVisitor`, `TupleVisitor`, `ScalarValueVisitor`).
3. Enforced `MAX_IMPORT_ROWS` check and increment logic within `RelationVisitor::visit_seq` (top-level) and `ScalarValueVisitor::visit_seq` (nested relations).
4. This ensures the total number of tuples imported across all nesting levels cannot exceed the limit.

**Verification:**
Added `relvar/tests/warden_exploit_nested_limit.rs` which attempts to import a JSON with 100,001 nested rows. The test confirms that the importer now returns a "Size limit exceeded" error instead of successfully creating the massive relation. Ran full test suite to ensure no regressions.

---
*PR created automatically by Jules for task [14989771554026836839](https://jules.google.com/task/14989771554026836839) started by @madmax983*