### PR TITLE
Enforce schema validation for CHECK constraints on empty relations

### DIFF
--- a/relvar-core/src/constraints/check.rs
+++ b/relvar-core/src/constraints/check.rs
@@ -39,6 +39,7 @@
 use crate::constraints::expression::ConstraintExpression;
 use crate::values::Tuple;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use thiserror::Error;
 
 /// Errors that can occur during CHECK constraint evaluation.
@@ -139,6 +140,11 @@ impl CheckConstraint {
             .evaluate(tuple)
             .map_err(|e| CheckConstraintError::EvaluationError(e.to_string()))
     }
+
+    /// Returns the set of all attribute names referenced in this constraint.
+    pub fn referenced_attributes(&self) -> HashSet<String> {
+        self.expression.referenced_attributes()
+    }
 }
 
 /// A collection of CHECK constraints for a relvar.
@@ -186,6 +192,15 @@ impl CheckConstraints {
     /// Returns all constraints.
     pub fn constraints(&self) -> &[CheckConstraint] {
         &self.constraints
+    }
+
+    /// Returns the set of all attribute names referenced in all constraints.
+    pub fn referenced_attributes(&self) -> HashSet<String> {
+        let mut attributes = HashSet::new();
+        for constraint in &self.constraints {
+            attributes.extend(constraint.referenced_attributes());
+        }
+        attributes
     }
 }
 

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -32,6 +32,7 @@
 use super::prepared::PreparedConstraintExpression;
 use crate::values::{ScalarValue, Tuple};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use thiserror::Error;
 
 /// Errors that can occur during constraint expression evaluation.
@@ -141,6 +142,54 @@ pub enum ConstraintExpression {
 }
 
 impl ConstraintExpression {
+    /// Evaluates this expression against a tuple.
+    ///
+    /// Returns `true` if the tuple satisfies the constraint,
+    /// `false` otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if:
+    /// - A referenced attribute is not found in the tuple
+    /// - A type mismatch occurs during comparison
+    /// - An invalid comparison is attempted
+    /// Returns the set of all attribute names referenced in this expression.
+    ///
+    /// This includes:
+    /// - Attributes on the left side of comparisons
+    /// - Attributes referenced via `ValueOrRef::Attribute` on the right side
+    /// - Attributes used in `IN` and `LIKE` expressions
+    /// - Attributes in nested sub-expressions (AND, OR, NOT)
+    pub fn referenced_attributes(&self) -> HashSet<String> {
+        let mut attributes = HashSet::new();
+        self.collect_attributes(&mut attributes);
+        attributes
+    }
+
+    fn collect_attributes(&self, attributes: &mut HashSet<String>) {
+        match self {
+            ConstraintExpression::Cmp { left, right, .. } => {
+                attributes.insert(left.clone());
+                if let ValueOrRef::Attribute(attr) = right {
+                    attributes.insert(attr.clone());
+                }
+            }
+            ConstraintExpression::And(l, r) | ConstraintExpression::Or(l, r) => {
+                l.collect_attributes(attributes);
+                r.collect_attributes(attributes);
+            }
+            ConstraintExpression::Not(expr) => {
+                expr.collect_attributes(attributes);
+            }
+            ConstraintExpression::In(attr, _) => {
+                attributes.insert(attr.clone());
+            }
+            ConstraintExpression::Like(attr, _) => {
+                attributes.insert(attr.clone());
+            }
+        }
+    }
+
     /// Evaluates this expression against a tuple.
     ///
     /// Returns `true` if the tuple satisfies the constraint,
@@ -735,6 +784,47 @@ mod tests {
         let result = expr.evaluate(&tuple);
         assert!(result.is_err());
         assert!(matches!(result, Err(ExpressionError::TypeMismatch(_, _))));
+    }
+
+    #[test]
+    fn test_referenced_attributes() {
+        // Simple comparison
+        let expr1 = ConstraintExpression::Cmp {
+            left: "age".to_string(),
+            op: CmpOp::Gt,
+            right: ValueOrRef::Value(ScalarValue::Int(18)),
+        };
+        let attrs1 = expr1.referenced_attributes();
+        assert_eq!(attrs1.len(), 1);
+        assert!(attrs1.contains("age"));
+
+        // Attribute to attribute comparison
+        let expr2 = ConstraintExpression::Cmp {
+            left: "start_date".to_string(),
+            op: CmpOp::Le,
+            right: ValueOrRef::Attribute("end_date".to_string()),
+        };
+        let attrs2 = expr2.referenced_attributes();
+        assert_eq!(attrs2.len(), 2);
+        assert!(attrs2.contains("start_date"));
+        assert!(attrs2.contains("end_date"));
+
+        // Nested expression
+        let expr3 = ConstraintExpression::And(
+            Box::new(expr1),
+            Box::new(expr2),
+        );
+        let attrs3 = expr3.referenced_attributes();
+        assert_eq!(attrs3.len(), 3);
+        assert!(attrs3.contains("age"));
+        assert!(attrs3.contains("start_date"));
+        assert!(attrs3.contains("end_date"));
+
+        // Like expression
+        let expr4 = ConstraintExpression::Like("name".to_string(), "A%".to_string());
+        let attrs4 = expr4.referenced_attributes();
+        assert_eq!(attrs4.len(), 1);
+        assert!(attrs4.contains("name"));
     }
 }
 

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -810,10 +810,7 @@ mod tests {
         assert!(attrs2.contains("end_date"));
 
         // Nested expression
-        let expr3 = ConstraintExpression::And(
-            Box::new(expr1),
-            Box::new(expr2),
-        );
+        let expr3 = ConstraintExpression::And(Box::new(expr1), Box::new(expr2));
         let attrs3 = expr3.referenced_attributes();
         assert_eq!(attrs3.len(), 3);
         assert!(attrs3.contains("age"));

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -142,17 +142,6 @@ pub enum ConstraintExpression {
 }
 
 impl ConstraintExpression {
-    /// Evaluates this expression against a tuple.
-    ///
-    /// Returns `true` if the tuple satisfies the constraint,
-    /// `false` otherwise.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err` if:
-    /// - A referenced attribute is not found in the tuple
-    /// - A type mismatch occurs during comparison
-    /// - An invalid comparison is attempted
     /// Returns the set of all attribute names referenced in this expression.
     ///
     /// This includes:

--- a/relvar-core/src/constraints/manager.rs
+++ b/relvar-core/src/constraints/manager.rs
@@ -202,6 +202,19 @@ impl ConstraintManager {
             ));
         }
 
+        // Validate that all referenced attributes exist in the relation
+        let metadata = engine.get_relation_metadata(relation_name)?;
+        let heading = metadata.relation_type.heading();
+
+        for attr in constraints.referenced_attributes() {
+            if !heading.has_attribute(&attr) {
+                return Err(ConstraintManagerError::AttributeNotFound(
+                    attr,
+                    relation_name.to_string(),
+                ));
+            }
+        }
+
         // Validate constraints against existing data
         let relation = engine.load_relation(relation_name)?;
 

--- a/relvar-core/tests/sentry_check_constraint_validation.rs
+++ b/relvar-core/tests/sentry_check_constraint_validation.rs
@@ -1,0 +1,49 @@
+#[cfg(test)]
+mod tests {
+    use relvar_core::database::Database;
+    use relvar_core::storage_engine::InMemoryEngine;
+    use relvar_core::types::{RelationType, ScalarType, TupleType};
+    use relvar_core::constraints::{CheckConstraint, CheckConstraints, ConstraintManagerError, ConstraintExpression, CmpOp, ValueOrRef};
+    use relvar_core::values::ScalarValue;
+    use relvar_core::tuple;
+    use relvar_core::error::DatabaseError;
+
+    #[test]
+    fn test_check_constraint_invalid_attribute_empty_relation() {
+        let mut db = Database::new(InMemoryEngine::new());
+
+        let heading = TupleType::new().with_attribute("a", ScalarType::Int);
+        let rel_type = RelationType::new(heading);
+        db.create_relvar("test_rel", rel_type).unwrap();
+
+        // Relation is empty.
+        // Add a check constraint referencing non-existent attribute "b".
+        let constraint = CheckConstraint::new(
+            "invalid_attr",
+            "b must be positive",
+            ConstraintExpression::Cmp {
+                left: "b".to_string(), // "b" does not exist
+                op: CmpOp::Gt,
+                right: ValueOrRef::Value(ScalarValue::Int(0)),
+            },
+        );
+        let constraints = CheckConstraints::new().with_constraint(constraint);
+
+        // This should now FAIL because we validate against schema even if relation is empty
+        let result = db.set_check_constraints("test_rel", constraints);
+
+        assert!(result.is_err(), "Setting invalid check constraint should fail");
+
+        match result.unwrap_err() {
+            DatabaseError::Constraint(ConstraintManagerError::AttributeNotFound(attr, rel)) => {
+                assert_eq!(attr, "b");
+                assert_eq!(rel, "test_rel");
+            },
+            err => panic!("Expected AttributeNotFound error, got: {:?}", err),
+        }
+
+        // Insert should work fine (since constraint wasn't added)
+        let insert_result = db.insert("test_rel", tuple! { a: 1i64 });
+        assert!(insert_result.is_ok());
+    }
+}

--- a/relvar-core/tests/sentry_check_constraint_validation.rs
+++ b/relvar-core/tests/sentry_check_constraint_validation.rs
@@ -1,12 +1,15 @@
 #[cfg(test)]
 mod tests {
+    use relvar_core::constraints::{
+        CheckConstraint, CheckConstraints, CmpOp, ConstraintExpression, ConstraintManagerError,
+        ValueOrRef,
+    };
     use relvar_core::database::Database;
-    use relvar_core::storage_engine::InMemoryEngine;
-    use relvar_core::types::{RelationType, ScalarType, TupleType};
-    use relvar_core::constraints::{CheckConstraint, CheckConstraints, ConstraintManagerError, ConstraintExpression, CmpOp, ValueOrRef};
-    use relvar_core::values::ScalarValue;
-    use relvar_core::tuple;
     use relvar_core::error::DatabaseError;
+    use relvar_core::storage_engine::InMemoryEngine;
+    use relvar_core::tuple;
+    use relvar_core::types::{RelationType, ScalarType, TupleType};
+    use relvar_core::values::ScalarValue;
 
     #[test]
     fn test_check_constraint_invalid_attribute_empty_relation() {
@@ -32,13 +35,16 @@ mod tests {
         // This should now FAIL because we validate against schema even if relation is empty
         let result = db.set_check_constraints("test_rel", constraints);
 
-        assert!(result.is_err(), "Setting invalid check constraint should fail");
+        assert!(
+            result.is_err(),
+            "Setting invalid check constraint should fail"
+        );
 
         match result.unwrap_err() {
             DatabaseError::Constraint(ConstraintManagerError::AttributeNotFound(attr, rel)) => {
                 assert_eq!(attr, "b");
                 assert_eq!(rel, "test_rel");
-            },
+            }
             err => panic!("Expected AttributeNotFound error, got: {:?}", err),
         }
 


### PR DESCRIPTION
Implemented schema validation for CHECK constraints in `ConstraintManager::set_check_constraints`. 
Previously, constraints were only validated against existing tuples, allowing invalid constraints (referencing non-existent attributes) to be added to empty relations, causing failures on subsequent inserts.

Changes:
- Added `referenced_attributes` method to `ConstraintExpression`, `CheckConstraint`, and `CheckConstraints` to recursively collect attribute names used in expressions.
- Modified `ConstraintManager::set_check_constraints` to verify that all referenced attributes exist in the relation's heading.
- Added regression test `relvar-core/tests/sentry_check_constraint_validation.rs`.


---
*PR created automatically by Jules for task [10826034927886445739](https://jules.google.com/task/10826034927886445739) started by @madmax983*