### PR TITLE
⚒️ Forge: Avoid redundant validation in algebra operators

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -526,3 +526,6 @@ Build it right, make it fast, keep it simple.
 ## 2025-06-03 - Algebraic Operator Refactoring
 **Learning:** Complex algebraic operators like `group` and `ungroup` often mix validation, schema derivation, and tuple processing. Extracting these into distinct phases (`validate`, `build_heading`, `compute_tuples`) improves readability and testability.
 **Action:** Apply this "Three-Phase Operator" pattern when refactoring other complex operators like `join` or `summarize`.
+## 2025-06-03 - Redundant Tuple Validation in Algebra Operators
+**Learning:** `Relation::from_tuples` performs O(N*M) validation (where N is tuple count and M is degree) to ensure tuples conform to the given heading. Several algebraic operators (`group`, `ungroup`, `summarize`, `extend`, `divide`, `semijoin`, `semidifference`) compute the heading and matching tuples dynamically in a way that inherently guarantees type conformance. They were redundantly calling `from_tuples` and using `.expect()` or `.map_err()` because they knew it shouldn't fail.
+**Action:** Replaced these specific, guaranteed-safe calls with `Relation::from_tuples_unchecked` to improve performance and remove redundant error handling paths, maintaining strict semantic equivalence.

--- a/patch_group.diff
+++ b/patch_group.diff
@@ -1,0 +1,36 @@
+<<<<<<< SEARCH
+        Ok(
+            Relation::from_tuples(RelationType::new(result_heading), result_tuples)
+                .expect("Grouped tuples should conform to result relation type"),
+        )
+=======
+        Ok(Relation::from_tuples_unchecked(
+            RelationType::new(result_heading),
+            result_tuples,
+        ))
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+        Ok(
+            Relation::from_tuples(RelationType::new(result_heading), result_tuples)
+                .expect("Ungrouped tuples should conform to result relation type"),
+        )
+=======
+        Ok(Relation::from_tuples_unchecked(
+            RelationType::new(result_heading),
+            result_tuples,
+        ))
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+        // Create RVA relation
+        let rva_relation =
+            Relation::from_tuples(RelationType::new(rva_heading.clone()), rva_tuples)
+                .map_err(|e| GroupError::TupleCreation(e.to_string()))?;
+        values.insert(rva_name.to_string(), ScalarValue::Relation(rva_relation));
+=======
+        // Create RVA relation
+        let rva_relation = Relation::from_tuples_unchecked(
+            RelationType::new(rva_heading.clone()),
+            rva_tuples,
+        );
+        values.insert(rva_name.to_string(), ScalarValue::Relation(rva_relation));
+>>>>>>> REPLACE

--- a/relvar-core/src/algebra/divide.rs
+++ b/relvar-core/src/algebra/divide.rs
@@ -110,8 +110,7 @@ impl Relation {
         // Return result relation
         use crate::types::RelationType;
         let result_type = RelationType::new(candidates.relation_type().heading().clone());
-        Ok(Relation::from_tuples(result_type, result_tuples)
-            .expect("Result tuples should conform to result type"))
+        Ok(Relation::from_tuples_unchecked(result_type, result_tuples))
     }
 }
 

--- a/relvar-core/src/algebra/extend.rs
+++ b/relvar-core/src/algebra/extend.rs
@@ -106,8 +106,10 @@ impl Relation {
             })
             .collect::<Result<_, _>>()?;
 
-        Ok(Relation::from_tuples(new_rel_type, extended_tuples)
-            .expect("Extended tuples should conform to new relation type"))
+        Ok(Relation::from_tuples_unchecked(
+            new_rel_type,
+            extended_tuples,
+        ))
     }
 }
 

--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -119,10 +119,10 @@ impl Relation {
             rva_name,
         )?;
 
-        Ok(
-            Relation::from_tuples(RelationType::new(result_heading), result_tuples)
-                .expect("Grouped tuples should conform to result relation type"),
-        )
+        Ok(Relation::from_tuples_unchecked(
+            RelationType::new(result_heading),
+            result_tuples,
+        ))
     }
 
     /// Ungroups a relation-valued attribute back into regular attributes.
@@ -154,10 +154,10 @@ impl Relation {
         let result_tuples =
             compute_ungrouped_tuples(self, rva_name, &result_heading, &rva_relation_type)?;
 
-        Ok(
-            Relation::from_tuples(RelationType::new(result_heading), result_tuples)
-                .expect("Ungrouped tuples should conform to result relation type"),
-        )
+        Ok(Relation::from_tuples_unchecked(
+            RelationType::new(result_heading),
+            result_tuples,
+        ))
     }
 }
 
@@ -287,8 +287,7 @@ fn compute_grouped_tuples(
 
         // Create RVA relation
         let rva_relation =
-            Relation::from_tuples(RelationType::new(rva_heading.clone()), rva_tuples)
-                .map_err(|e| GroupError::TupleCreation(e.to_string()))?;
+            Relation::from_tuples_unchecked(RelationType::new(rva_heading.clone()), rva_tuples);
         values.insert(rva_name.to_string(), ScalarValue::Relation(rva_relation));
 
         let tuple = Tuple::new(result_heading.clone(), values)

--- a/relvar-core/src/algebra/semijoin.rs
+++ b/relvar-core/src/algebra/semijoin.rs
@@ -152,8 +152,7 @@ impl Relation {
             }
         }
 
-        Relation::from_tuples(self.relation_type().clone(), matched)
-            .expect("Semijoin tuples conform to self's relation type")
+        Relation::from_tuples_unchecked(self.relation_type().clone(), matched)
     }
 
     /// Alias for [`semijoin`](Self::semijoin) using Tutorial D naming (MATCHING).
@@ -250,8 +249,7 @@ impl Relation {
             }
         }
 
-        Relation::from_tuples(self.relation_type().clone(), non_matched)
-            .expect("Semidifference tuples conform to self's relation type")
+        Relation::from_tuples_unchecked(self.relation_type().clone(), non_matched)
     }
 
     /// Alias for [`semidifference`](Self::semidifference) using Tutorial D naming (NOT MATCHING).

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -479,10 +479,10 @@ impl Relation {
             result_tuples.push(tuple);
         }
 
-        Ok(
-            Relation::from_tuples(RelationType::new(result_heading), result_tuples)
-                .expect("Summarized tuples should conform to result relation type"),
-        )
+        Ok(Relation::from_tuples_unchecked(
+            RelationType::new(result_heading),
+            result_tuples,
+        ))
     }
 
     fn validate_grouping_attributes(&self, group_by: &[&str]) -> Result<(), SummarizeError> {


### PR DESCRIPTION
🚮 Smell: Redundant tuple schema validation via `Relation::from_tuples` in multiple algebraic operators (`group`, `ungroup`, `summarize`, `extend`, `divide`, `semijoin`, `semidifference`), resulting in unnecessary O(N*M) overhead and redundant `expect()` / `.map_err()` boilerplate.
✨ Solution: Replaced calls to `from_tuples` with `from_tuples_unchecked`, as these operators correctly construct output schemas and ensure tuples conform to them during execution.
🧼 Benefit: Improves performance by skipping redundant validation step, and removes confusing boilerplate error handling for operations guaranteed to be valid.
🛡️ Verification: Tests passed. No logic changed. Added learning to `.jules/forge.md`.

---
*PR created automatically by Jules for task [3785837755185309079](https://jules.google.com/task/3785837755185309079) started by @madmax983*