### PR TITLE
⚒️ Forge: [Refactor Ord implementation for ScalarType::Relation]

### DIFF
--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -398,27 +398,14 @@ impl Ord for ScalarType {
                     (ScalarType::Relation(a), ScalarType::Relation(b)) => {
                         // Compare relation types by their headings
                         // Since TupleType doesn't have Ord, we need a custom comparison
-                        let a_attrs: Vec<_> = a
-                            .heading()
-                            .attribute_names()
-                            .map(|n| (n, a.heading().get_attribute_type(n).unwrap()))
-                            .collect();
-                        let b_attrs: Vec<_> = b
-                            .heading()
-                            .attribute_names()
-                            .map(|n| (n, b.heading().get_attribute_type(n).unwrap()))
-                            .collect();
+                        let a_attrs = a.heading().attributes();
+                        let b_attrs = b.heading().attributes();
 
-                        // Compare by count first, then by sorted attributes
+                        // Compare by count first, then by sorted attributes (BTreeMap iterates in sorted order by key)
                         match a_attrs.len().cmp(&b_attrs.len()) {
                             Ordering::Equal => {
-                                let mut a_sorted = a_attrs;
-                                let mut b_sorted = b_attrs;
-                                a_sorted.sort_by_key(|(name, _)| *name);
-                                b_sorted.sort_by_key(|(name, _)| *name);
-
                                 for ((a_name, a_ty), (b_name, b_ty)) in
-                                    a_sorted.iter().zip(b_sorted.iter())
+                                    a_attrs.iter().zip(b_attrs.iter())
                                 {
                                     match a_name.cmp(b_name) {
                                         Ordering::Equal => match a_ty.cmp(b_ty) {


### PR DESCRIPTION
🚮 **Smell**: Unnecessary `.unwrap()` calls, multiple redundant `Vec` allocations, and repetitive `sort_by_key` calls in the `Ord` implementation for `ScalarType::Relation`. 
✨ **Solution**: Replaced the redundant mapping and sorting logic with a direct iteration over `.heading().attributes()`, which returns a natively sorted `BTreeMap`.
🧼 **Benefit**: Significantly reduces cognitive load, eliminates potential runtime panics, and heavily minimizes heap allocations by leveraging idiomatic Rust iterator comparisons. 
🛡️ **Verification**: `cargo test`, `cargo fmt`, and `cargo clippy` passed entirely. No behavioral changes.

---
*PR created automatically by Jules for task [14222355595297999179](https://jules.google.com/task/14222355595297999179) started by @madmax983*