### PR TITLE
⚒️ Forge: Optimize algebraic operators with iterator chaining

### DIFF
--- a/relvar-core/src/algebra/difference.rs
+++ b/relvar-core/src/algebra/difference.rs
@@ -111,17 +111,14 @@ impl Relation {
             return Err(DifferenceError::TypeMismatch);
         }
 
-        // Find tuples in self that are not in other
-        let diff_tuples: Vec<_> = self
-            .tuples()
-            .filter(|tuple| !other.contains(tuple))
-            .cloned()
-            .collect();
-
-        Ok(
-            Relation::from_tuples(self.relation_type().clone(), diff_tuples)
-                .expect("Difference tuples should conform to relation type"),
-        )
+        // Filter tuples and create relation without redundant checks
+        // Safety: source tuples are from a valid relation of the same type
+        Ok(Relation::from_tuples_unchecked(
+            self.relation_type().clone(),
+            self.tuples()
+                .filter(|tuple| !other.contains(tuple))
+                .cloned(),
+        ))
     }
 
     /// Alias for [`difference`](Self::difference) with SQL-style naming.

--- a/relvar-core/src/algebra/intersect.rs
+++ b/relvar-core/src/algebra/intersect.rs
@@ -112,17 +112,12 @@ impl Relation {
             return Err(IntersectError::TypeMismatch);
         }
 
-        // Find tuples that exist in both relations
-        let common_tuples: Vec<_> = self
-            .tuples()
-            .filter(|tuple| other.contains(tuple))
-            .cloned()
-            .collect();
-
-        Ok(
-            Relation::from_tuples(self.relation_type().clone(), common_tuples)
-                .expect("Intersection tuples should conform to relation type"),
-        )
+        // Filter tuples and create relation without redundant checks
+        // Safety: source tuples are from a valid relation of the same type
+        Ok(Relation::from_tuples_unchecked(
+            self.relation_type().clone(),
+            self.tuples().filter(|tuple| other.contains(tuple)).cloned(),
+        ))
     }
 }
 

--- a/relvar-core/src/algebra/restrict.rs
+++ b/relvar-core/src/algebra/restrict.rs
@@ -83,14 +83,12 @@ impl Relation {
     where
         F: Fn(&Tuple) -> bool,
     {
-        let filtered_tuples: Vec<_> = self
-            .tuples()
-            .filter(|tuple| predicate(tuple))
-            .cloned()
-            .collect();
-
-        Relation::from_tuples(self.relation_type().clone(), filtered_tuples)
-            .expect("Filtered tuples should conform to relation type")
+        // Filter tuples and create relation without redundant checks
+        // Safety: source tuples are from a valid relation
+        Relation::from_tuples_unchecked(
+            self.relation_type().clone(),
+            self.tuples().filter(|tuple| predicate(tuple)).cloned(),
+        )
     }
 }
 

--- a/relvar-core/src/algebra/union.rs
+++ b/relvar-core/src/algebra/union.rs
@@ -106,15 +106,12 @@ impl Relation {
             return Err(UnionError::TypeMismatch);
         }
 
-        // Collect all tuples from both relations
-        let mut all_tuples: Vec<_> = self.tuples().cloned().collect();
-        all_tuples.extend(other.tuples().cloned());
-
-        // from_tuples automatically removes duplicates via HashSet
-        Ok(
-            Relation::from_tuples(self.relation_type().clone(), all_tuples)
-                .expect("Union tuples should conform to relation type"),
-        )
+        // Chain iterators and create relation without redundant checks
+        // Safety: both relations are verified to have the same type, so their tuples must conform
+        Ok(Relation::from_tuples_unchecked(
+            self.relation_type().clone(),
+            self.tuples().chain(other.tuples()).cloned(),
+        ))
     }
 }
 


### PR DESCRIPTION
🚮 Smell: Intermediate `Vec` allocations and redundant type checks in `union`, `difference`, `intersect`, and `restrict`.
✨ Solution: Replaced `collect::<Vec<_>>()` with iterator chaining and used `Relation::from_tuples_unchecked` where input tuples are guaranteed to be valid.
🧼 Benefit: Reduces memory overhead and improves performance by avoiding unnecessary allocations and traversals.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [14750897413941922513](https://jules.google.com/task/14750897413941922513) started by @madmax983*