### PR TITLE
⚡ Bolt: [performance improvement] - Optimize tuple generation with `new_unchecked`

### DIFF
--- a/relvar-core/src/algebra/divide.rs
+++ b/relvar-core/src/algebra/divide.rs
@@ -172,10 +172,11 @@ fn filter_matching_candidates(
     dividend: &Relation,
     dividend_heading: &crate::types::TupleType,
 ) -> Vec<crate::values::Tuple> {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
 
     // Clone dividend_heading once outside the loop to avoid repeated clones
-    let dividend_heading = dividend_heading.clone();
+    let dividend_heading_arc = Arc::new(dividend_heading.clone());
 
     candidates
         .tuples()
@@ -183,7 +184,7 @@ fn filter_matching_candidates(
             // Check if ALL divisor tuples match when extended with this candidate
             divisor.tuples().all(|divisor_tuple| {
                 // Extend candidate with divisor tuple using iterator-based approach
-                let extended_values: HashMap<_, _> = candidate
+                let extended_values: BTreeMap<_, _> = candidate
                     .values()
                     .iter()
                     .chain(divisor_tuple.values())
@@ -191,9 +192,10 @@ fn filter_matching_candidates(
                     .collect();
 
                 // Create extended tuple
-                let extended_tuple =
-                    crate::values::Tuple::new(dividend_heading.clone(), extended_values)
-                        .expect("Extended tuple should conform to dividend heading");
+                let extended_tuple = crate::values::Tuple::new_unchecked(
+                    dividend_heading_arc.clone(),
+                    extended_values,
+                );
 
                 // Check if this extended tuple exists in the dividend
                 dividend.contains(&extended_tuple)

--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -254,6 +254,9 @@ fn compute_grouped_tuples(
     rva_heading: &TupleType,
     rva_name: &str,
 ) -> Result<Vec<Tuple>, GroupError> {
+    let rva_heading_arc = std::sync::Arc::new(rva_heading.clone());
+    let result_heading_arc = std::sync::Arc::new(result_heading.clone());
+
     let mut groups: HashMap<Vec<ScalarValue>, Vec<Tuple>> = HashMap::new();
 
     for tuple in relation.tuples() {
@@ -264,21 +267,21 @@ fn compute_grouped_tuples(
             .collect();
 
         // Extract grouped attributes for RVA
-        let mut rva_values = HashMap::new();
+        let mut rva_values = std::collections::BTreeMap::new();
         for attr in attrs_to_group {
             rva_values.insert(attr.to_string(), tuple.get(attr).unwrap().clone());
         }
 
-        let rva_tuple = Tuple::new(rva_heading.clone(), rva_values)
-            .map_err(|e| GroupError::TupleCreation(e.to_string()))?;
+        let rva_tuple = Tuple::new_unchecked(rva_heading_arc.clone(), rva_values);
 
         groups.entry(key).or_default().push(rva_tuple);
     }
 
     // Build result tuples
     let mut result_tuples = Vec::new();
+    let rva_relation_type = RelationType::new(rva_heading.clone());
     for (key, rva_tuples) in groups {
-        let mut values = HashMap::new();
+        let mut values = std::collections::BTreeMap::new();
 
         // Add grouping attribute values
         for (i, attr) in grouping_attrs.iter().enumerate() {
@@ -286,13 +289,11 @@ fn compute_grouped_tuples(
         }
 
         // Create RVA relation
-        let rva_relation =
-            Relation::from_tuples(RelationType::new(rva_heading.clone()), rva_tuples)
-                .map_err(|e| GroupError::TupleCreation(e.to_string()))?;
+        let rva_relation = Relation::from_tuples(rva_relation_type.clone(), rva_tuples)
+            .map_err(|e| GroupError::TupleCreation(e.to_string()))?;
         values.insert(rva_name.to_string(), ScalarValue::Relation(rva_relation));
 
-        let tuple = Tuple::new(result_heading.clone(), values)
-            .map_err(|e| GroupError::TupleCreation(e.to_string()))?;
+        let tuple = Tuple::new_unchecked(result_heading_arc.clone(), values);
         result_tuples.push(tuple);
     }
 
@@ -362,6 +363,7 @@ fn compute_ungrouped_tuples(
     rva_relation_type: &RelationType,
 ) -> Result<Vec<Tuple>, UngroupError> {
     let mut result_tuples = Vec::new();
+    let result_heading_arc = std::sync::Arc::new(result_heading.clone());
 
     for tuple in relation.tuples() {
         // Get the RVA relation
@@ -372,7 +374,7 @@ fn compute_ungrouped_tuples(
 
         // For each tuple in the RVA, create a new tuple combining non-RVA and RVA attributes
         for rva_tuple in rva_relation.tuples() {
-            let mut values = HashMap::new();
+            let mut values = std::collections::BTreeMap::new();
 
             // Add non-RVA attribute values
             for attr_name in relation.relation_type().tuple_type().attribute_names() {
@@ -389,8 +391,7 @@ fn compute_ungrouped_tuples(
                 );
             }
 
-            let result_tuple = Tuple::new(result_heading.clone(), values)
-                .map_err(|e| UngroupError::TupleCreation(e.to_string()))?;
+            let result_tuple = Tuple::new_unchecked(result_heading_arc.clone(), values);
             result_tuples.push(result_tuple);
         }
     }

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -456,12 +456,15 @@ impl Relation {
     ) -> Result<Relation, SummarizeError> {
         self.validate_grouping_attributes(group_by)?;
         let result_heading = self.build_result_heading(group_by, aggregations)?;
+        let result_rel_type = RelationType::new(result_heading.clone());
+        let result_heading_arc = std::sync::Arc::new(result_heading);
+
         let groups = self.group_tuples(group_by);
 
         // Compute aggregations for each group
         let mut result_tuples = Vec::new();
         for (key, group_tuples) in groups {
-            let mut values = HashMap::new();
+            let mut values = std::collections::BTreeMap::new();
 
             // Add grouping attribute values
             for (i, attr) in group_by.iter().enumerate() {
@@ -474,15 +477,14 @@ impl Relation {
                 values.insert(agg.result_name.clone(), agg_value);
             }
 
-            let tuple = Tuple::new(result_heading.clone(), values)
-                .map_err(|e| SummarizeError::TupleCreation(e.to_string()))?;
+            // Using new_unchecked avoids O(N) validation per tuple where N is degree,
+            // since we've already validated the grouping and aggregation attributes
+            let tuple = Tuple::new_unchecked(result_heading_arc.clone(), values);
             result_tuples.push(tuple);
         }
 
-        Ok(
-            Relation::from_tuples(RelationType::new(result_heading), result_tuples)
-                .expect("Summarized tuples should conform to result relation type"),
-        )
+        Ok(Relation::from_tuples(result_rel_type, result_tuples)
+            .expect("Summarized tuples should conform to result relation type"))
     }
 
     fn validate_grouping_attributes(&self, group_by: &[&str]) -> Result<(), SummarizeError> {


### PR DESCRIPTION
💡 What: Refactored `summarize.rs`, `group.rs`, and `divide.rs` to construct result tuples using `BTreeMap` and `Tuple::new_unchecked` rather than `HashMap` and `Tuple::new`. Pre-allocated the result heading inside an `Arc` before loop entry.

🎯 Why: During these relational algebra operations, we dynamically build new tuples that we *know* conform to their designated resulting schema. However, passing a `HashMap` into `Tuple::new` triggers a redundant schema validation (which iterates the attributes linearly) and a secondary allocation when converting the `HashMap` into the internal `BTreeMap` storage structure for `Tuple`.

📊 Impact: Reduces heap allocations and bypasses the O(N) validation overhead for every resulting tuple in the `group`, `summarize`, and `divide` operators.

🔬 Measurement: Run `cargo test -p relvar-core` and verify all tests pass. Performance gains are most pronounced when summarizing or grouping large datasets with wide schemas.

---
*PR created automatically by Jules for task [9701957413061020864](https://jules.google.com/task/9701957413061020864) started by @madmax983*