### PR TITLE
Atlas: Decouple experimental features and enforce encapsulation

### DIFF
--- a/relvar-core/src/database/mod.rs
+++ b/relvar-core/src/database/mod.rs
@@ -884,7 +884,7 @@ impl<E: StorageEngine> Database<E> {
 ///
 /// Stores the metadata required to evaluate a virtual relvar on demand.
 #[derive(Debug, Clone)]
-pub struct VirtualRelvarDefinition {
+pub(crate) struct VirtualRelvarDefinition {
     /// The unique name of the virtual relvar.
     pub name: String,
 

--- a/relvar-core/src/database/mod.rs
+++ b/relvar-core/src/database/mod.rs
@@ -739,7 +739,6 @@ impl<E: StorageEngine> Database<E> {
         self.virtual_relvars.insert(
             name.to_string(),
             VirtualRelvarDefinition {
-                name: name.to_string(),
                 relation_type,
                 evaluator,
             },
@@ -885,9 +884,6 @@ impl<E: StorageEngine> Database<E> {
 /// Stores the metadata required to evaluate a virtual relvar on demand.
 #[derive(Debug, Clone)]
 pub(crate) struct VirtualRelvarDefinition {
-    /// The unique name of the virtual relvar.
-    pub name: String,
-
     /// The relation type (heading) of the view.
     ///
     /// This defines the schema of the result produced by the evaluator.

--- a/relvar/src/experimental/automl.rs
+++ b/relvar/src/experimental/automl.rs
@@ -38,7 +38,8 @@
 //!     // ... more data ...
 //!
 //!     // 2. Train Model
-//!     let model = NaiveBayesClassifier::train(&mut db, "GOLF", "play")?;
+//!     let golf = db.query("GOLF")?;
+//!     let model = NaiveBayesClassifier::train(&golf, "play")?;
 //!
 //!     // 3. Predict
 //!     let t = tuple! { outlook: "sunny", humidity: "high" };
@@ -50,10 +51,8 @@
 //! ```
 
 use relvar_core::algebra::summarize::Aggregation;
-use relvar_core::database::Database;
 use relvar_core::error::DatabaseError;
-use relvar_core::storage_engine::StorageEngine;
-use relvar_core::values::{ScalarValue, Tuple};
+use relvar_core::values::{Relation, ScalarValue, Tuple};
 use std::collections::HashMap;
 
 /// A simple Naive Bayes classifier.
@@ -82,21 +81,15 @@ impl NaiveBayesClassifier {
     ///
     /// # Arguments
     ///
-    /// * `db` - The database instance.
-    /// * `rel_name` - The name of the relation containing training data.
+    /// * `relation` - The relation containing training data.
     /// * `target_attr` - The name of the target attribute (class label).
-    pub fn train<S: StorageEngine>(
-        db: &mut Database<S>,
-        rel_name: &str,
-        target_attr: &str,
-    ) -> Result<Self, DatabaseError> {
-        let relation = db.query(rel_name)?;
+    pub fn train(relation: &Relation, target_attr: &str) -> Result<Self, DatabaseError> {
         let heading = relation.relation_type().heading();
 
         if !heading.has_attribute(target_attr) {
             return Err(DatabaseError::AttributeNotFound(
                 target_attr.to_string(),
-                rel_name.to_string(),
+                "<input_relation>".to_string(),
             ));
         }
 
@@ -247,6 +240,7 @@ fn scalar_to_string(val: &ScalarValue) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use relvar_core::database::Database;
     use relvar_core::storage_engine::InMemoryEngine;
     use relvar_core::tuple;
     use relvar_core::types::{RelationType, ScalarType, TupleType};
@@ -285,7 +279,8 @@ mod tests {
         )?;
 
         // 2. Train
-        let model = NaiveBayesClassifier::train(&mut db, "GOLF", "play")?;
+        let golf = db.query("GOLF")?;
+        let model = NaiveBayesClassifier::train(&golf, "play")?;
 
         // 3. Predict
         // Test 1: Sunny (No), Hot (No), High (No), False (No/Yes) -> Expect "no"

--- a/relvar/src/experimental/search.rs
+++ b/relvar/src/experimental/search.rs
@@ -20,7 +20,7 @@
 //!    - Results are grouped by `doc_id` and ranked by `sum(count)`.
 
 use relvar_core::{
-    Database,
+    Database, QueryExecutor,
     algebra::summarize::Aggregation,
     error::DatabaseError,
     storage_engine::StorageEngine,
@@ -154,11 +154,7 @@ impl FullTextIndex {
     /// Searches the index for the given query string.
     ///
     /// Returns a relation `(doc_id, score)` where score is the sum of term frequencies.
-    pub fn search<S: StorageEngine>(
-        &self,
-        db: &Database<S>,
-        query: &str,
-    ) -> Result<Relation, DatabaseError> {
+    pub fn search(&self, db: &impl QueryExecutor, query: &str) -> Result<Relation, DatabaseError> {
         // 1. Tokenize query
         let tokens = Tokenizer::tokenize(query);
         let query_terms: Vec<String> = tokens.keys().cloned().collect();


### PR DESCRIPTION
This PR implements architectural improvements to the `relvar` codebase, focusing on high cohesion and low coupling ("Atlas" philosophy).

**Changes:**
1.  **Decoupling AutoML:** The `NaiveBayesClassifier::train` method in `relvar/src/experimental/automl.rs` previously took a mutable reference to `Database`. It has been refactored to take a reference to `Relation`. This makes the training logic pure and independent of the storage layer.
2.  **Abstracting Search:** The `FullTextIndex::search` method in `relvar/src/experimental/search.rs` previously took a reference to `Database`. It has been refactored to take `&impl QueryExecutor`. This allows the search logic to operate against any provider that implements the `query` interface.
3.  **Encapsulation:** The `VirtualRelvarDefinition` struct in `relvar-core/src/database/mod.rs` was public but is an internal detail of the `Database` implementation. It has been restricted to `pub(crate)`.

**Verification:**
- `cargo check` passes.
- `cargo test` passes (including unit tests and doc tests for modified modules).
- `cargo fmt` has been run.

---
*PR created automatically by Jules for task [11178648566202909762](https://jules.google.com/task/11178648566202909762) started by @madmax983*