### PR TITLE
docs: improve experimental module documentation

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -34,3 +34,7 @@ This ensures the map matches the territory.
 ## 2024-05-27 - The Ghost Variants
 **Confusion:** The `ScalarValueError` and `RelationError` enums had variants that were technically public but lacked documentation explaining *when* they occur or *what* they mean. This forced users to guess based on the variant name.
 **Clarification:** I've added detailed documentation to these enum variants, explaining the specific conditions that trigger them (e.g., `NotUserDefined` only happens when calling `observer()` on a built-in type).
+
+## 2024-05-27 - Time Series Self-Join Collision
+**Confusion:** The `moving_average` function silently failed or produced incorrect results when the input relation had attributes ending in `_prev`.
+**Clarification:** The function implements a self-join by renaming the "previous" relation's attributes with a `_prev` suffix. This naive implementation causes a name collision if the input relation already has such attributes. I've documented this as a `# Known Issue` and advised users to avoid the `_prev` suffix in input data.

--- a/relvar/src/experimental/automl.rs
+++ b/relvar/src/experimental/automl.rs
@@ -14,40 +14,40 @@
 //! # Example
 //!
 //! ```
+//! use relvar::{Database, InMemoryEngine, tuple};
+//! use relvar::{RelationType, ScalarType, TupleType};
+//! use relvar::{ScalarValue, Relation};
 //! use relvar::experimental::automl::NaiveBayesClassifier;
-//! use relvar_core::Database;
-//! use relvar_core::storage_engine::InMemoryEngine;
-//! use relvar_core::types::{RelationType, ScalarType, TupleType};
-//! use relvar_core::values::{Relation, ScalarValue};
-//! use relvar_core::tuple;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let mut db = Database::new(InMemoryEngine::new());
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // 1. Setup Database
+//! let mut db = Database::new(InMemoryEngine::new());
 //!
-//!     // 1. Create Training Data
-//!     let heading = TupleType::new()
-//!         .with_attribute("outlook", ScalarType::String)
-//!         .with_attribute("humidity", ScalarType::String)
-//!         .with_attribute("play", ScalarType::String);
+//! // 2. Create Training Data Schema
+//! let heading = TupleType::new()
+//!     .with_attribute("outlook", ScalarType::String)
+//!     .with_attribute("humidity", ScalarType::String)
+//!     .with_attribute("play", ScalarType::String);
 //!
-//!     let rel_type = RelationType::new(heading);
-//!     db.create_relvar("GOLF", rel_type)?;
+//! db.create_relvar("GOLF", RelationType::new(heading))?;
 //!
-//!     db.insert("GOLF", tuple! { outlook: "sunny", humidity: "high", play: "no" })?;
-//!     db.insert("GOLF", tuple! { outlook: "overcast", humidity: "normal", play: "yes" })?;
-//!     // ... more data ...
+//! // 3. Insert Training Data
+//! db.insert("GOLF", tuple! { outlook: "sunny", humidity: "high", play: "no" })?;
+//! db.insert("GOLF", tuple! { outlook: "overcast", humidity: "normal", play: "yes" })?;
+//! // ... (in real usage, you'd add more data) ...
 //!
-//!     // 2. Train Model
-//!     let golf = db.query("GOLF")?;
-//!     let model = NaiveBayesClassifier::train(&golf, "play")?;
+//! // 4. Train Model
+//! let golf = db.query("GOLF")?;
+//! let model = NaiveBayesClassifier::train(&golf, "play")?;
 //!
-//!     // 3. Predict
-//!     let t = tuple! { outlook: "sunny", humidity: "high" };
-//!     let prediction = model.predict(&t);
+//! // 5. Predict
+//! let t = tuple! { outlook: "sunny", humidity: "high" };
+//! let prediction = model.predict(&t);
 //!
-//!     assert_eq!(prediction, ScalarValue::String("no".to_string()));
-//!     Ok(())
-//! }
+//! // With very limited data (sunny=no, overcast=yes), sunny predicts "no"
+//! assert_eq!(prediction, ScalarValue::String("no".to_string()));
+//! # Ok(())
+//! # }
 //! ```
 
 use relvar_core::algebra::summarize::Aggregation;
@@ -83,6 +83,11 @@ impl NaiveBayesClassifier {
     ///
     /// * `relation` - The relation containing training data.
     /// * `target_attr` - The name of the target attribute (class label).
+    ///
+    /// # Errors
+    ///
+    /// Returns `DatabaseError::AttributeNotFound` if `target_attr` is not in the relation.
+    /// Returns `DatabaseError::AlgebraError` if internal algebra operations fail.
     pub fn train(relation: &Relation, target_attr: &str) -> Result<Self, DatabaseError> {
         let heading = relation.relation_type().heading();
 

--- a/relvar/src/experimental/ecs.rs
+++ b/relvar/src/experimental/ecs.rs
@@ -12,24 +12,23 @@
 //! # Usage
 //!
 //! ```
+//! use relvar::{InMemoryEngine, ScalarType, tuple};
 //! use relvar::experimental::ecs::World;
-//! use relvar_core::storage_engine::InMemoryEngine;
-//! use relvar_core::types::ScalarType;
-//! use relvar_core::tuple;
-//! use relvar_core::values::ScalarValue;
 //!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut world = World::new(InMemoryEngine::new());
 //!
 //! // 1. Define Components
-//! world.register_component("Position", &[("x", ScalarType::Float), ("y", ScalarType::Float)]).unwrap();
-//! world.register_component("Velocity", &[("vx", ScalarType::Float), ("vy", ScalarType::Float)]).unwrap();
+//! world.register_component("Position", &[("x", ScalarType::Float), ("y", ScalarType::Float)])?;
+//! world.register_component("Velocity", &[("vx", ScalarType::Float), ("vy", ScalarType::Float)])?;
 //!
 //! // 2. Create Entity
-//! let e = world.spawn().unwrap();
-//! world.add_component(e, "Position", tuple! { x: 0.0, y: 0.0 }).unwrap();
-//! world.add_component(e, "Velocity", tuple! { vx: 1.0, vy: 1.0 }).unwrap();
+//! let e = world.spawn()?;
+//! world.add_component(e, "Position", tuple! { x: 0.0, y: 0.0 })?;
+//! world.add_component(e, "Velocity", tuple! { vx: 1.0, vy: 1.0 })?;
 //!
 //! // 3. Run System (Update Position based on Velocity)
+//! // System: For every entity with Position AND Velocity, update Position
 //! world.run_update_system("Position", &["Velocity"], |joined_tuple| {
 //!     let x = joined_tuple.get_typed::<f64>("x").unwrap();
 //!     let y = joined_tuple.get_typed::<f64>("y").unwrap();
@@ -40,12 +39,20 @@
 //!         x: x + vx,
 //!         y: y + vy
 //!     }
-//! }).unwrap();
+//! })?;
 //!
 //! // 4. Verify
-//! let pos = world.get_component(e, "Position").unwrap();
+//! let pos = world.get_component(e, "Position")?;
 //! assert_eq!(pos.get_typed::<f64>("x"), Some(1.0));
+//! # Ok(())
+//! # }
 //! ```
+//!
+//! # Limitations
+//!
+//! The `World` struct maintains the `next_entity_id` counter in memory. If the `World` instance
+//! is dropped, this counter is lost. When using a persistent engine, you must manually manage
+//! entity ID generation or serialize the `World` state to persist this counter.
 
 use relvar_core::database::{Database, DatabaseError};
 use relvar_core::storage_engine::StorageEngine;

--- a/relvar/src/experimental/graph.rs
+++ b/relvar/src/experimental/graph.rs
@@ -7,35 +7,36 @@
 //! # Example: Breadth-First Search (BFS)
 //!
 //! ```
+//! use relvar::{Relation, RelationType, ScalarType, TupleType, ScalarValue, tuple};
 //! use relvar::experimental::graph::Graph;
-//! use relvar_core::values::{Relation, ScalarValue};
-//! use relvar_core::types::{RelationType, TupleType, ScalarType};
-//! use relvar_core::tuple;
 //!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // 1. Define Nodes: {id}
 //! let node_heading = TupleType::new().with_attribute("id", ScalarType::Int);
 //! let mut nodes = Relation::new(RelationType::new(node_heading));
-//! nodes.insert(tuple! { id: 1i64 }).unwrap();
-//! nodes.insert(tuple! { id: 2i64 }).unwrap();
-//! nodes.insert(tuple! { id: 3i64 }).unwrap();
+//! nodes.insert(tuple! { id: 1i64 })?;
+//! nodes.insert(tuple! { id: 2i64 })?;
+//! nodes.insert(tuple! { id: 3i64 })?;
 //!
 //! // 2. Define Edges: {from, to}
 //! let edge_heading = TupleType::new()
 //!     .with_attribute("from", ScalarType::Int)
 //!     .with_attribute("to", ScalarType::Int);
 //! let mut edges = Relation::new(RelationType::new(edge_heading));
-//! edges.insert(tuple! { from: 1i64, to: 2i64 }).unwrap();
-//! edges.insert(tuple! { from: 2i64, to: 3i64 }).unwrap();
+//! edges.insert(tuple! { from: 1i64, to: 2i64 })?;
+//! edges.insert(tuple! { from: 2i64, to: 3i64 })?;
 //!
 //! // 3. Create Graph View
 //! let graph = Graph::new(nodes, edges, "id", "from", "to");
 //!
 //! // 4. Run BFS from node 1
-//! let distances = graph.bfs(ScalarValue::Int(1)).unwrap();
+//! let distances = graph.bfs(ScalarValue::Int(1))?;
 //!
 //! // Result: 1->0, 2->1, 3->2
 //! let t3 = distances.tuples().find(|t| t.get_typed::<i64>("id") == Some(3)).unwrap();
-//! assert_eq!(t3.get_typed::<i64>("distance").unwrap(), 2);
+//! assert_eq!(t3.get_typed::<i64>("distance"), Some(2));
+//! # Ok(())
+//! # }
 //! ```
 
 use relvar_core::algebra::summarize::Aggregation;
@@ -86,6 +87,11 @@ impl Graph {
     ///
     /// Returns a relation with heading `(node_id, distance)` containing all
     /// reachable nodes and their shortest distance from the start node.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DatabaseError::AlgebraError` if internal relational operations (Join, Project, etc.) fail,
+    /// typically due to schema mismatches or invalid attribute names.
     pub fn bfs(&self, start_node_id: ScalarValue) -> Result<Relation, DatabaseError> {
         // 1. Initialize result schema: (node_id, distance)
         let result_heading = TupleType::new()
@@ -215,6 +221,10 @@ impl Graph {
     /// # Returns
     ///
     /// A relation with heading `(node_id, rank)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DatabaseError::AlgebraError` if internal relational operations fail.
     pub fn pagerank(
         &self,
         iterations: usize,

--- a/relvar/src/experimental/mod.rs
+++ b/relvar/src/experimental/mod.rs
@@ -5,15 +5,15 @@
 //!
 //! # Included Features
 //!
-//! - **Pivot**: Operator to rotate unique values from one column into multiple columns.
-//! - **Mock**: Tools for generating random relations for testing.
-//! - **Spatial**: Spatial data types.
-//! - **Search**: Relational Full-Text Search.
-//! - **Image**: Relational Image Processing (RIP).
-//! - **Graph**: Relational Graph Analytics (BFS, PageRank).
-//! - **AutoML**: Relational Machine Learning (Naive Bayes).
-//! - **Time Series**: Relational Time Series Analysis (Moving Averages).
-//! - **ECS**: Relational Entity Component System.
+//! - **[`automl`](crate::experimental::automl)**: Relational Machine Learning (Naive Bayes).
+//! - **[`ecs`](crate::experimental::ecs)**: Relational Entity Component System (ECS) pattern.
+//! - **[`graph`](crate::experimental::graph)**: Relational Graph Analytics (BFS, PageRank).
+//! - **[`image`](crate::experimental::image)**: Relational Image Processing (RIP).
+//! - **[`mock`](crate::experimental::mock)**: Tools for generating random relations for testing.
+//! - **[`pivot`](crate::experimental::pivot)**: Operator to rotate unique values from one column into multiple columns.
+//! - **[`search`](crate::experimental::search)**: Relational Full-Text Search.
+//! - **[`spatial`](crate::experimental::spatial)**: Spatial data types and operations.
+//! - **[`timeseries`](crate::experimental::timeseries)**: Relational Time Series Analysis (Moving Averages).
 
 pub mod automl;
 pub mod ecs;

--- a/relvar/src/experimental/timeseries.rs
+++ b/relvar/src/experimental/timeseries.rs
@@ -38,6 +38,7 @@ use relvar_core::values::{Relation, ScalarValue};
 /// use relvar::{tuple, Relation, RelationType, TupleType, ScalarType};
 /// use relvar::experimental::timeseries::moving_average;
 ///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// // Create a relation with (time, value)
 /// let mut rel = Relation::new(RelationType::new(
 ///     TupleType::new()
@@ -45,15 +46,27 @@ use relvar_core::values::{Relation, ScalarValue};
 ///         .with_attribute("value", ScalarType::Float)
 /// ));
 ///
-/// rel.insert(tuple! { time: 1, value: 10.0 }).unwrap();
-/// rel.insert(tuple! { time: 2, value: 20.0 }).unwrap();
-/// rel.insert(tuple! { time: 3, value: 30.0 }).unwrap();
+/// rel.insert(tuple! { time: 1, value: 10.0 })?;
+/// rel.insert(tuple! { time: 2, value: 20.0 })?;
+/// rel.insert(tuple! { time: 3, value: 30.0 })?;
 ///
 /// // Compute 2-period moving average
-/// let result = moving_average(&rel, "time", "value", 2, &[]).unwrap();
+/// let result = moving_average(&rel, "time", "value", 2, &[])?;
 ///
 /// // Result at time 3: avg(20, 30) = 25.0
+/// let t3 = result.tuples().find(|t| t.get_typed::<i64>("time") == Some(3)).unwrap();
+/// assert_eq!(t3.get_typed::<f64>("moving_avg"), Some(25.0));
+/// # Ok(())
+/// # }
 /// ```
+///
+/// # Known Issues
+///
+/// * **Attribute Naming Collision**: This function works by self-joining the relation. To do this,
+///   it renames the attributes of the "previous" relation by appending `_prev` to them.
+///   If your input relation already contains attributes ending in `_prev` that would conflict
+///   with these generated names, the function will fail (panic or return error depending on the exact conflict).
+///   **Workaround**: Ensure input attributes do not end with `_prev`.
 pub fn moving_average(
     relation: &Relation,
     time_attr: &str,

--- a/relvar/src/tools/mod.rs
+++ b/relvar/src/tools/mod.rs
@@ -6,11 +6,11 @@
 //!
 //! # Included Tools
 //!
-//! - **[`exporter`]:** Export relations to standard formats like CSV, JSON, and ASCII tables.
+//! - **[`exporter`](crate::tools::exporter):** Export relations to standard formats like CSV, JSON, and ASCII tables.
 //!   Useful for reporting, backups, or integrating with other systems.
-//! - **[`importer`]:** Import data from JSON and CSV. Features strict type checking
+//! - **[`importer`](crate::tools::importer):** Import data from JSON and CSV. Features strict type checking
 //!   and limit enforcement (DoS protection).
-//! - **[`visualizer`]:** Generate Graphviz DOT diagrams of your database schema,
+//! - **[`visualizer`](crate::tools::visualizer):** Generate Graphviz DOT diagrams of your database schema,
 //!   showing tables, columns, keys, and relationships.
 //!
 //! # Example: Import, Visualize, and Export


### PR DESCRIPTION
This PR improves the documentation for the `experimental` modules in the `relvar` crate. It converts static code examples into runnable doctests to ensure they remain correct and up-to-date. It also adds critical information about error conditions and known issues, such as the attribute name collision bug in the time-series moving average function.

The changes include:
- `relvar/src/experimental/automl.rs`: Runnable example, `# Errors` section.
- `relvar/src/experimental/ecs.rs`: Runnable example, `# Limitations` section regarding persistence.
- `relvar/src/experimental/graph.rs`: Runnable example, `# Errors` section.
- `relvar/src/experimental/timeseries.rs`: Runnable example, `# Known Issues` section regarding `_prev` suffix.
- `relvar/src/experimental/mod.rs`: Improved module index with links.
- `relvar/src/tools/mod.rs`: Fixed intra-doc links.
- `.jules/bard.md`: Updated journal.


---
*PR created automatically by Jules for task [1607401971610511223](https://jules.google.com/task/1607401971610511223) started by @madmax983*