### PR TITLE
⚒️ Forge: Refactor `compute_relation_after_update` using guard clauses

### DIFF
--- a/relvar-core/src/database/dml.rs
+++ b/relvar-core/src/database/dml.rs
@@ -39,18 +39,19 @@ where
     let (tuples, update_count) = current_relation.into_iter().try_fold(
         (Vec::with_capacity(initial_cardinality), 0),
         |(mut acc, count), tuple| {
-            if predicate(&tuple) {
-                let updated_tuple = updater(&tuple);
-
-                if !updated_tuple.conforms_to(&expected_type) {
-                    return Err(DatabaseError::TupleMismatch);
-                }
-                acc.push(updated_tuple);
-                Ok((acc, count + 1))
-            } else {
+            if !predicate(&tuple) {
                 acc.push(tuple);
-                Ok((acc, count))
+                return Ok((acc, count));
             }
+
+            let updated_tuple = updater(&tuple);
+
+            if !updated_tuple.conforms_to(&expected_type) {
+                return Err(DatabaseError::TupleMismatch);
+            }
+
+            acc.push(updated_tuple);
+            Ok((acc, count + 1))
         },
     )?;
 


### PR DESCRIPTION
🚮 Smell: Deeply nested `if/else` block in `compute_relation_after_update`.
✨ Solution: Extracted the non-matching case (`!predicate(&tuple)`) into an early return guard clause.
🧼 Benefit: Reduces cognitive load and flattens the structure of the function.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [8298517327724860423](https://jules.google.com/task/8298517327724860423) started by @madmax983*