### PR TITLE
⚡ Bolt: Optimize DML tuple construction using `from_tuples_unchecked`

### DIFF
--- a/relvar-core/src/database/dml.rs
+++ b/relvar-core/src/database/dml.rs
@@ -11,14 +11,18 @@ where
     let initial_cardinality = current_relation.cardinality();
     let relation_type = current_relation.relation_type().clone();
 
-    let kept_tuples: Vec<Tuple> = current_relation
-        .into_iter()
-        .filter(|tuple| !predicate(tuple))
-        .collect();
+    // Optimization: Pass the iterator directly to `from_tuples_unchecked`
+    // instead of collecting into an intermediate `Vec`. Since the source
+    // relation is valid, the filtered tuples are also guaranteed to be valid,
+    // allowing us to bypass redundant type checking.
+    let new_relation = Relation::from_tuples_unchecked(
+        relation_type,
+        current_relation
+            .into_iter()
+            .filter(|tuple| !predicate(tuple)),
+    );
 
-    let delete_count = initial_cardinality - kept_tuples.len();
-
-    let new_relation = Relation::from_tuples(relation_type, kept_tuples)?;
+    let delete_count = initial_cardinality - new_relation.cardinality();
 
     Ok((new_relation, delete_count))
 }
@@ -55,7 +59,10 @@ where
         },
     )?;
 
-    let new_relation = Relation::from_tuples(relation_type, tuples)?;
+    // Optimization: The updated tuples are already validated via `conforms_to`
+    // inside the `try_fold` loop. We can safely use `from_tuples_unchecked`
+    // to build the new relation, avoiding a second O(N*M) validation pass.
+    let new_relation = Relation::from_tuples_unchecked(relation_type, tuples);
 
     Ok((new_relation, update_count))
 }


### PR DESCRIPTION
💡 **What:** 
Optimized relational DML operations (`compute_relation_after_delete` and `compute_relation_after_update`) in `relvar-core/src/database/dml.rs`. Replaced calls to `Relation::from_tuples` with `Relation::from_tuples_unchecked`.

🎯 **Why:** 
Previously, `delete` operations built an intermediate `Vec<Tuple>` before calling `Relation::from_tuples`, which internally loops to hash and insert, effectively doubling the iteration and heap allocation count. Additionally, `update` was validating tuples with `conforms_to` in the map loop, and then passing them to `Relation::from_tuples` which performed a secondary `O(N*M)` validation pass. Since tuples derived from a valid relation's subset (or verified via fold) are guaranteed valid, these redundant operations were pure overhead.

📊 **Impact:** 
- Removes 1 intermediate `Vec` allocation entirely per `delete` query.
- Eliminates an `O(N*M)` validation pass per `update` query where `N` is cardinality and `M` is degree.
- Execution operates closer to zero-cost abstractions over the underlying data models.

🔬 **Measurement:** 
Verify functionality by running existing integration tests (which currently all pass):
`cargo test`

---
*PR created automatically by Jules for task [7202018657692211214](https://jules.google.com/task/7202018657692211214) started by @madmax983*