### PR TITLE
🛡️ Sentry: [test coverage improvement] and unwrap removal in ScalarType::Relation Ord

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -45,3 +45,7 @@
 ## 2027-08-15 - Integer Truncation and Overflow in Storage Layers
 **Learning:** `WalManager` and `PageFile` were casting `u64` length prefixes to `usize` without checking for truncation (on 32-bit systems) or overflow during offset calculation. This allowed malicious payloads to cause panics or potentially bypass size checks.
 **Action:** Always validate `u64` values from external sources (disk/network) using `checked_add` and `usize::try_from` before using them for memory indexing or allocation.
+
+## 2025-03-01 - Avoid unwrap in Ord implementations
+**Learning:** Found a ticking time bomb `.unwrap()` inside the `Ord` implementation for `ScalarType::Relation` when comparing attribute types. While technically safe due to prior invariants, it's brittle and fails Sentry's zero-unwrap philosophy for core logic.
+**Action:** When extracting data from nested maps/structures during ordering or equality checks, prefer direct iterators (`.attributes()`) that yield both key and value simultaneously over extracting keys and doing secondary `.get().unwrap()` lookups. This is both safer (no panics) and more performant.

--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -398,27 +398,16 @@ impl Ord for ScalarType {
                     (ScalarType::Relation(a), ScalarType::Relation(b)) => {
                         // Compare relation types by their headings
                         // Since TupleType doesn't have Ord, we need a custom comparison
-                        let a_attrs: Vec<_> = a
-                            .heading()
-                            .attribute_names()
-                            .map(|n| (n, a.heading().get_attribute_type(n).unwrap()))
-                            .collect();
-                        let b_attrs: Vec<_> = b
-                            .heading()
-                            .attribute_names()
-                            .map(|n| (n, b.heading().get_attribute_type(n).unwrap()))
-                            .collect();
+                        let a_attrs: Vec<_> = a.heading().attributes().iter().collect();
+                        let b_attrs: Vec<_> = b.heading().attributes().iter().collect();
 
                         // Compare by count first, then by sorted attributes
                         match a_attrs.len().cmp(&b_attrs.len()) {
                             Ordering::Equal => {
-                                let mut a_sorted = a_attrs;
-                                let mut b_sorted = b_attrs;
-                                a_sorted.sort_by_key(|(name, _)| *name);
-                                b_sorted.sort_by_key(|(name, _)| *name);
-
+                                // BTreeMap iterators are already sorted by key, so we don't need
+                                // to sort again.
                                 for ((a_name, a_ty), (b_name, b_ty)) in
-                                    a_sorted.iter().zip(b_sorted.iter())
+                                    a_attrs.iter().zip(b_attrs.iter())
                                 {
                                     match a_name.cmp(b_name) {
                                         Ordering::Equal => match a_ty.cmp(b_ty) {
@@ -777,5 +766,46 @@ impl TryFrom<ScalarTypeUnchecked> for ScalarType {
             ));
         }
         Ok(ty)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::tuple_type::TupleType;
+    use crate::types::relation_type::RelationType;
+
+    #[test]
+    fn should_treat_relations_with_different_headings_as_unequal() {
+        let t1 = TupleType::new().with_attribute("a", ScalarType::Int);
+        let rel1 = RelationType::new(t1);
+
+        let t2 = TupleType::new().with_attribute("b", ScalarType::Int);
+        let rel2 = RelationType::new(t2);
+
+        let s1 = ScalarType::Relation(Box::new(rel1));
+        let s2 = ScalarType::Relation(Box::new(rel2));
+
+        assert!(s1 != s2);
+        assert!(s1.cmp(&s2) != std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn should_compare_relation_types_deterministically() {
+        let t1 = TupleType::new()
+            .with_attribute("a", ScalarType::Int)
+            .with_attribute("b", ScalarType::String);
+        let rel1 = RelationType::new(t1);
+
+        let t2 = TupleType::new()
+            .with_attribute("b", ScalarType::String)
+            .with_attribute("a", ScalarType::Int);
+        let rel2 = RelationType::new(t2);
+
+        let s1 = ScalarType::Relation(Box::new(rel1));
+        let s2 = ScalarType::Relation(Box::new(rel2));
+
+        assert!(s1 == s2);
+        assert!(s1.cmp(&s2) == std::cmp::Ordering::Equal);
     }
 }


### PR DESCRIPTION
*   🎯 **Target:** `relvar-core/src/types/scalar.rs` - `Ord` implementation for `ScalarType::Relation`.
*   💣 **Risk:** The previous `Ord` implementation extracted attribute names and then performed a secondary lookup with a `.unwrap()` to get the corresponding `ScalarType`. While this theoretically shouldn't fail due to type invariants, it violates Sentry's zero-unwrap philosophy for core logic and represents a brittle failure point if schemas are ever constructed dynamically or mocked in tests.
*   🧪 **Strategy:** Refactored the tuple attribute comparison to iterate directly over `a.heading().attributes()`, which yields both the attribute name and its type (`(&String, &ScalarType)`), completely eliminating the need for `unwrap()`. Added unit tests inside a `#[cfg(test)] mod tests` block at the bottom of the file to verify deterministic comparison and proper ordering of relations with differing headings and types.
*   🔬 **Verification:** Run `cargo test --manifest-path relvar-core/Cargo.toml --all-features types::scalar::tests::` to execute the newly added tests.

---
*PR created automatically by Jules for task [5411005904678001306](https://jules.google.com/task/5411005904678001306) started by @madmax983*