### PR TITLE
Enhance relational algebra documentation with Tutorial D aliases and safe join patterns

### DIFF
--- a/relvar-core/src/algebra/join.rs
+++ b/relvar-core/src/algebra/join.rs
@@ -152,7 +152,7 @@ impl Relation {
     ///
     /// O(n * m) where n and m are the cardinalities of the two relations.
     ///
-    /// # Example
+    /// # Example: Standard Usage
     ///
     /// ```
     /// use relvar_core::types::{TupleType, RelationType, ScalarType};
@@ -184,6 +184,37 @@ impl Relation {
     /// });
     /// // Only employee 2 (salary 75000) qualifies for dept 10 (min 60000)
     /// assert_eq!(result.cardinality(), 1);
+    /// ```
+    ///
+    /// # Example: Safe Usage (Avoiding Collisions)
+    ///
+    /// To avoid silent attribute collisions when both relations share attribute names
+    /// (e.g., both have `id`), rename the attributes before joining:
+    ///
+    /// ```
+    /// use relvar_core::types::{TupleType, RelationType, ScalarType};
+    /// use relvar_core::values::Relation;
+    /// use relvar_core::tuple;
+    ///
+    /// let heading = TupleType::new().with_attribute("id", ScalarType::Int);
+    /// let rel_type = RelationType::new(heading);
+    ///
+    /// let mut r1 = Relation::new(rel_type.clone());
+    /// r1.insert(tuple! { id: 1i64 }).unwrap();
+    ///
+    /// let mut r2 = Relation::new(rel_type);
+    /// r2.insert(tuple! { id: 2i64 }).unwrap();
+    ///
+    /// // DANGEROUS: r1.theta_join(&r2, ...) will drop r2's "id" attribute!
+    ///
+    /// // SAFE: Rename r2's attribute first
+    /// let r2_renamed = r2.rename(&[("id", "r2_id")]);
+    ///
+    /// let result = r1.theta_join(&r2_renamed, |t1, t2| true);
+    ///
+    /// // Result now has both: "id" (from r1) and "r2_id" (from r2)
+    /// assert!(result.relation_type().has_attribute("id"));
+    /// assert!(result.relation_type().has_attribute("r2_id"));
     /// ```
     pub fn theta_join<F>(&self, other: &Relation, predicate: F) -> Self
     where

--- a/relvar-core/src/algebra/mod.rs
+++ b/relvar-core/src/algebra/mod.rs
@@ -4,6 +4,16 @@
 //! as defined in *The Third Manifesto* (RM Prescription 7). All operators
 //! are implemented as methods on the [`Relation`](crate::values::Relation) type.
 //!
+//! # Why Relational Algebra?
+//!
+//! Relational algebra is the functional programming language of data.
+//! Just as you compose functions like `map`, `filter`, and `fold` to transform collections
+//! in Rust, you compose relational operators to transform relations.
+//!
+//! - **Composable**: The output of every operator is a relation, so you can chain them endlessly.
+//! - **Declarative**: You specify *what* result you want, not *how* to compute it.
+//! - **Safe**: The type system guarantees that every intermediate result is a valid relation.
+//!
 //! # Operators
 //!
 //! ## Set Operators (require type-compatible relations)
@@ -24,13 +34,13 @@
 //!
 //! ## Join Operators
 //!
-//! | Operator | Method | Description |
-//! |----------|--------|-------------|
-//! | Natural Join | [`join()`](crate::values::Relation::join) | Joins on common attributes |
-//! | Theta Join | [`theta_join()`](crate::values::Relation::theta_join) | Joins with arbitrary predicate |
-//! | Semijoin | [`semijoin()`](crate::values::Relation::semijoin) | Tuples from A matching B |
-//! | Semidifference | [`semidifference()`](crate::values::Relation::semidifference) | Tuples from A not matching B |
-//! | Division | [`divide()`](crate::values::Relation::divide) | Relational division (A ÷ B) |
+//! | Operator | Method | Description | Tutorial D Alias |
+//! |----------|--------|-------------|------------------|
+//! | Natural Join | [`join()`](crate::values::Relation::join) | Joins on common attributes | `JOIN` |
+//! | Theta Join | [`theta_join()`](crate::values::Relation::theta_join) | Joins with arbitrary predicate | - |
+//! | Semijoin | [`semijoin()`](crate::values::Relation::semijoin) | Tuples from A matching B | `MATCHING` |
+//! | Semidifference | [`semidifference()`](crate::values::Relation::semidifference) | Tuples from A not matching B | `NOT MATCHING` |
+//! | Division | [`divide()`](crate::values::Relation::divide) | Relational division (A ÷ B) | `DIVIDEBY` |
 //!
 //! ## Extended Operators
 //!


### PR DESCRIPTION
Improved documentation for relational algebra components to better explain concepts and potential pitfalls.

1.  **Algebra Module Docs (`relvar-core/src/algebra/mod.rs`)**:
    *   Added a "Why Relational Algebra?" section to explain the composable, functional nature of the operators.
    *   Added a "Tutorial D Alias" column to the operators table, explicitly linking `semijoin` -> `MATCHING`, `semidifference` -> `NOT MATCHING`, etc. This helps users familiar with Date & Darwen's terminology find the right functions.

2.  **Join Operator Docs (`relvar-core/src/algebra/join.rs`)**:
    *   Enhanced `theta_join` documentation with a "Safe Usage" example.
    *   Explicitly demonstrated how to use `rename` before joining to avoid silent attribute collisions (where the right side's attribute is dropped), which is a critical safety pattern for users.

---
*PR created automatically by Jules for task [1452508416150768406](https://jules.google.com/task/1452508416150768406) started by @madmax983*