### PR TITLE
⚒️ Forge: Implement Guard Clauses to Flatten Deep Nesting

### DIFF
--- a/relvar-core/src/constraints/manager.rs
+++ b/relvar-core/src/constraints/manager.rs
@@ -288,20 +288,23 @@ impl ConstraintManager {
         relation_name: &str,
         tuple: &Tuple,
     ) -> Result<(), ConstraintManagerError> {
-        if let Some(attr_constraints) = self.type_constraints.get(relation_name) {
-            for (attr_name, constraints) in attr_constraints {
-                if let Some(value) = tuple.get(attr_name)
-                    && !constraints.is_satisfied_by(value).map_err(|e| {
-                        ConstraintManagerError::TypeConstraintViolation(e.to_string())
-                    })?
-                {
-                    return Err(ConstraintManagerError::TypeConstraintViolation(format!(
-                        "Attribute {} violates constraint",
-                        attr_name
-                    )));
-                }
+        let Some(attr_constraints) = self.type_constraints.get(relation_name) else {
+            return Ok(());
+        };
+
+        for (attr_name, constraints) in attr_constraints {
+            if let Some(value) = tuple.get(attr_name)
+                && !constraints
+                    .is_satisfied_by(value)
+                    .map_err(|e| ConstraintManagerError::TypeConstraintViolation(e.to_string()))?
+            {
+                return Err(ConstraintManagerError::TypeConstraintViolation(format!(
+                    "Attribute {} violates constraint",
+                    attr_name
+                )));
             }
         }
+
         Ok(())
     }
 

--- a/relvar-core/src/values/tuple.rs
+++ b/relvar-core/src/values/tuple.rs
@@ -172,16 +172,15 @@ impl Tuple {
 
         // Verify all values match their types
         for (attr_name, value) in &values_map {
-            if let Some(expected_type) = tuple_type.get_attribute_type(attr_name) {
-                if !value.is_type(expected_type) {
-                    return Err(TupleError::TypeMismatch(
-                        attr_name.clone(),
-                        expected_type.name().to_string(),
-                        value.scalar_type().name().to_string(),
-                    ));
-                }
-            } else {
+            let Some(expected_type) = tuple_type.get_attribute_type(attr_name) else {
                 return Err(TupleError::AttributeNotFound(attr_name.clone()));
+            };
+            if !value.is_type(expected_type) {
+                return Err(TupleError::TypeMismatch(
+                    attr_name.clone(),
+                    expected_type.name().to_string(),
+                    value.scalar_type().name().to_string(),
+                ));
             }
         }
 
@@ -254,11 +253,10 @@ impl Tuple {
 
         // Check that all values match their types
         for (attr_name, value) in &self.values {
-            if let Some(expected_type) = tuple_type.get_attribute_type(attr_name) {
-                if !value.is_type(expected_type) {
-                    return false;
-                }
-            } else {
+            let Some(expected_type) = tuple_type.get_attribute_type(attr_name) else {
+                return false;
+            };
+            if !value.is_type(expected_type) {
                 return false;
             }
         }
@@ -364,100 +362,100 @@ impl From<Vec<u8>> for ScalarValue {
 impl TryFrom<ScalarValue> for i64 {
     type Error = ();
     fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
-        match value {
-            ScalarValue::Int(v) => Ok(v),
-            _ => Err(()),
-        }
+        let ScalarValue::Int(v) = value else {
+            return Err(());
+        };
+        Ok(v)
     }
 }
 
 impl TryFrom<ScalarValue> for f64 {
     type Error = ();
     fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
-        match value {
-            ScalarValue::Float(v) => Ok(v),
-            _ => Err(()),
-        }
+        let ScalarValue::Float(v) = value else {
+            return Err(());
+        };
+        Ok(v)
     }
 }
 
 impl TryFrom<ScalarValue> for String {
     type Error = ();
     fn try_from(mut value: ScalarValue) -> Result<Self, Self::Error> {
-        match value {
-            ScalarValue::String(ref mut v) => Ok(std::mem::take(v)),
-            _ => Err(()),
-        }
+        let ScalarValue::String(ref mut v) = value else {
+            return Err(());
+        };
+        Ok(std::mem::take(v))
     }
 }
 
 impl TryFrom<ScalarValue> for bool {
     type Error = ();
     fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
-        match value {
-            ScalarValue::Bool(v) => Ok(v),
-            _ => Err(()),
-        }
+        let ScalarValue::Bool(v) = value else {
+            return Err(());
+        };
+        Ok(v)
     }
 }
 
 impl TryFrom<ScalarValue> for Vec<u8> {
     type Error = ();
     fn try_from(mut value: ScalarValue) -> Result<Self, Self::Error> {
-        match value {
-            ScalarValue::Bytes(ref mut v) => Ok(std::mem::take(v)),
-            _ => Err(()),
-        }
+        let ScalarValue::Bytes(ref mut v) = value else {
+            return Err(());
+        };
+        Ok(std::mem::take(v))
     }
 }
 
 impl<'a> TryFrom<&'a ScalarValue> for i64 {
     type Error = ();
     fn try_from(value: &'a ScalarValue) -> Result<Self, Self::Error> {
-        match value {
-            ScalarValue::Int(v) => Ok(*v),
-            _ => Err(()),
-        }
+        let ScalarValue::Int(v) = value else {
+            return Err(());
+        };
+        Ok(*v)
     }
 }
 
 impl<'a> TryFrom<&'a ScalarValue> for f64 {
     type Error = ();
     fn try_from(value: &'a ScalarValue) -> Result<Self, Self::Error> {
-        match value {
-            ScalarValue::Float(v) => Ok(*v),
-            _ => Err(()),
-        }
+        let ScalarValue::Float(v) = value else {
+            return Err(());
+        };
+        Ok(*v)
     }
 }
 
 impl<'a> TryFrom<&'a ScalarValue> for String {
     type Error = ();
     fn try_from(value: &'a ScalarValue) -> Result<Self, Self::Error> {
-        match value {
-            ScalarValue::String(v) => Ok(v.clone()),
-            _ => Err(()),
-        }
+        let ScalarValue::String(v) = value else {
+            return Err(());
+        };
+        Ok(v.clone())
     }
 }
 
 impl<'a> TryFrom<&'a ScalarValue> for bool {
     type Error = ();
     fn try_from(value: &'a ScalarValue) -> Result<Self, Self::Error> {
-        match value {
-            ScalarValue::Bool(v) => Ok(*v),
-            _ => Err(()),
-        }
+        let ScalarValue::Bool(v) = value else {
+            return Err(());
+        };
+        Ok(*v)
     }
 }
 
 impl<'a> TryFrom<&'a ScalarValue> for Vec<u8> {
     type Error = ();
     fn try_from(value: &'a ScalarValue) -> Result<Self, Self::Error> {
-        match value {
-            ScalarValue::Bytes(v) => Ok(v.clone()),
-            _ => Err(()),
-        }
+        let ScalarValue::Bytes(v) = value else {
+            return Err(());
+        };
+        Ok(v.clone())
     }
 }
 


### PR DESCRIPTION
🚮 Smell: `Tuple` creation (`new`), verification (`conforms_to`), and value extraction (`TryFrom` impls) featured "Pyramids of Doom" and unnecessary verbose `match` blocks containing `_ => Err(())` catch-alls. Similarly, `ConstraintManager::validate_type_constraints` nested iteration inside an `if let Some(...)` check.

✨ Solution: Refactored these areas using the "Guard Clauses" pattern. Replaced 10 repetitive `match` statements in `relvar-core/src/values/tuple.rs` with concise `let ... else { return; }` bindings. Flattened `conforms_to` and `new` by inverting `if let` conditionals. Unnested `validate_type_constraints` in `relvar-core/src/constraints/manager.rs` with an early return `let else`.

🧼 Benefit: Significantly reduces nesting depth, eliminates verbose match-arms, and brings the code into alignment with modern idiomatic Rust standards for control flow clarity without altering runtime behavior.

🛡️ Verification: Ran `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`. All checks passed. Zero logic changed.

---
*PR created automatically by Jules for task [15997464756469837769](https://jules.google.com/task/15997464756469837769) started by @madmax983*