### PR TITLE
🗺️ Atlas: Refactor `relvar-core` Database module

### DIFF
--- a/relvar-core/src/database/dml.rs
+++ b/relvar-core/src/database/dml.rs
@@ -1,0 +1,60 @@
+use crate::error::DatabaseError;
+use crate::values::{Relation, Tuple};
+
+pub(crate) fn compute_relation_after_delete<F>(
+    current_relation: Relation,
+    predicate: F,
+) -> Result<(Relation, usize), DatabaseError>
+where
+    F: Fn(&Tuple) -> bool,
+{
+    let initial_cardinality = current_relation.cardinality();
+    let relation_type = current_relation.relation_type().clone();
+
+    let kept_tuples: Vec<Tuple> = current_relation
+        .into_iter()
+        .filter(|tuple| !predicate(tuple))
+        .collect();
+
+    let delete_count = initial_cardinality - kept_tuples.len();
+
+    let new_relation = Relation::from_tuples(relation_type, kept_tuples)?;
+
+    Ok((new_relation, delete_count))
+}
+
+pub(crate) fn compute_relation_after_update<F, U>(
+    current_relation: Relation,
+    predicate: F,
+    updater: U,
+) -> Result<(Relation, usize), DatabaseError>
+where
+    F: Fn(&Tuple) -> bool,
+    U: Fn(&Tuple) -> Tuple,
+{
+    let relation_type = current_relation.relation_type().clone();
+    let expected_type = relation_type.tuple_type().clone();
+    let initial_cardinality = current_relation.cardinality();
+
+    let (tuples, update_count) = current_relation.into_iter().try_fold(
+        (Vec::with_capacity(initial_cardinality), 0),
+        |(mut acc, count), tuple| {
+            if predicate(&tuple) {
+                let updated_tuple = updater(&tuple);
+
+                if !updated_tuple.conforms_to(&expected_type) {
+                    return Err(DatabaseError::TupleMismatch);
+                }
+                acc.push(updated_tuple);
+                Ok((acc, count + 1))
+            } else {
+                acc.push(tuple);
+                Ok((acc, count))
+            }
+        },
+    )?;
+
+    let new_relation = Relation::from_tuples(relation_type, tuples)?;
+
+    Ok((new_relation, update_count))
+}

--- a/relvar-core/src/database/mod.rs
+++ b/relvar-core/src/database/mod.rs
@@ -80,6 +80,12 @@ use crate::values::{Relation, Tuple};
 
 use std::collections::HashMap;
 
+mod dml;
+mod virtual_relvar;
+
+use self::dml::{compute_relation_after_delete, compute_relation_after_update};
+pub(crate) use self::virtual_relvar::VirtualRelvarDefinition;
+
 /// A relational database instance.
 ///
 /// The `Database` struct is the primary interface for interacting with Relvar. It is
@@ -549,7 +555,7 @@ impl<E: StorageEngine> Database<E> {
 
         // Filter out tuples to delete
         let (new_relation, delete_count) =
-            self.compute_relation_after_delete(current_relation, predicate)?;
+            compute_relation_after_delete(current_relation, predicate)?;
 
         self.constraints.validate_referencing_foreign_keys(
             &mut self.engine,
@@ -635,7 +641,7 @@ impl<E: StorageEngine> Database<E> {
 
         // Apply updates
         let (new_relation, update_count) =
-            self.compute_relation_after_update(current_relation, predicate, updater)?;
+            compute_relation_after_update(current_relation, predicate, updater)?;
 
         self.validate_relation_constraints(relation_name, &new_relation)?;
 
@@ -771,66 +777,6 @@ impl<E: StorageEngine> Database<E> {
         }
     }
 
-    fn compute_relation_after_delete<F>(
-        &self,
-        current_relation: Relation,
-        predicate: F,
-    ) -> Result<(Relation, usize), DatabaseError>
-    where
-        F: Fn(&Tuple) -> bool,
-    {
-        let initial_cardinality = current_relation.cardinality();
-        let relation_type = current_relation.relation_type().clone();
-
-        let kept_tuples: Vec<Tuple> = current_relation
-            .into_iter()
-            .filter(|tuple| !predicate(tuple))
-            .collect();
-
-        let delete_count = initial_cardinality - kept_tuples.len();
-
-        let new_relation = Relation::from_tuples(relation_type, kept_tuples)?;
-
-        Ok((new_relation, delete_count))
-    }
-
-    fn compute_relation_after_update<F, U>(
-        &self,
-        current_relation: Relation,
-        predicate: F,
-        updater: U,
-    ) -> Result<(Relation, usize), DatabaseError>
-    where
-        F: Fn(&Tuple) -> bool,
-        U: Fn(&Tuple) -> Tuple,
-    {
-        let relation_type = current_relation.relation_type().clone();
-        let expected_type = relation_type.tuple_type().clone();
-        let initial_cardinality = current_relation.cardinality();
-
-        let (tuples, update_count) = current_relation.into_iter().try_fold(
-            (Vec::with_capacity(initial_cardinality), 0),
-            |(mut acc, count), tuple| {
-                if predicate(&tuple) {
-                    let updated_tuple = updater(&tuple);
-
-                    if !updated_tuple.conforms_to(&expected_type) {
-                        return Err(DatabaseError::TupleMismatch);
-                    }
-                    acc.push(updated_tuple);
-                    Ok((acc, count + 1))
-                } else {
-                    acc.push(tuple);
-                    Ok((acc, count))
-                }
-            },
-        )?;
-
-        let new_relation = Relation::from_tuples(relation_type, tuples)?;
-
-        Ok((new_relation, update_count))
-    }
-
     fn validate_insert(&mut self, relation_name: &str, tuple: &Tuple) -> Result<(), DatabaseError> {
         // Pure checks and Type validations
         self.constraints
@@ -877,35 +823,6 @@ impl<E: StorageEngine> Database<E> {
 
         Ok(())
     }
-}
-
-/// Definition of a virtual relvar (view).
-///
-/// Stores the metadata required to evaluate a virtual relvar on demand.
-#[derive(Debug, Clone)]
-pub(crate) struct VirtualRelvarDefinition {
-    /// The relation type (heading) of the view.
-    ///
-    /// This defines the schema of the result produced by the evaluator.
-    /// The database uses this to validate queries against the view without
-    /// needing to evaluate it first.
-    pub relation_type: RelationType,
-
-    /// The evaluation function (closure) that computes the view's contents.
-    ///
-    /// # Signature
-    ///
-    /// `fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError>`
-    ///
-    /// - **Input**: A `&dyn QueryExecutor`, which allows the view
-    ///   to query other relvars (base or virtual) in the database.
-    /// - **Output**: A `Result` containing the computed `Relation`.
-    ///
-    /// # Safety
-    ///
-    /// The evaluator is passed a read-only reference (`&`), ensuring that
-    /// viewing a relation cannot cause side effects (mutations) in the database.
-    pub evaluator: fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError>,
 }
 
 #[cfg(test)]

--- a/relvar-core/src/database/virtual_relvar.rs
+++ b/relvar-core/src/database/virtual_relvar.rs
@@ -1,0 +1,33 @@
+use crate::error::DatabaseError;
+use crate::traits::QueryExecutor;
+use crate::types::RelationType;
+use crate::values::Relation;
+
+/// Definition of a virtual relvar (view).
+///
+/// Stores the metadata required to evaluate a virtual relvar on demand.
+#[derive(Debug, Clone)]
+pub(crate) struct VirtualRelvarDefinition {
+    /// The relation type (heading) of the view.
+    ///
+    /// This defines the schema of the result produced by the evaluator.
+    /// The database uses this to validate queries against the view without
+    /// needing to evaluate it first.
+    pub relation_type: RelationType,
+
+    /// The evaluation function (closure) that computes the view's contents.
+    ///
+    /// # Signature
+    ///
+    /// `fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError>`
+    ///
+    /// - **Input**: A `&dyn QueryExecutor`, which allows the view
+    ///   to query other relvars (base or virtual) in the database.
+    /// - **Output**: A `Result` containing the computed `Relation`.
+    ///
+    /// # Safety
+    ///
+    /// The evaluator is passed a read-only reference (`&`), ensuring that
+    /// viewing a relation cannot cause side effects (mutations) in the database.
+    pub evaluator: fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError>,
+}


### PR DESCRIPTION
🕸️ Tangle: The `relvar-core/src/database/mod.rs` file was becoming a "Blob" (900+ lines), mixing the Facade pattern responsibilities of the `Database` struct with low-level DML computation logic and auxiliary struct definitions like `VirtualRelvarDefinition`.

📐 Blueprint: 
1.  Extracted `VirtualRelvarDefinition` into a new module `relvar-core/src/database/virtual_relvar.rs`.
2.  Extracted the pure functional DML logic (`compute_relation_after_delete`, `compute_relation_after_update`) into `relvar-core/src/database/dml.rs`.
3.  Updated `relvar-core/src/database/mod.rs` to import and use these components, keeping `Database` focused on orchestration.

🧱 Stability: The refactoring involves moving code to pure functions and separate structs without changing logic. All tests passed, ensuring no regression. API compatibility is maintained by re-exporting `VirtualRelvarDefinition`.

🔬 Verification: Ran `cargo check` and `cargo test`. All 110 tests in `relvar-core` passed.

---
*PR created automatically by Jules for task [17775973398166771057](https://jules.google.com/task/17775973398166771057) started by @madmax983*