### PR TITLE
🛡️ Sentry: Test coverage improvement for Delta error paths

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -45,3 +45,6 @@
 ## 2027-08-15 - Integer Truncation and Overflow in Storage Layers
 **Learning:** `WalManager` and `PageFile` were casting `u64` length prefixes to `usize` without checking for truncation (on 32-bit systems) or overflow during offset calculation. This allowed malicious payloads to cause panics or potentially bypass size checks.
 **Action:** Always validate `u64` values from external sources (disk/network) using `checked_add` and `usize::try_from` before using them for memory indexing or allocation.
+## 2025-03-03 - Delta Error Paths
+**Learning:** The `DatabaseError::AlgebraError` return paths for type mismatch in the `Delta` struct (`new`, `between`, `apply`, `compose`) were entirely untested, despite being standard error branches.
+**Action:** When testing algebra structs, explicitly check that all operations fail correctly when passed relations with mismatched types.

--- a/relvar-core/src/algebra/delta.rs
+++ b/relvar-core/src/algebra/delta.rs
@@ -319,4 +319,50 @@ mod tests {
         let r_final = d3.apply(&r1).unwrap();
         assert_eq!(r_final, r3);
     }
+    fn test_type_2() -> RelationType {
+        RelationType::new(TupleType::new().with_attribute("y", ScalarType::Int))
+    }
+
+    #[test]
+    fn test_delta_new_type_mismatch() {
+        let r1 = Relation::new(test_type());
+        let r2 = Relation::new(test_type_2());
+
+        let result = Delta::new(r1, r2);
+        assert!(matches!(result, Err(DatabaseError::AlgebraError(_))));
+    }
+
+    #[test]
+    fn test_delta_between_type_mismatch() {
+        let r1 = Relation::new(test_type());
+        let r2 = Relation::new(test_type_2());
+
+        let result = Delta::between(&r1, &r2);
+        assert!(matches!(result, Err(DatabaseError::AlgebraError(_))));
+    }
+
+    #[test]
+    fn test_delta_apply_type_mismatch() {
+        let r1 = Relation::new(test_type());
+        let r2 = Relation::new(test_type());
+        let r3 = Relation::new(test_type_2());
+
+        let delta = Delta::between(&r1, &r2).unwrap();
+        let result = delta.apply(&r3);
+        assert!(matches!(result, Err(DatabaseError::AlgebraError(_))));
+    }
+
+    #[test]
+    fn test_delta_compose_type_mismatch() {
+        let r1 = Relation::new(test_type());
+        let r2 = Relation::new(test_type());
+        let r3 = Relation::new(test_type_2());
+        let r4 = Relation::new(test_type_2());
+
+        let d1 = Delta::between(&r1, &r2).unwrap();
+        let d2 = Delta::between(&r3, &r4).unwrap();
+
+        let result = d1.compose(&d2);
+        assert!(matches!(result, Err(DatabaseError::AlgebraError(_))));
+    }
 }


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 **Target:** `relvar-core/src/algebra/delta.rs`
💣 **Risk:** The `DatabaseError::AlgebraError` return paths for type mismatches were entirely untested, creating a blind spot for regressions if error handling logic changed.
🧪 **Strategy:** Added targeted unit tests (`test_delta_new_type_mismatch`, `test_delta_between_type_mismatch`, `test_delta_apply_type_mismatch`, `test_delta_compose_type_mismatch`) using different mock relation types to explicitly trigger and assert on these errors.
🔬 **Verification:** `cargo test --manifest-path relvar-core/Cargo.toml test_delta_`

---
*PR created automatically by Jules for task [2450374067768581162](https://jules.google.com/task/2450374067768581162) started by @madmax983*