### PR TITLE
Shield: Fix broken Ord implementation for Relation values

### DIFF
--- a/relvar-core/src/types/relation_type.rs
+++ b/relvar-core/src/types/relation_type.rs
@@ -60,7 +60,7 @@ use serde::{Deserialize, Serialize};
 /// assert!(employee_type.has_attribute("emp_id"));
 /// assert!(!employee_type.has_attribute("salary"));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct RelationType {
     /// The heading (tuple type) that defines this relation type.
     heading: TupleType,

--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -394,44 +394,7 @@ impl Ord for ScalarType {
                     | (ScalarType::String, ScalarType::String)
                     | (ScalarType::Bool, ScalarType::Bool)
                     | (ScalarType::Bytes, ScalarType::Bytes) => Ordering::Equal,
-                    (ScalarType::Relation(a), ScalarType::Relation(b)) => {
-                        // Compare relation types by their headings
-                        // Since TupleType doesn't have Ord, we need a custom comparison
-                        let a_attrs: Vec<_> = a
-                            .heading()
-                            .attribute_names()
-                            .map(|n| (n, a.heading().get_attribute_type(n).unwrap()))
-                            .collect();
-                        let b_attrs: Vec<_> = b
-                            .heading()
-                            .attribute_names()
-                            .map(|n| (n, b.heading().get_attribute_type(n).unwrap()))
-                            .collect();
-
-                        // Compare by count first, then by sorted attributes
-                        match a_attrs.len().cmp(&b_attrs.len()) {
-                            Ordering::Equal => {
-                                let mut a_sorted = a_attrs;
-                                let mut b_sorted = b_attrs;
-                                a_sorted.sort_by_key(|(name, _)| *name);
-                                b_sorted.sort_by_key(|(name, _)| *name);
-
-                                for ((a_name, a_ty), (b_name, b_ty)) in
-                                    a_sorted.iter().zip(b_sorted.iter())
-                                {
-                                    match a_name.cmp(b_name) {
-                                        Ordering::Equal => match a_ty.cmp(b_ty) {
-                                            Ordering::Equal => continue,
-                                            other => return other,
-                                        },
-                                        other => return other,
-                                    }
-                                }
-                                Ordering::Equal
-                            }
-                            other => other,
-                        }
-                    }
+                    (ScalarType::Relation(a), ScalarType::Relation(b)) => a.cmp(b),
                     (
                         ScalarType::UserDefined {
                             name: a_name,

--- a/relvar-core/src/types/tuple_type.rs
+++ b/relvar-core/src/types/tuple_type.rs
@@ -64,7 +64,7 @@ use std::collections::BTreeMap;
 /// assert_eq!(person_type.get_attribute_type("id"), Some(&ScalarType::Int));
 /// assert!(!person_type.has_attribute("nonexistent"));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct TupleType {
     /// The attributes of this tuple type, mapping names to scalar types.
     attributes: BTreeMap<String, ScalarType>,

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -428,9 +428,24 @@ impl Ord for ScalarValue {
                     (ScalarValue::Bool(a), ScalarValue::Bool(b)) => a.cmp(b),
                     (ScalarValue::Bytes(a), ScalarValue::Bytes(b)) => a.cmp(b),
                     (ScalarValue::Relation(a), ScalarValue::Relation(b)) => {
-                        // For relations, order by cardinality first, then degree
-                        match a.cardinality().cmp(&b.cardinality()) {
-                            Ordering::Equal => a.degree().cmp(&b.degree()),
+                        // 1. Compare relation types (headings)
+                        match a.relation_type().cmp(b.relation_type()) {
+                            Ordering::Equal => {
+                                // 2. Compare cardinality (optimization: different sizes can't be equal)
+                                match a.cardinality().cmp(&b.cardinality()) {
+                                    Ordering::Equal => {
+                                        // 3. Compare sorted tuples (expensive but necessary for correctness)
+                                        // Relations are sets, so to compare them deterministically as values,
+                                        // we must sort their elements.
+                                        let mut tuples_a: Vec<_> = a.tuples().collect();
+                                        let mut tuples_b: Vec<_> = b.tuples().collect();
+                                        tuples_a.sort();
+                                        tuples_b.sort();
+                                        tuples_a.cmp(&tuples_b)
+                                    }
+                                    other => other,
+                                }
+                            }
                             other => other,
                         }
                     }

--- a/relvar-core/src/values/tuple.rs
+++ b/relvar-core/src/values/tuple.rs
@@ -111,7 +111,7 @@ pub enum TupleError {
 /// let age: i64 = person.get_typed("age").unwrap();
 /// assert_eq!(age, 30);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Tuple {
     /// The tuple type (heading) that this tuple conforms to.
     #[serde(with = "arc_serde")]

--- a/relvar-core/tests/sentry_scalar_ord.rs
+++ b/relvar-core/tests/sentry_scalar_ord.rs
@@ -1,0 +1,59 @@
+use relvar_core::tuple;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
+use relvar_core::values::{Relation, ScalarValue};
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+
+#[test]
+fn test_relation_scalar_ord_detects_content_difference() {
+    let heading = TupleType::new().with_attribute("val", ScalarType::Int);
+    let rel_type = RelationType::new(heading);
+
+    // Relation 1: {val: 1}
+    let mut r1 = Relation::new(rel_type.clone());
+    r1.insert(tuple! { val: 1i64 }).unwrap();
+
+    // Relation 2: {val: 2}
+    let mut r2 = Relation::new(rel_type.clone());
+    r2.insert(tuple! { val: 2i64 }).unwrap();
+
+    assert_eq!(r1.cardinality(), 1);
+    assert_eq!(r2.cardinality(), 1);
+    assert_ne!(r1, r2); // Equality works
+
+    let v1 = ScalarValue::Relation(r1);
+    let v2 = ScalarValue::Relation(r2);
+
+    // This assertion fails currently because cmp only checks cardinality/degree
+    assert_ne!(
+        v1.cmp(&v2),
+        Ordering::Equal,
+        "ScalarValue::cmp should distinguish different relations"
+    );
+}
+
+#[test]
+fn test_relation_scalar_btreeset_data_loss() {
+    let heading = TupleType::new().with_attribute("val", ScalarType::Int);
+    let rel_type = RelationType::new(heading);
+
+    let mut r1 = Relation::new(rel_type.clone());
+    r1.insert(tuple! { val: 1i64 }).unwrap();
+
+    let mut r2 = Relation::new(rel_type.clone());
+    r2.insert(tuple! { val: 2i64 }).unwrap();
+
+    let v1 = ScalarValue::Relation(r1);
+    let v2 = ScalarValue::Relation(r2);
+
+    let mut set = BTreeSet::new();
+    set.insert(v1);
+    set.insert(v2);
+
+    // This assertion fails currently because BTreeSet thinks they are equal keys
+    assert_eq!(
+        set.len(),
+        2,
+        "BTreeSet should contain both distinct relations"
+    );
+}


### PR DESCRIPTION
Fixes a critical correctness bug in `ScalarValue::Ord` implementation where distinct `Relation` values were considered equal if they had the same cardinality and degree. This caused silent data loss in `BTreeSet` and incorrect sorting.

Changes:
- Derived `PartialOrd` and `Ord` for `TupleType`, `RelationType`, and `Tuple`.
- Refactored `ScalarValue::cmp` to perform a deterministic content comparison for relations by sorting tuples.
- Added regression test `relvar-core/tests/sentry_scalar_ord.rs`.

---
*PR created automatically by Jules for task [10193476367221225486](https://jules.google.com/task/10193476367221225486) started by @madmax983*