### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -47,3 +47,7 @@ This ensures the map matches the territory.
 
 **Confusion:** The `Delta` module in `relvar-core/src/algebra/delta.rs` was largely undocumented. It had basic struct descriptions, but no module-level documentation (`//!`) to explain *why* it exists or how it works. Additionally, the public methods (`new`, `between`, `apply`, `invert`, `compose`) lacked executable doc-tests (`## Examples`), leaving users guessing about their usage and the difference between them.
 **Clarification:** I rewrote the entire documentation for the `delta.rs` module. I added a module-level `//!` comment explaining its purpose (Materialized View Maintenance, Triggers, Replication). For every public method, I added detailed `///` comments explaining the parameters, `# Errors` sections for panics/failures, and executable `## Example` blocks demonstrating exact usage with code.
+
+## 2024-05-29 - Missing Module Docs and Redundant Boilerplate Comments
+**Confusion:** Several modules in `relvar-core` lacked module-level (`//!`) documentation explaining their purpose, causing the "Black Box" problem. Additionally, getter functions had repetitive, unhelpful documentation like "Returns the x".
+**Clarification:** I added module-level documentation to `dml.rs`, `virtual_relvar.rs`, `traits.rs`, `recursion.rs`, `mod.rs`, `divide.rs`, and `prepared.rs`. I also replaced "Gets the x" and "Returns the x" comments with descriptive verbs and context across `types`, `values`, and `constraints` modules.

--- a/relvar-core/src/algebra/divide.rs
+++ b/relvar-core/src/algebra/divide.rs
@@ -1,3 +1,41 @@
+//! The relational division (÷) operator.
+//!
+//! This module implements the `Divide` algebraic operation. Relational division is analogous
+//! to integer division but operates on sets. It is commonly used to answer queries involving
+//! "for all" conditions (e.g., "Find all suppliers who supply *all* parts").
+//!
+//! # Examples
+//!
+//! ```
+//! use relvar_core::types::{RelationType, TupleType, ScalarType};
+//! use relvar_core::values::{Relation, Tuple};
+//! use relvar_core::tuple;
+//!
+//! // "Completed Tasks" - employee_id, task_id
+//! let dividend_heading = TupleType::new()
+//!     .with_attribute("employee_id", ScalarType::Int)
+//!     .with_attribute("task_id", ScalarType::String);
+//!
+//! let mut completed = Relation::new(RelationType::new(dividend_heading.clone()));
+//! completed.insert(Tuple::new(dividend_heading.clone(), vec![("employee_id".to_string(), relvar_core::values::ScalarValue::Int(1)), ("task_id".to_string(), relvar_core::values::ScalarValue::String("A".to_string()))]).unwrap()).unwrap();
+//! completed.insert(Tuple::new(dividend_heading.clone(), vec![("employee_id".to_string(), relvar_core::values::ScalarValue::Int(1)), ("task_id".to_string(), relvar_core::values::ScalarValue::String("B".to_string()))]).unwrap()).unwrap();
+//! completed.insert(Tuple::new(dividend_heading.clone(), vec![("employee_id".to_string(), relvar_core::values::ScalarValue::Int(2)), ("task_id".to_string(), relvar_core::values::ScalarValue::String("A".to_string()))]).unwrap()).unwrap();
+//!
+//! // "Required Tasks" - task_id
+//! let divisor_heading = TupleType::new()
+//!     .with_attribute("task_id", ScalarType::String);
+//!
+//! let mut required = Relation::new(RelationType::new(divisor_heading.clone()));
+//! required.insert(Tuple::new(divisor_heading.clone(), vec![("task_id".to_string(), relvar_core::values::ScalarValue::String("A".to_string()))]).unwrap()).unwrap();
+//! required.insert(Tuple::new(divisor_heading.clone(), vec![("task_id".to_string(), relvar_core::values::ScalarValue::String("B".to_string()))]).unwrap()).unwrap();
+//!
+//! // Who completed ALL required tasks?
+//! let result = completed.divide(&required).unwrap();
+//!
+//! // Only employee 1 completed both A and B
+//! assert_eq!(result.cardinality(), 1);
+//! assert!(result.contains(&Tuple::new(result.relation_type().tuple_type().clone(), vec![("employee_id".to_string(), relvar_core::values::ScalarValue::Int(1))]).unwrap()));
+//! ```
 use crate::values::Relation;
 use thiserror::Error;
 

--- a/relvar-core/src/constraints/check.rs
+++ b/relvar-core/src/constraints/check.rs
@@ -115,17 +115,17 @@ impl CheckConstraint {
         }
     }
 
-    /// Returns the constraint name.
+    /// Retrieves the identifier name of the constraint.
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    /// Returns the constraint description.
+    /// Retrieves the human-readable description of the constraint.
     pub fn description(&self) -> &str {
         &self.description
     }
 
-    /// Returns the constraint expression.
+    /// Accesses the underlying logical expression of the constraint.
     pub fn expression(&self) -> &ConstraintExpression {
         &self.expression
     }
@@ -189,12 +189,12 @@ impl CheckConstraints {
         Ok(true)
     }
 
-    /// Returns all constraints.
+    /// Provides a slice containing all configured check constraints.
     pub fn constraints(&self) -> &[CheckConstraint] {
         &self.constraints
     }
 
-    /// Returns the set of all attribute names referenced in all constraints.
+    /// Aggregates a unified set of all attribute names referenced across all constraints.
     pub fn referenced_attributes(&self) -> HashSet<String> {
         let mut attributes = HashSet::new();
         for constraint in &self.constraints {

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -142,7 +142,7 @@ pub enum ConstraintExpression {
 }
 
 impl ConstraintExpression {
-    /// Returns the set of all attribute names referenced in this expression.
+    /// Scans the expression tree to collect all referenced attribute names.
     ///
     /// This includes:
     /// - Attributes on the left side of comparisons

--- a/relvar-core/src/constraints/prepared.rs
+++ b/relvar-core/src/constraints/prepared.rs
@@ -1,3 +1,9 @@
+//! Pre-compiled Execution Plans for Constraints.
+//!
+//! This module contains `PreparedConstraint`, which is an optimized, read-only
+//! version of a `ConstraintExpression`. By pre-compiling `IN` lists to HashSets
+//! and string patterns to compiled regexers, evaluating these constraints during
+//! filtering loops is O(1) instead of O(N) per tuple.
 use super::expression::{CmpOp, ConstraintExpression, ExpressionError, ValueOrRef};
 use crate::values::{ScalarValue, Tuple};
 use std::collections::HashSet;

--- a/relvar-core/src/database/dml.rs
+++ b/relvar-core/src/database/dml.rs
@@ -1,3 +1,9 @@
+//! Data Manipulation Language (DML) primitives.
+//!
+//! This module contains pure functions for computing the resulting state of a relation
+//! after applying `UPDATE` or `DELETE` operations. These functions are intentionally decoupled
+//! from the `Database` struct and storage engine to facilitate testing and optimize
+//! tuple evaluation loops.
 use crate::error::DatabaseError;
 use crate::values::{Relation, Tuple};
 

--- a/relvar-core/src/database/virtual_relvar.rs
+++ b/relvar-core/src/database/virtual_relvar.rs
@@ -1,3 +1,8 @@
+//! Virtual Relvar (View) Definitions.
+//!
+//! This module defines the metadata and evaluation structures for Virtual Relvars,
+//! which are the relational equivalent of SQL Views. Unlike base relvars, virtual relvars
+//! do not store data; they store an expression (a query) that is evaluated on demand.
 use crate::error::DatabaseError;
 use crate::traits::QueryExecutor;
 use crate::types::RelationType;

--- a/relvar-core/src/traits.rs
+++ b/relvar-core/src/traits.rs
@@ -1,3 +1,9 @@
+//! Shared trait definitions for inversion of control.
+//!
+//! This module contains central trait definitions used across the `relvar-core` codebase
+//! to break circular dependencies and allow abstractions to interact generically.
+//! The most critical trait is [`QueryExecutor`], which allows components like virtual relvars
+//! to execute queries without depending directly on the concrete `Database` implementation.
 use crate::error::DatabaseError;
 use crate::values::Relation;
 
@@ -5,7 +11,7 @@ use crate::values::Relation;
 ///
 /// This trait abstracts the query execution capability, allowing components
 /// like virtual relvars (views) and query ASTs to operate without depending
-/// on the concrete `Database` struct or specific storage engines.
+/// on the concrete [`crate::database::Database`] struct or specific storage engines.
 pub trait QueryExecutor {
     /// Execute a query for a named relation.
     ///

--- a/relvar-core/src/types/relation_type.rs
+++ b/relvar-core/src/types/relation_type.rs
@@ -97,14 +97,14 @@ impl RelationType {
         Self { heading }
     }
 
-    /// Returns the nesting depth of this relation type.
+    /// Calculates the nesting depth of this relation type.
     ///
     /// This is 1 + the depth of its heading.
     pub fn depth(&self) -> usize {
         1 + self.heading.depth()
     }
 
-    /// Returns the heading (tuple type) of this relation type.
+    /// Retrieves the heading (tuple type) of this relation type.
     ///
     /// The heading defines what attributes tuples in this relation must have.
     ///
@@ -123,7 +123,7 @@ impl RelationType {
         &self.heading
     }
 
-    /// Returns the degree (number of attributes) of this relation type.
+    /// Calculates the degree (number of attributes) of this relation type.
     ///
     /// This is equivalent to `self.heading().degree()`.
     ///
@@ -143,7 +143,7 @@ impl RelationType {
         self.heading.degree()
     }
 
-    /// Returns the tuple type (heading) of this relation type.
+    /// Retrieves the tuple type (heading) of this relation type.
     ///
     /// This is an alias for [`heading()`](Self::heading).
     ///

--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -219,7 +219,7 @@ pub enum ScalarType {
 }
 
 impl ScalarType {
-    /// Returns the name of the type
+    /// Retrieves the textual name of the type.
     pub fn name(&self) -> &str {
         match self {
             ScalarType::Int => "Int",
@@ -232,7 +232,7 @@ impl ScalarType {
         }
     }
 
-    /// Returns the nesting depth of this type.
+    /// Calculates the nesting depth of this type to prevent unbounded recursion.
     ///
     /// - Primitive types have depth 1.
     /// - Recursive types (UserDefined, Relation) have 1 + depth of inner type.

--- a/relvar-core/src/types/tuple_type.rs
+++ b/relvar-core/src/types/tuple_type.rs
@@ -125,7 +125,7 @@ impl TupleType {
         self
     }
 
-    /// Gets the type of an attribute by name.
+    /// Retrieves the underlying scalar type for a named attribute.
     ///
     /// Returns `None` if no attribute with the given name exists.
     ///
@@ -169,7 +169,7 @@ impl TupleType {
         self.attributes.contains_key(name)
     }
 
-    /// Returns an iterator over all attribute names.
+    /// Provides an iterator over all attribute names in the tuple type.
     ///
     /// Per TTM Proscription 4, the order of iteration is arbitrary and
     /// should not be relied upon. Attributes are identified by name only.
@@ -190,7 +190,7 @@ impl TupleType {
         self.attributes.keys()
     }
 
-    /// Returns the maximum depth of any attribute type + 1.
+    /// Calculates the maximum nesting depth of any attribute type plus one.
     ///
     /// If there are no attributes, returns 1.
     pub fn depth(&self) -> usize {
@@ -202,7 +202,7 @@ impl TupleType {
             + 1
     }
 
-    /// Returns the degree (number of attributes) of this tuple type.
+    /// Calculates the degree (number of attributes) of this tuple type.
     ///
     /// The degree is the count of distinct attributes in the heading.
     ///
@@ -222,7 +222,7 @@ impl TupleType {
         self.attributes.len()
     }
 
-    /// Returns a reference to the underlying attribute map.
+    /// Exposes read-only access to the underlying attribute map.
     ///
     /// This provides access to all attribute definitions as a map from
     /// names to types.

--- a/relvar-core/src/utils/mod.rs
+++ b/relvar-core/src/utils/mod.rs
@@ -1,1 +1,5 @@
+//! General utility functions and common structures.
+//!
+//! This module contains helper components that do not inherently belong to relational
+//! logic but are used across the codebase, such as memory bounds checking or recursion limits.
 pub(crate) mod recursion;

--- a/relvar-core/src/utils/recursion.rs
+++ b/relvar-core/src/utils/recursion.rs
@@ -1,3 +1,8 @@
+//! Bounded Recursion Safety.
+//!
+//! This module provides a simple `DepthGuarded` wrapper to enforce maximum recursion
+//! limits (`MAX_TYPE_DEPTH`) on nested tree structures (like ASTs or nested Types).
+//! This prevents stack overflows, particularly against deeply nested payload attacks.
 use serde::Deserialize;
 use std::cell::Cell;
 

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -311,7 +311,7 @@ impl Relation {
         }
     }
 
-    /// Returns the relation type (heading) of this relation.
+    /// Retrieves the relation type (heading) defining this relation's structure.
     ///
     /// # Example
     ///
@@ -331,7 +331,7 @@ impl Relation {
         &self.relation_type
     }
 
-    /// Returns the cardinality (number of tuples) of this relation.
+    /// Calculates the cardinality (total number of tuples) currently held in this relation.
     ///
     /// # Example
     ///
@@ -353,7 +353,7 @@ impl Relation {
         self.body.len()
     }
 
-    /// Returns the degree (number of attributes) of this relation.
+    /// Calculates the degree (number of attributes) defined by this relation's heading.
     ///
     /// This is determined by the relation type's heading.
     ///
@@ -439,7 +439,7 @@ impl Relation {
         self.body.contains(tuple)
     }
 
-    /// Returns an iterator over the tuples in this relation.
+    /// Provides an iterator yielding all tuples currently in the relation.
     ///
     /// Per TTM Proscription 3, tuples have no inherent ordering. The
     /// iteration order is not guaranteed to be consistent.

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -122,7 +122,7 @@ pub enum ScalarValue {
 }
 
 impl ScalarValue {
-    /// Returns the scalar type of this value.
+    /// Resolves the concrete scalar type of this value instance.
     ///
     /// Every value in the relational model carries its type. This method
     /// allows introspection of the value's type at runtime.


### PR DESCRIPTION
📖 Chapter: Missing Module Docs and Redundant Boilerplate Comments
🔦 Insight: Several modules in `relvar-core` lacked module-level (`//!`) documentation explaining their purpose, causing a "Black Box" problem. Additionally, getter functions had repetitive, unhelpful documentation like "Returns the x". Added module-level documentation to `dml.rs`, `virtual_relvar.rs`, `traits.rs`, `recursion.rs`, `mod.rs`, `divide.rs`, and `prepared.rs`. Replaced "Gets the x" and "Returns the x" comments with descriptive verbs and context across `types`, `values`, and `constraints` modules.
🧪 Example: Added an executable doc test to `divide.rs` module documentation.
🖼️ Preview: All docs now compile cleanly under `cargo doc` with zero warnings.

---
*PR created automatically by Jules for task [14031940909835304615](https://jules.google.com/task/14031940909835304615) started by @madmax983*