### PR TITLE
🎻 Bard: Document Storage Architecture & Fix Examples

### DIFF
--- a/relvar-storage/src/lib.rs
+++ b/relvar-storage/src/lib.rs
@@ -1,14 +1,130 @@
-//! # Relvar Storage - Persistent Storage Layer
+//! # Relvar Storage - The Persistent Storage Layer
 //!
-//! This crate provides the persistent storage implementation for Relvar:
+//! `relvar-storage` provides the physical storage engine for the Relvar database system.
+//! It implements a durable, page-based storage architecture that supports ACID transactions,
+//! Multi-Version Concurrency Control (MVCC), and Write-Ahead Logging (WAL).
 //!
-//! - HeapFile - Unordered tuple storage
-//! - Page - Fixed-size disk blocks
-//! - Catalog - Relation metadata storage
-//! - PersistentEngine - StorageEngine implementation with persistence
+//! While `relvar-core` defines the *logical* relational model (types, values, algebra),
+//! `relvar-storage` handles the *physical* reality of bytes on disk.
 //!
-//! This crate implements the physical storage layer and is feature-flagged
-//! as optional in the main relvar crate.
+//! ## Architecture
+//!
+//! The storage engine is built in layers, from raw bytes up to relational storage:
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────┐
+//! │                      PersistentEngine                       │
+//! │           (Orchestrates Transactions, WAL, MVCC)            │
+//! ├──────────────────────────────────────┬──────────────────────┤
+//! │             Catalog                  │       HeapFile       │
+//! │   (Metadata: Schema, Keys)           │   (Tuple Storage)    │
+//! ├──────────────────────────────────────┴──────────────────────┤
+//! │                      StorageManager                         │
+//! │             (Manages files and directory layout)            │
+//! ├─────────────────────────────────────────────────────────────┤
+//! │                        PageFile                             │
+//! │              (Fixed-size Page I/O abstraction)              │
+//! └─────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! ## Core Components
+//!
+//! ### 1. Page ([`storage::Page`])
+//! The fundamental unit of I/O. All data is stored in fixed-size (4KB) pages.
+//! This aligns with operating system virtual memory pages and disk sectors for efficiency.
+//!
+//! ### 2. HeapFile ([`storage::HeapFile`])
+//! Implements unordered tuple storage using a **Slotted Page** architecture.
+//! - **Slotted Pages**: Allows variable-length tuples to be stored efficiently within fixed-size pages.
+//! - **Tuple IDs**: Tuples are identified internally by `(PageID, SlotIndex)`, but this is never exposed to the logical layer.
+//!
+//! ### 3. Catalog ([`storage::Catalog`])
+//! Stores metadata about relations (names, types, constraints).
+//! Currently implemented as a JSON file for simplicity, but designed to be replaced with a system relation.
+//!
+//! ### 4. PersistentEngine ([`PersistentEngine`])
+//! The high-level entry point that implements the `StorageEngine` trait from `relvar-core`.
+//! It handles:
+//! - **Transactions**: Begin, Commit, Rollback.
+//! - **WAL**: Ensures durability by logging changes before applying them.
+//! - **MVCC**: Provides Snapshot Isolation by maintaining multiple versions of tuples.
+//!
+//! ## Theory & Design
+//!
+//! ### TTM Compliance (The Third Manifesto)
+//!
+//! This storage layer is designed to support the pure relational model:
+//!
+//! - **Physical Independence**: The logical model (relations) knows nothing about pages or files.
+//! - **No Tuple IDs**: Per *Proscription 6*, internal tuple addresses (Page/Slot) are never exposed to the user or the logical layer. Queries operate on values, not pointers.
+//! - **Set Semantics**: While the physical storage (HeapFile) allows duplicates, the logical layer enforces set semantics (no duplicates) via unique constraints and rigorous algebra.
+//!
+//! ### Concurrency Control (MVCC)
+//!
+//! Relvar uses Multi-Version Concurrency Control to allow readers and writers to operate without blocking each other.
+//!
+//! - **Readers** see a consistent snapshot of the database as of the start of their transaction.
+//! - **Writers** create new versions of tuples instead of overwriting data in place.
+//! - **Garbage Collection** removes old tuple versions that are no longer visible to any active transaction.
+//!
+//! ## Usage
+//!
+//! ### Using `PersistentEngine` directly
+//!
+//! ```no_run
+//! use relvar_storage::PersistentEngine;
+//! use relvar_core::storage_engine::StorageEngine; // Trait
+//! use relvar_core::types::{RelationType, TupleType, ScalarType};
+//! use relvar_core::tuple;
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     // Open the database directory
+//!     let mut engine = PersistentEngine::open("my_db")?;
+//!
+//!     // Define schema
+//!     let heading = TupleType::new()
+//!         .with_attribute("id", ScalarType::Int)
+//!         .with_attribute("name", ScalarType::String);
+//!     let rel_type = RelationType::new(heading);
+//!
+//!     // Create relation
+//!     engine.create_relation("USERS", rel_type)?;
+//!
+//!     // Insert data (auto-commit if not in transaction)
+//!     engine.insert_tuple("USERS", tuple! { id: 1i64, name: "Alice" })?;
+//!
+//!     // Load relation
+//!     let users = engine.load_relation("USERS")?;
+//!     assert_eq!(users.cardinality(), 1);
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ### Using `HeapFile` (Low-level)
+//!
+//! ```no_run
+//! use relvar_storage::storage::HeapFile;
+//! use relvar_core::types::{RelationType, TupleType, ScalarType};
+//! use relvar_core::tuple;
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let heading = TupleType::new().with_attribute("data", ScalarType::String);
+//!     let rel_type = RelationType::new(heading);
+//!
+//!     // Create a heap file directly
+//!     let mut heap = HeapFile::create("data.heap", rel_type)?;
+//!
+//!     // Write tuples
+//!     heap.insert_tuple(&tuple! { data: "Hello" })?;
+//!
+//!     // Read tuples
+//!     let tuples = heap.scan()?;
+//!     assert_eq!(tuples.len(), 1);
+//!
+//!     Ok(())
+//! }
+//! ```
 
 #![warn(missing_docs)]
 

--- a/relvar/src/lib.rs
+++ b/relvar/src/lib.rs
@@ -1,14 +1,14 @@
 //! # Relvar - A Pure Relational Database Management System
 //!
 //! Relvar is a Rust implementation of a relational database management system (RDBMS)
-//! that strictly adheres to the principles outlined in *The Third Manifesto* by
+//! that strictly adheres to the principles outlined in *The Third Manifesto* (TTM) by
 //! C.J. Date and Hugh Darwen.
 //!
 //! ## Architecture
 //!
 //! This crate is a facade over:
-//! - `relvar-core` - Pure TTM logical model (always available)
-//! - `relvar-storage` - Persistent storage (optional, via "storage" feature)
+//! - [`relvar-core`](../relvar_core/index.html) - Pure TTM logical model (always available)
+//! - [`relvar-storage`](../relvar_storage/index.html) - Persistent storage (optional, via "storage" feature)
 //!
 //! ## Examples
 //!
@@ -36,14 +36,17 @@
 //!
 //! ### Persistent database (requires "storage" feature)
 //!
-//! ```no_run
+//! ```
 //! # #[cfg(feature = "storage")]
 //! # {
 //! use relvar::{Database, PersistentEngine};
 //! use relvar::{TupleType, RelationType, ScalarType};
 //! use relvar::tuple;
+//! use tempfile::TempDir;
 //!
-//! let mut db = Database::new(PersistentEngine::open("my_db").unwrap());
+//! // Create a temporary directory for the database
+//! let temp_dir = TempDir::new().unwrap();
+//! let mut db = Database::new(PersistentEngine::open(temp_dir.path()).unwrap());
 //!
 //! let rel_type = RelationType::new(
 //!     TupleType::new()
@@ -179,12 +182,14 @@ pub fn in_memory() -> Database<InMemoryEngine> {
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```
 /// # #[cfg(feature = "storage")]
 /// # {
 /// use relvar;
+/// use tempfile::TempDir;
 ///
-/// let mut db = relvar::open("my_database").unwrap();
+/// let temp_dir = TempDir::new().unwrap();
+/// let mut db = relvar::open(temp_dir.path()).unwrap();
 /// # }
 /// ```
 #[cfg(feature = "storage")]


### PR DESCRIPTION
This PR overhauls the documentation for the storage layer.

### 📖 Chapter: The Storage Chronicles
The `relvar-storage` crate was a mysterious black box. I have illuminated it with a comprehensive guide.

### 🔦 Insight
- **Architecture**: Explained the hierarchy from `PersistentEngine` down to `PageFile`.
- **Theory**: detailed how the physical layer respects TTM (no exposed Tuple IDs) and implements MVCC.
- **Usage**: Provided clear examples for using the storage engine directly.

### 🧪 Example
- `PersistentEngine` examples in `relvar` are now executable tests using `tempfile`, moving from `no_run` to `run`.


---
*PR created automatically by Jules for task [6108292812307207629](https://jules.google.com/task/6108292812307207629) started by @madmax983*