### PR TITLE
⚒️ Forge: Refactor extend and project algebra operators

### DIFF
--- a/relvar-core/src/algebra/extend.rs
+++ b/relvar-core/src/algebra/extend.rs
@@ -99,37 +99,50 @@ impl Relation {
         let new_heading_arc = std::sync::Arc::new(new_heading);
 
         // Create extended tuples
-        let mut extended_tuples = Vec::with_capacity(self.cardinality());
-        let attr_name_string = attr_name.to_string();
-
-        for tuple in self.tuples() {
-            let computed_value = compute(tuple);
-
-            // Manual type check for the new value
-            // We only need to check this one value because the existing values
-            // come from a valid tuple and are guaranteed to match the rest of the heading.
-            if !computed_value.is_type(&attr_type) {
-                return Err(ExtendError::TupleCreation(format!(
-                    "Type mismatch for attribute '{}': expected {}, got {}",
-                    attr_name,
-                    attr_type.name(),
-                    computed_value.scalar_type().name()
-                )));
-            }
-
-            let mut new_values = tuple.values().clone();
-            new_values.insert(attr_name_string.clone(), computed_value);
-
-            // Safety: We verified the new value's type above, and existing values
-            // are known to be valid because they come from a valid Tuple.
-            // Using new_unchecked avoids O(N) validation per tuple where N is degree.
-            let extended_tuple = Tuple::new_unchecked(new_heading_arc.clone(), new_values);
-            extended_tuples.push(extended_tuple);
-        }
+        let extended_tuples: Vec<Tuple> = self
+            .tuples()
+            .map(|tuple| {
+                create_extended_tuple(tuple, attr_name, &attr_type, &new_heading_arc, &compute)
+            })
+            .collect::<Result<_, _>>()?;
 
         Ok(Relation::from_tuples(new_rel_type, extended_tuples)
             .expect("Extended tuples should conform to new relation type"))
     }
+}
+
+/// Helper function to create a single extended tuple.
+fn create_extended_tuple<F>(
+    tuple: &Tuple,
+    attr_name: &str,
+    attr_type: &crate::types::ScalarType,
+    new_heading: &std::sync::Arc<crate::types::TupleType>,
+    compute: &F,
+) -> Result<Tuple, ExtendError>
+where
+    F: Fn(&Tuple) -> ScalarValue,
+{
+    let computed_value = compute(tuple);
+
+    // Manual type check for the new value
+    // We only need to check this one value because the existing values
+    // come from a valid tuple and are guaranteed to match the rest of the heading.
+    if !computed_value.is_type(attr_type) {
+        return Err(ExtendError::TupleCreation(format!(
+            "Type mismatch for attribute '{}': expected {}, got {}",
+            attr_name,
+            attr_type.name(),
+            computed_value.scalar_type().name()
+        )));
+    }
+
+    let mut new_values = tuple.values().clone();
+    new_values.insert(attr_name.to_string(), computed_value);
+
+    // Safety: We verified the new value's type above, and existing values
+    // are known to be valid because they come from a valid Tuple.
+    // Using new_unchecked avoids O(N) validation per tuple where N is degree.
+    Ok(Tuple::new_unchecked(new_heading.clone(), new_values))
 }
 
 #[cfg(test)]

--- a/relvar-core/src/algebra/project.rs
+++ b/relvar-core/src/algebra/project.rs
@@ -96,39 +96,46 @@ impl Relation {
         let shared_heading = Arc::new(new_heading);
 
         // Project each tuple
-        let projected_tuples = self.tuples().map(|tuple| {
-            // Optimization: Use synchronized iteration (merge-join style) between source tuple values
-            // and result heading attributes. Both are sorted BTreeMaps.
-            // This avoids O(log N) lookup for each attribute, reducing complexity from O(M log N) to O(N).
-            let mut source_iter = tuple.values().iter();
-
-            let values: BTreeMap<_, _> = shared_heading
-                .attribute_names()
-                .map(|target_attr| {
-                    // Advance source iterator until we find the target attribute.
-                    // Since both are sorted and target is a subset of source, we are guaranteed to find it
-                    // without backtracking.
-                    loop {
-                        let (source_attr, source_val) = source_iter
-                            .next()
-                            .expect("Attribute from result heading must exist in source tuple");
-
-                        if source_attr == target_attr {
-                            return (target_attr.clone(), source_val.clone());
-                        }
-                        // If source_attr < target_attr, continue skipping unwanted attributes
-                    }
-                })
-                .collect();
-            // Safety: We constructed values exactly from attributes present in new_heading
-            // derived from the source relation schema, so types match by definition.
-            Tuple::new_unchecked(shared_heading.clone(), values)
-        });
+        let projected_tuples = self
+            .tuples()
+            .map(|tuple| project_tuple_values(tuple, &shared_heading));
 
         // Duplicates are automatically removed when creating the relation
         // Safety: projected_tuples use shared_heading which matches new_rel_type.heading()
         Relation::from_tuples_unchecked(new_rel_type, projected_tuples)
     }
+}
+
+/// Helper function to project values from a source tuple based on a target heading.
+///
+/// Optimization: Uses synchronized iteration (merge-join style) between source tuple values
+/// and result heading attributes. Both are sorted BTreeMaps (or iterate in sorted order).
+/// This avoids O(log N) lookup for each attribute, reducing complexity from O(M log N) to O(N).
+fn project_tuple_values(source_tuple: &Tuple, target_heading: &Arc<TupleType>) -> Tuple {
+    let mut source_iter = source_tuple.values().iter();
+
+    let values: BTreeMap<_, _> = target_heading
+        .attribute_names()
+        .map(|target_attr| {
+            // Advance source iterator until we find the target attribute.
+            // Since both are sorted and target is a subset of source, we are guaranteed to find it
+            // without backtracking.
+            loop {
+                let (source_attr, source_val) = source_iter
+                    .next()
+                    .expect("Attribute from result heading must exist in source tuple");
+
+                if source_attr == target_attr {
+                    return (target_attr.clone(), source_val.clone());
+                }
+                // If source_attr < target_attr, continue skipping unwanted attributes
+            }
+        })
+        .collect();
+
+    // Safety: We constructed values exactly from attributes present in new_heading
+    // derived from the source relation schema, so types match by definition.
+    Tuple::new_unchecked(target_heading.clone(), values)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Refactored `extend.rs` and `project.rs` in `relvar-core/src/algebra/` to improve readability and maintainability.

**Changes:**
1.  `relvar-core/src/algebra/extend.rs`:
    -   Replaced the manual `for` loop in `extend` with a functional `.map().collect()` pipeline.
    -   Extracted the tuple creation and validation logic into a private helper function `create_extended_tuple`.
    -   Maintained explicit type checks and error handling.

2.  `relvar-core/src/algebra/project.rs`:
    -   Extracted the complex synchronized iteration (merge-join) logic for attribute projection from the closure into a private helper function `project_tuple_values`.
    -   Flattened the `project` method structure.

**Verification:**
-   Ran `cargo test algebra::extend` - All tests passed.
-   Ran `cargo test algebra::project` - All tests passed.
-   Ran `cargo clippy --all-targets --all-features -- -D warnings` - No warnings.

---
*PR created automatically by Jules for task [4508066569072272015](https://jules.google.com/task/4508066569072272015) started by @madmax983*