### PR TITLE
🗺️ Atlas: [architectural change] virtual relvar evaluator closure support

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -1,3 +1,6 @@
 ## 2024-03-XX - Module Encapsulation Cleanup
 **Tangle:** Broad visibility (`pub mod`) across many internal modules (`algebra`, `values`, `types`, etc.) leaked implementation details and complicated the dependency graph.
 **Blueprint:** Converted most top-level internal module definitions in `relvar-core`, `relvar-storage`, and `relvar` to `pub(crate) mod`. Re-exported necessary types via their respective `mod.rs` files, ensuring clean, intention-revealing public APIs while maintaining low coupling between internal components.
+## 2026-03-04 - Virtual Relvar Evaluator Closure
+**Tangle:** Virtual relvars defined their evaluator as a raw function pointer `fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError>`. This prevented closures from capturing external state, significantly limiting how virtual relvars could be dynamically constructed.
+**Blueprint:** Refactored `VirtualRelvarDefinition` to use `Arc<dyn Fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError> + Send + Sync>`. This allows the evaluator to be any state-capturing closure or function that implements `Fn`, vastly improving flexibility while remaining safe and thread-safe. A custom `fmt::Debug` was also implemented to handle the non-debuggable closure.

--- a/relvar-core/src/database/mod.rs
+++ b/relvar-core/src/database/mod.rs
@@ -866,12 +866,15 @@ impl<E: StorageEngine> Database<E> {
     /// # Errors
     ///
     /// Returns an error if a relvar with this name already exists.
-    pub fn define_virtual_relvar(
+    pub fn define_virtual_relvar<F>(
         &mut self,
         name: &str,
         relation_type: RelationType,
-        evaluator: fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError>,
-    ) -> Result<(), DatabaseError> {
+        evaluator: F,
+    ) -> Result<(), DatabaseError>
+    where
+        F: Fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError> + Send + Sync + 'static,
+    {
         if self.relvar_exists(name) {
             return Err(DatabaseError::RelationAlreadyExists(name.to_string()));
         }
@@ -880,7 +883,7 @@ impl<E: StorageEngine> Database<E> {
             name.to_string(),
             VirtualRelvarDefinition {
                 relation_type,
-                evaluator,
+                evaluator: std::sync::Arc::new(evaluator),
             },
         );
 

--- a/relvar-core/src/database/virtual_relvar.rs
+++ b/relvar-core/src/database/virtual_relvar.rs
@@ -2,11 +2,13 @@ use crate::error::DatabaseError;
 use crate::traits::QueryExecutor;
 use crate::types::RelationType;
 use crate::values::Relation;
+use std::fmt;
+use std::sync::Arc;
 
 /// Definition of a virtual relvar (view).
 ///
 /// Stores the metadata required to evaluate a virtual relvar on demand.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct VirtualRelvarDefinition {
     /// The relation type (heading) of the view.
     ///
@@ -19,7 +21,7 @@ pub(crate) struct VirtualRelvarDefinition {
     ///
     /// # Signature
     ///
-    /// `fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError>`
+    /// `Arc<dyn Fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError> + Send + Sync>`
     ///
     /// - **Input**: A `&dyn QueryExecutor`, which allows the view
     ///   to query other relvars (base or virtual) in the database.
@@ -29,5 +31,14 @@ pub(crate) struct VirtualRelvarDefinition {
     ///
     /// The evaluator is passed a read-only reference (`&`), ensuring that
     /// viewing a relation cannot cause side effects (mutations) in the database.
-    pub evaluator: fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError>,
+    pub evaluator: Arc<dyn Fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError> + Send + Sync>,
+}
+
+impl fmt::Debug for VirtualRelvarDefinition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VirtualRelvarDefinition")
+            .field("relation_type", &self.relation_type)
+            .field("evaluator", &"<closure>")
+            .finish()
+    }
 }


### PR DESCRIPTION
🕸️ Tangle: The `evaluator` for virtual relvars was constrained to a raw function pointer (`fn(&dyn QueryExecutor)`), preventing users from passing state-capturing closures. This architectural limitation made it difficult to define dynamic views that relied on external context, query ASTs, or scoped variables.

📐 Blueprint: Upgraded `VirtualRelvarDefinition` to store the evaluator as an `Arc<dyn Fn(&dyn QueryExecutor) -> Result<Relation, DatabaseError> + Send + Sync>`. This architectural upgrade enables safe, capturing closures to serve as evaluators. Also added a custom `fmt::Debug` implementation, as closures natively do not implement it. `Database::define_virtual_relvar` now accepts an `impl Fn` to keep the API ergonomics clean.

🧱 Stability: This refactor improves the structural boundaries by making the API strictly more capable and ergonomic without breaking backwards compatibility (functions inherently implement `Fn`). It maintains thread safety via `Send + Sync`.

🔬 Verification: Builds successfully, all tests pass, and existing tests using closures or function pointers compile seamlessly under the new `impl Fn` signature. No regressions.

---
*PR created automatically by Jules for task [12581462714305013044](https://jules.google.com/task/12581462714305013044) started by @madmax983*