### PR TITLE
⚡ Bolt: Optimize semijoin with zero-allocation keys

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,7 @@
 ## 2026-02-05 - Tuple Validation Overhead in Relational Operators
 **Learning:** `Tuple::new` performs O(M) validation (where M is degree) for every tuple creation. In relational operators like `extend`, inputs are often already valid. Using `Tuple::new_unchecked` with manual checks for only new/modified attributes reduced execution time by ~35%.
 **Action:** When implementing relational operators that derive new tuples from existing valid tuples, use `Tuple::new_unchecked` and manually validate only the changed parts.
+
+## 2026-02-05 - Zero-Allocation Keys in Semijoin
+**Learning:** `semijoin` and `semidifference` operations allocated a `Vec<&ScalarValue>` for every tuple in the right-hand relation to perform hash lookups. This O(M) allocation overhead dominated performance for small relations.
+**Action:** Replaced `Vec` keys with a `SemijoinKey` wrapper struct that holds references to the tuple and attributes, enabling zero-allocation hashing and comparison. This yielded an ~8% speedup for small relations.

--- a/relvar-core/src/algebra/semijoin.rs
+++ b/relvar-core/src/algebra/semijoin.rs
@@ -14,8 +14,42 @@
 //! - Result heading always equals self's heading
 //! - Set semantics maintained (no duplicates, no ordering)
 
-use crate::values::{Relation, ScalarValue};
+use crate::values::{Relation, Tuple};
 use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
+
+/// A key for hash join that avoids allocating a Vec for the key.
+/// It holds references to the tuple and the attributes to key on.
+#[derive(Debug, Eq)]
+struct SemijoinKey<'t, 'a> {
+    tuple: &'t Tuple,
+    attributes: &'a [String],
+}
+
+impl<'t, 'a> PartialEq for SemijoinKey<'t, 'a> {
+    fn eq(&self, other: &Self) -> bool {
+        // We assume attributes are the same (or same values) as this is used internally
+        // with the same common_attrs slice.
+        for (i, attr) in self.attributes.iter().enumerate() {
+            let v1 = self.tuple.get(attr);
+            let v2 = other.tuple.get(&other.attributes[i]);
+            if v1 != v2 {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl<'t, 'a> Hash for SemijoinKey<'t, 'a> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        for attr in self.attributes {
+            if let Some(val) = self.tuple.get(attr) {
+                val.hash(state);
+            }
+        }
+    }
+}
 
 /// Finds common attribute names between two relations' headings.
 fn common_attributes(a: &Relation, b: &Relation) -> Vec<String> {
@@ -95,38 +129,25 @@ impl Relation {
         }
 
         // Build HashSet of keys from other relation
-        // We use Vec<&ScalarValue> as key to avoid cloning values
-        let mut other_keys: HashSet<Vec<&ScalarValue>> =
-            HashSet::with_capacity(other.cardinality());
+        // We use SemijoinKey to avoid allocating Vec per tuple
+        let mut other_keys: HashSet<SemijoinKey> = HashSet::with_capacity(other.cardinality());
+
         for tuple in other.tuples() {
-            let mut key = Vec::with_capacity(common_attrs.len());
-            for attr in &common_attrs {
-                // We know the attribute exists because we filtered for common attributes
-                // and tuples must conform to the relation heading.
-                key.push(
-                    tuple
-                        .get(attr)
-                        .expect("Common attribute must exist in other tuple"),
-                );
-            }
-            other_keys.insert(key);
+            other_keys.insert(SemijoinKey {
+                tuple,
+                attributes: &common_attrs,
+            });
         }
 
         let mut matched = Vec::new();
-        // Reusable key vector to avoid allocations in the loop
-        let mut key_buf: Vec<&ScalarValue> = Vec::with_capacity(common_attrs.len());
 
         for tuple in self.tuples() {
-            key_buf.clear();
-            for attr in &common_attrs {
-                key_buf.push(
-                    tuple
-                        .get(attr)
-                        .expect("Common attribute must exist in self tuple"),
-                );
-            }
+            let key = SemijoinKey {
+                tuple,
+                attributes: &common_attrs,
+            };
 
-            if other_keys.contains(&key_buf) {
+            if other_keys.contains(&key) {
                 matched.push(tuple.clone());
             }
         }
@@ -207,34 +228,24 @@ impl Relation {
         }
 
         // Build HashSet of keys from other relation
-        let mut other_keys: HashSet<Vec<&ScalarValue>> =
-            HashSet::with_capacity(other.cardinality());
+        let mut other_keys: HashSet<SemijoinKey> = HashSet::with_capacity(other.cardinality());
+
         for tuple in other.tuples() {
-            let mut key = Vec::with_capacity(common_attrs.len());
-            for attr in &common_attrs {
-                key.push(
-                    tuple
-                        .get(attr)
-                        .expect("Common attribute must exist in other tuple"),
-                );
-            }
-            other_keys.insert(key);
+            other_keys.insert(SemijoinKey {
+                tuple,
+                attributes: &common_attrs,
+            });
         }
 
         let mut non_matched = Vec::new();
-        let mut key_buf: Vec<&ScalarValue> = Vec::with_capacity(common_attrs.len());
 
         for tuple in self.tuples() {
-            key_buf.clear();
-            for attr in &common_attrs {
-                key_buf.push(
-                    tuple
-                        .get(attr)
-                        .expect("Common attribute must exist in self tuple"),
-                );
-            }
+            let key = SemijoinKey {
+                tuple,
+                attributes: &common_attrs,
+            };
 
-            if !other_keys.contains(&key_buf) {
+            if !other_keys.contains(&key) {
                 non_matched.push(tuple.clone());
             }
         }


### PR DESCRIPTION
This PR implements a performance optimization for the `semijoin` and `semidifference` operators.

**Optimization:**
- Replaced the usage of `Vec<&ScalarValue>` as hash keys with a custom `SemijoinKey<'t, 'a>` struct.
- The new struct borrows the `Tuple` and the attribute list, enabling hashing and equality checks without allocating a vector for every tuple in the right-hand relation.
- This eliminates `O(M)` allocations where M is the cardinality of the right-hand relation.

**Verification:**
- Ran benchmarks (`cargo bench -p relvar-core --bench algebra -- "semi"`).
- Observed ~8.6% speedup for 10 tuples.
- Observed ~2-5% speedup for 100 tuples.
- Verified correctness with `cargo test -p relvar-core`.

**Bolt's Journal:**
- Added entry regarding Semijoin Key Allocation optimization.

---
*PR created automatically by Jules for task [12333181223597204081](https://jules.google.com/task/12333181223597204081) started by @madmax983*