### PR TITLE
🎻 Bard: Fix intra-doc links in relvar-core

### DIFF
--- a/relvar-core/src/database/mod.rs
+++ b/relvar-core/src/database/mod.rs
@@ -29,10 +29,10 @@
 //! ## Key Interactions
 //!
 //! 1.  **Operation Request**: User calls methods like [`insert`](Database::insert), [`update`](Database::update), [`delete`](Database::delete).
-//! 2.  **Constraint Validation**: `Database` consults [`ConstraintManager`](crate::constraints::ConstraintManager)
+//! 2.  **Constraint Validation**: `Database` consults [`ConstraintManager`]
 //!     to ensure the operation violates no integrity rules (e.g., uniqueness, foreign keys).
 //! 3.  **Persistence**: If valid, `Database` delegates the physical data modification
-//!     to the configured [`StorageEngine`](crate::storage_engine::StorageEngine).
+//!     to the configured [`StorageEngine`].
 //! 4.  **Transaction Management**: `Database` coordinates with `StorageEngine` to begin,
 //!     commit, or rollback transactions.
 //!

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides a serializable AST ([`Query`]) and a fluent builder API
 //! for constructing relational algebra queries. It allows queries to be
 //! defined data-driven (e.g., from JSON), optimized, inspected ([`Query::explain`]),
-//! and executed against a [`Database`].
+//! and executed against a [`Database`](crate::database::Database).
 //!
 //! # Example
 //!


### PR DESCRIPTION
📖 Chapter: The `database` and `query` modules.
🔦 Insight: Fixed broken intra-doc links for `Database` and `StorageEngine` to ensure correct rendering.
🧪 Example: Resolved the warning `error: unresolved link to Database`.
🖼️ Preview: Documentation builds flawlessly with `-D warnings`.

---
*PR created automatically by Jules for task [2931171238949922824](https://jules.google.com/task/2931171238949922824) started by @madmax983*