### PR TITLE
fix(security): Enforce recursion limits on ConstraintExpression deserialization

### DIFF
--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -30,9 +30,11 @@
 //! ```
 
 use super::prepared::PreparedConstraintExpression;
+use crate::utils::recursion::DepthGuarded;
 use crate::values::{ScalarValue, Tuple};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::convert::TryFrom;
 use thiserror::Error;
 
 /// Errors that can occur during constraint expression evaluation.
@@ -90,6 +92,7 @@ pub enum CmpOp {
 /// - **Set membership**: In
 /// - **Pattern matching**: Like
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(try_from = "ConstraintExpressionUnchecked")]
 pub enum ConstraintExpression {
     /// Comparison: left_attr op right_value_or_ref
     Cmp {
@@ -378,6 +381,57 @@ impl ConstraintExpression {
         }
 
         Ok((left, right))
+    }
+}
+
+// ------------------- Recursion Protection -------------------
+
+#[derive(Debug, Deserialize)]
+enum ConstraintExpressionUnchecked {
+    Cmp {
+        left: String,
+        op: CmpOp,
+        right: ValueOrRef,
+    },
+    And(
+        Box<DepthGuarded<ConstraintExpressionUnchecked>>,
+        Box<DepthGuarded<ConstraintExpressionUnchecked>>,
+    ),
+    Or(
+        Box<DepthGuarded<ConstraintExpressionUnchecked>>,
+        Box<DepthGuarded<ConstraintExpressionUnchecked>>,
+    ),
+    Not(Box<DepthGuarded<ConstraintExpressionUnchecked>>),
+    In(String, Vec<ScalarValue>),
+    Like(String, String),
+}
+
+impl TryFrom<ConstraintExpressionUnchecked> for ConstraintExpression {
+    type Error = String;
+
+    fn try_from(value: ConstraintExpressionUnchecked) -> Result<Self, Self::Error> {
+        match value {
+            ConstraintExpressionUnchecked::Cmp { left, op, right } => {
+                Ok(ConstraintExpression::Cmp { left, op, right })
+            }
+            ConstraintExpressionUnchecked::And(left, right) => Ok(ConstraintExpression::And(
+                Box::new(ConstraintExpression::try_from(left.0)?),
+                Box::new(ConstraintExpression::try_from(right.0)?),
+            )),
+            ConstraintExpressionUnchecked::Or(left, right) => Ok(ConstraintExpression::Or(
+                Box::new(ConstraintExpression::try_from(left.0)?),
+                Box::new(ConstraintExpression::try_from(right.0)?),
+            )),
+            ConstraintExpressionUnchecked::Not(expr) => Ok(ConstraintExpression::Not(Box::new(
+                ConstraintExpression::try_from(expr.0)?,
+            ))),
+            ConstraintExpressionUnchecked::In(left, right) => {
+                Ok(ConstraintExpression::In(left, right))
+            }
+            ConstraintExpressionUnchecked::Like(left, right) => {
+                Ok(ConstraintExpression::Like(left, right))
+            }
+        }
     }
 }
 

--- a/relvar-core/src/lib.rs
+++ b/relvar-core/src/lib.rs
@@ -106,6 +106,7 @@ pub mod storage_engine;
 /// Core traits for decoupling components.
 pub mod traits;
 pub mod types;
+pub mod utils;
 pub mod values;
 
 pub use database::{Database, DatabaseError};

--- a/relvar-core/src/utils/mod.rs
+++ b/relvar-core/src/utils/mod.rs
@@ -1,0 +1,6 @@
+//! Utility modules for internal use.
+//!
+//! This module contains shared utilities that don't fit into the main
+//! type/value/algebra hierarchy.
+
+pub mod recursion;

--- a/relvar-core/src/utils/recursion.rs
+++ b/relvar-core/src/utils/recursion.rs
@@ -1,0 +1,69 @@
+//! Recursion depth protection for deserialization.
+//!
+//! This module provides [`RecursionGuard`] and [`DepthGuarded`] to prevent
+//! stack overflow attacks during deserialization of deeply nested structures.
+
+use serde::{Deserialize, Deserializer};
+use std::cell::Cell;
+
+// ------------------- Recursion Guard -------------------
+
+thread_local! {
+    static RECURSION_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Maximum allowed recursion depth for deserialization.
+pub const MAX_RECURSION_DEPTH: usize = 32;
+
+/// A guard that increments recursion depth on creation and decrements on drop.
+///
+/// If `MAX_RECURSION_DEPTH` is exceeded, `new()` returns an error.
+pub struct RecursionGuard;
+
+impl RecursionGuard {
+    /// Attempts to create a new recursion guard.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string if the recursion limit would be exceeded.
+    pub fn new() -> Result<Self, String> {
+        RECURSION_DEPTH.with(|cell| {
+            let depth = cell.get();
+            if depth >= MAX_RECURSION_DEPTH {
+                Err("Recursion limit exceeded".to_string())
+            } else {
+                cell.set(depth + 1);
+                Ok(RecursionGuard)
+            }
+        })
+    }
+}
+
+impl Drop for RecursionGuard {
+    fn drop(&mut self) {
+        RECURSION_DEPTH.with(|cell| {
+            let depth = cell.get();
+            if depth > 0 {
+                cell.set(depth - 1);
+            }
+        });
+    }
+}
+
+/// A wrapper that enforces recursion depth limits during deserialization.
+///
+/// Wrap recursive fields in `Box<DepthGuarded<T>>` to ensure that
+/// processing them doesn't blow the stack.
+#[derive(Debug)]
+pub struct DepthGuarded<T>(pub T);
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for DepthGuarded<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let _guard = RecursionGuard::new().map_err(serde::de::Error::custom)?;
+        let value = T::deserialize(deserializer)?;
+        Ok(DepthGuarded(value))
+    }
+}

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -27,8 +27,8 @@
 //! ```
 
 use crate::types::ScalarType;
+use crate::utils::recursion::DepthGuarded;
 use serde::{Deserialize, Serialize};
-use std::cell::Cell;
 use std::convert::TryFrom;
 use thiserror::Error;
 
@@ -482,57 +482,6 @@ impl Ord for ScalarValue {
         }
     }
 }
-
-// ------------------- Recursion Guard -------------------
-
-thread_local! {
-    static RECURSION_DEPTH: Cell<usize> = const { Cell::new(0) };
-}
-
-const MAX_RECURSION_DEPTH: usize = 32;
-
-struct RecursionGuard;
-
-impl RecursionGuard {
-    fn new() -> Result<Self, &'static str> {
-        RECURSION_DEPTH.with(|cell| {
-            let depth = cell.get();
-            if depth >= MAX_RECURSION_DEPTH {
-                Err("Recursion limit exceeded")
-            } else {
-                cell.set(depth + 1);
-                Ok(RecursionGuard)
-            }
-        })
-    }
-}
-
-impl Drop for RecursionGuard {
-    fn drop(&mut self) {
-        RECURSION_DEPTH.with(|cell| {
-            let depth = cell.get();
-            if depth > 0 {
-                cell.set(depth - 1);
-            }
-        });
-    }
-}
-
-#[derive(Debug)]
-struct DepthGuarded<T>(pub T);
-
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for DepthGuarded<T> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let _guard = RecursionGuard::new().map_err(serde::de::Error::custom)?;
-        let value = T::deserialize(deserializer)?;
-        Ok(DepthGuarded(value))
-    }
-}
-
-// -------------------------------------------------------
 
 // Private structure to assist with deserialization and validation.
 // This allows us to intercept deserialization and enforce type consistency and depth limits.

--- a/relvar-core/tests/sentry_constraint_recursion.rs
+++ b/relvar-core/tests/sentry_constraint_recursion.rs
@@ -1,0 +1,35 @@
+use relvar_core::constraints::ConstraintExpression;
+
+#[test]
+fn test_constraint_expression_recursion_limit() {
+    // My custom limit is 32 (MAX_RECURSION_DEPTH).
+    // Serde JSON default limit is 128.
+    // If I use depth 64, serde_json would allow it, but my guard should block it.
+    let depth = 64;
+    let mut json = String::new();
+
+    for _ in 0..depth {
+        json.push_str("{\"Not\":");
+    }
+
+    // The innermost expression needs to be valid.
+    json.push_str(r#"{"Cmp":{"left":"a","op":"Eq","right":{"Value":{"Int":1}}}}"#);
+
+    for _ in 0..depth {
+        json.push('}');
+    }
+
+    // Do NOT disable recursion limit (avoids API issues).
+    // rely on default > 32.
+    let result: Result<ConstraintExpression, _> = serde_json::from_str(&json);
+
+    match result {
+        Ok(_) => panic!("Deserialization should have failed due to custom recursion limit (depth 64 > 32)"),
+        Err(e) => {
+            let msg = e.to_string();
+            println!("Deserialization failed as expected: {}", msg);
+            // My error message is "Recursion limit exceeded"
+            assert!(msg.contains("Recursion limit exceeded"), "Error message should mention recursion limit, got: {}", msg);
+        }
+    }
+}

--- a/relvar-core/tests/sentry_constraint_recursion.rs
+++ b/relvar-core/tests/sentry_constraint_recursion.rs
@@ -24,12 +24,18 @@ fn test_constraint_expression_recursion_limit() {
     let result: Result<ConstraintExpression, _> = serde_json::from_str(&json);
 
     match result {
-        Ok(_) => panic!("Deserialization should have failed due to custom recursion limit (depth 64 > 32)"),
+        Ok(_) => panic!(
+            "Deserialization should have failed due to custom recursion limit (depth 64 > 32)"
+        ),
         Err(e) => {
             let msg = e.to_string();
             println!("Deserialization failed as expected: {}", msg);
             // My error message is "Recursion limit exceeded"
-            assert!(msg.contains("Recursion limit exceeded"), "Error message should mention recursion limit, got: {}", msg);
+            assert!(
+                msg.contains("Recursion limit exceeded"),
+                "Error message should mention recursion limit, got: {}",
+                msg
+            );
         }
     }
 }


### PR DESCRIPTION
Identified and fixed a potential stack overflow vulnerability in `ConstraintExpression` deserialization. Deeply nested JSON payloads (e.g., 5000 layers of `Not(...)`) could cause a crash.

I extracted the existing recursion protection mechanism from `ScalarValue` into a shared module `relvar-core/src/utils/recursion.rs` and applied it to `ConstraintExpression`. I verified the fix with a new test case `relvar-core/tests/sentry_constraint_recursion.rs` which confirms that payloads exceeding the limit (32) are now rejected with a "Recursion limit exceeded" error.

---
*PR created automatically by Jules for task [13509088976458066784](https://jules.google.com/task/13509088976458066784) started by @madmax983*