### PR TITLE
🛡️ Sentry: Fix stack overflow in ScalarValue Drop/Eq/Hash

### DIFF
--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -219,7 +219,11 @@ impl Drop for ScalarValue {
         if let ScalarValue::UserDefined { value, .. } = self {
             // Iteratively drop nested UserDefined values to prevent stack overflow
             let mut current = std::mem::replace(value, Box::new(ScalarValue::Int(0)));
-            while let ScalarValue::UserDefined { value: ref mut next, .. } = *current {
+            while let ScalarValue::UserDefined {
+                value: ref mut next,
+                ..
+            } = *current
+            {
                 current = std::mem::replace(next, Box::new(ScalarValue::Int(0)));
             }
         }
@@ -333,7 +337,10 @@ impl std::hash::Hash for ScalarValue {
                 let mut cur = value;
                 loop {
                     match &**cur {
-                        ScalarValue::UserDefined { type_def: t, value: v } => {
+                        ScalarValue::UserDefined {
+                            type_def: t,
+                            value: v,
+                        } => {
                             6u8.hash(state);
                             t.hash(state);
                             cur = v;
@@ -454,15 +461,13 @@ impl Ord for ScalarValue {
                                                 type_def: tb,
                                                 value: vb,
                                             },
-                                        ) => {
-                                            match ta.cmp(tb) {
-                                                Ordering::Equal => {
-                                                    cur_a = va;
-                                                    cur_b = vb;
-                                                }
-                                                other => return other,
+                                        ) => match ta.cmp(tb) {
+                                            Ordering::Equal => {
+                                                cur_a = va;
+                                                cur_b = vb;
                                             }
-                                        }
+                                            other => return other,
+                                        },
                                         (a, b) => return a.cmp(b),
                                     }
                                 }

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -214,6 +214,18 @@ impl ScalarValue {
     }
 }
 
+impl Drop for ScalarValue {
+    fn drop(&mut self) {
+        if let ScalarValue::UserDefined { value, .. } = self {
+            // Iteratively drop nested UserDefined values to prevent stack overflow
+            let mut current = std::mem::replace(value, Box::new(ScalarValue::Int(0)));
+            while let ScalarValue::UserDefined { value: ref mut next, .. } = *current {
+                current = std::mem::replace(next, Box::new(ScalarValue::Int(0)));
+            }
+        }
+    }
+}
+
 // Custom PartialEq implementation for ScalarValue
 // Note: Float comparison uses bit equality, which is appropriate for
 // database values (we want NaN == NaN for set semantics)
@@ -244,7 +256,35 @@ impl PartialEq for ScalarValue {
                     type_def: type_b,
                     value: val_b,
                 },
-            ) => type_a == type_b && val_a == val_b,
+            ) => {
+                if type_a != type_b {
+                    return false;
+                }
+                // Iterative comparison to prevent stack overflow
+                let mut cur_a = val_a;
+                let mut cur_b = val_b;
+                loop {
+                    match (&**cur_a, &**cur_b) {
+                        (
+                            ScalarValue::UserDefined {
+                                type_def: ta,
+                                value: va,
+                            },
+                            ScalarValue::UserDefined {
+                                type_def: tb,
+                                value: vb,
+                            },
+                        ) => {
+                            if ta != tb {
+                                return false;
+                            }
+                            cur_a = va;
+                            cur_b = vb;
+                        }
+                        (a, b) => return a == b,
+                    }
+                }
+            }
             _ => false,
         }
     }
@@ -289,7 +329,21 @@ impl std::hash::Hash for ScalarValue {
             ScalarValue::UserDefined { type_def, value } => {
                 6u8.hash(state);
                 type_def.hash(state);
-                value.hash(state);
+                // Iterative hash to prevent stack overflow
+                let mut cur = value;
+                loop {
+                    match &**cur {
+                        ScalarValue::UserDefined { type_def: t, value: v } => {
+                            6u8.hash(state);
+                            t.hash(state);
+                            cur = v;
+                        }
+                        other => {
+                            other.hash(state);
+                            break;
+                        }
+                    }
+                }
             }
         }
     }
@@ -385,7 +439,34 @@ impl Ord for ScalarValue {
                     ) => {
                         // Order by type identity first (structural comparison), then by value
                         match type_a.cmp(type_b) {
-                            Ordering::Equal => val_a.cmp(val_b),
+                            Ordering::Equal => {
+                                // Iterative comparison to prevent stack overflow
+                                let mut cur_a = val_a;
+                                let mut cur_b = val_b;
+                                loop {
+                                    match (&**cur_a, &**cur_b) {
+                                        (
+                                            ScalarValue::UserDefined {
+                                                type_def: ta,
+                                                value: va,
+                                            },
+                                            ScalarValue::UserDefined {
+                                                type_def: tb,
+                                                value: vb,
+                                            },
+                                        ) => {
+                                            match ta.cmp(tb) {
+                                                Ordering::Equal => {
+                                                    cur_a = va;
+                                                    cur_b = vb;
+                                                }
+                                                other => return other,
+                                            }
+                                        }
+                                        (a, b) => return a.cmp(b),
+                                    }
+                                }
+                            }
                             other => other,
                         }
                     }

--- a/relvar-core/src/values/tuple.rs
+++ b/relvar-core/src/values/tuple.rs
@@ -383,9 +383,9 @@ impl TryFrom<ScalarValue> for f64 {
 
 impl TryFrom<ScalarValue> for String {
     type Error = ();
-    fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
+    fn try_from(mut value: ScalarValue) -> Result<Self, Self::Error> {
         match value {
-            ScalarValue::String(v) => Ok(v),
+            ScalarValue::String(ref mut v) => Ok(std::mem::take(v)),
             _ => Err(()),
         }
     }
@@ -396,6 +396,16 @@ impl TryFrom<ScalarValue> for bool {
     fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
         match value {
             ScalarValue::Bool(v) => Ok(v),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<ScalarValue> for Vec<u8> {
+    type Error = ();
+    fn try_from(mut value: ScalarValue) -> Result<Self, Self::Error> {
+        match value {
+            ScalarValue::Bytes(ref mut v) => Ok(std::mem::take(v)),
             _ => Err(()),
         }
     }

--- a/relvar-core/tests/sentry_stack_overflow.rs
+++ b/relvar-core/tests/sentry_stack_overflow.rs
@@ -1,0 +1,76 @@
+use relvar_core::values::ScalarValue;
+use relvar_core::types::ScalarType;
+use std::hash::{Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
+
+#[test]
+fn test_deeply_nested_drop_should_not_overflow() {
+    let mut val = ScalarValue::Int(0);
+    let type_def = ScalarType::user_defined("RecursiveType", ScalarType::Int);
+
+    // 100,000 layers should be enough to blow the stack on most systems if recursion is present
+    for _ in 0..100000 {
+        val = ScalarValue::UserDefined {
+            type_def: type_def.clone(),
+            value: Box::new(val),
+        };
+    }
+}
+
+#[test]
+fn test_deeply_nested_eq_should_not_overflow() {
+    let mut val1 = ScalarValue::Int(0);
+    let mut val2 = ScalarValue::Int(0);
+    let type_def = ScalarType::user_defined("RecursiveType", ScalarType::Int);
+
+    for _ in 0..100000 {
+        val1 = ScalarValue::UserDefined {
+            type_def: type_def.clone(),
+            value: Box::new(val1),
+        };
+        val2 = ScalarValue::UserDefined {
+            type_def: type_def.clone(),
+            value: Box::new(val2),
+        };
+    }
+
+    assert_eq!(val1, val2);
+}
+
+#[test]
+fn test_deeply_nested_hash_should_not_overflow() {
+    let mut val = ScalarValue::Int(0);
+    let type_def = ScalarType::user_defined("RecursiveType", ScalarType::Int);
+
+    for _ in 0..100000 {
+        val = ScalarValue::UserDefined {
+            type_def: type_def.clone(),
+            value: Box::new(val),
+        };
+    }
+
+    let mut hasher = DefaultHasher::new();
+    val.hash(&mut hasher);
+    let _hash = hasher.finish();
+}
+
+#[test]
+fn test_deeply_nested_ord_should_not_overflow() {
+    let mut val1 = ScalarValue::Int(0);
+    let mut val2 = ScalarValue::Int(0);
+    let type_def = ScalarType::user_defined("RecursiveType", ScalarType::Int);
+
+    for _ in 0..100000 {
+        val1 = ScalarValue::UserDefined {
+            type_def: type_def.clone(),
+            value: Box::new(val1),
+        };
+        val2 = ScalarValue::UserDefined {
+            type_def: type_def.clone(),
+            value: Box::new(val2),
+        };
+    }
+
+    // This triggers Ord::cmp
+    assert!(val1 <= val2);
+}

--- a/relvar-core/tests/sentry_stack_overflow.rs
+++ b/relvar-core/tests/sentry_stack_overflow.rs
@@ -1,7 +1,7 @@
-use relvar_core::values::ScalarValue;
 use relvar_core::types::ScalarType;
-use std::hash::{Hash, Hasher};
+use relvar_core::values::ScalarValue;
 use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 #[test]
 fn test_deeply_nested_drop_should_not_overflow() {

--- a/relvar/src/experimental/spatial.rs
+++ b/relvar/src/experimental/spatial.rs
@@ -136,7 +136,7 @@ fn extract_coords(p: &ScalarValue) -> Result<(f64, f64), String> {
     let inner_val = p.observer().map_err(|_| "Not a user-defined type")?;
 
     match inner_val {
-        ScalarValue::Relation(rel) => {
+        ScalarValue::Relation(ref rel) => {
             if rel.cardinality() != 1 {
                 return Err("Point relation must have exactly 1 tuple".to_string());
             }


### PR DESCRIPTION
This PR addresses a critical stability issue where deeply nested `ScalarValue::UserDefined` structures could cause a stack overflow during `Drop`, `PartialEq`, `Hash`, or `Ord` operations.

### The Vulnerability
Although `ScalarValue` deserialization is protected by recursion limits (`RecursionGuard`), users can programmatically construct deeply nested structures (e.g., linked lists using `UserDefined` types). When these structures go out of scope, the default recursive `Drop` implementation blows the stack. Similarly, comparing or hashing these structures would crash.

### The Fix
1.  **Iterative Drop:** Implemented `Drop` for `ScalarValue` that uses a loop and `std::mem::replace` to iteratively unwind `UserDefined` chains, ensuring $O(1)$ stack usage for cleanup.
2.  **Iterative Trait Impls:** Replaced recursive logic in `PartialEq`, `Hash`, and `Ord` with iterative loops for `UserDefined` variants.
3.  **Tuple Compatibility:** Updated `impl TryFrom<ScalarValue>` in `tuple.rs`. Since `ScalarValue` now implements `Drop`, partial moves are forbidden. We now use `std::mem::take` (via `Default`) to extract `String` and `Vec<u8>` values safely.

### Verification
Added `relvar-core/tests/sentry_stack_overflow.rs` which constructs a 100,000-deep nested `UserDefined` structure and asserts that `Drop`, `Eq`, `Hash`, and `Ord` complete successfully without crashing.

Full regression suite passed.

---
*PR created automatically by Jules for task [13274108863914550032](https://jules.google.com/task/13274108863914550032) started by @madmax983*