### PR TITLE
⚡ Bolt: [performance improvement] Optimize join/semijoin tuple collection

### DIFF
--- a/relvar-core/src/algebra/join.rs
+++ b/relvar-core/src/algebra/join.rs
@@ -291,7 +291,9 @@ fn probe_and_combine_single<'a>(
     attr: &str,
     result_heading: &Arc<TupleType>,
 ) -> Result<Vec<Tuple>, DatabaseError> {
-    let mut joined_tuples = Vec::new();
+    // Optimization: Pre-allocate capacity based on the larger relation.
+    // This avoids resizing allocations in the hot loop.
+    let mut joined_tuples = Vec::with_capacity(probe_rel.cardinality());
 
     for probe_tuple in probe_rel.tuples() {
         let val = probe_tuple.get(attr).ok_or_else(|| {
@@ -365,7 +367,9 @@ fn probe_and_combine<'t, 'a>(
     common_attrs: &'a [String],
     result_heading: &Arc<TupleType>,
 ) -> Result<Vec<Tuple>, DatabaseError> {
-    let mut joined_tuples = Vec::new();
+    // Optimization: Pre-allocate capacity based on the larger relation.
+    // This avoids resizing allocations in the hot loop.
+    let mut joined_tuples = Vec::with_capacity(probe_rel.cardinality());
 
     for probe_tuple in probe_rel.tuples() {
         let key = JoinKey {
@@ -424,7 +428,10 @@ fn compute_theta_join_tuples<F>(
 where
     F: Fn(&Tuple, &Tuple) -> bool,
 {
-    let mut joined_tuples = Vec::new();
+    // Optimization: Use `std::cmp::max` to pre-allocate an initial capacity
+    // to reduce vector re-allocations during the cross product.
+    let capacity = std::cmp::max(left.cardinality(), right.cardinality());
+    let mut joined_tuples = Vec::with_capacity(capacity);
 
     for tuple1 in left.tuples() {
         for tuple2 in right.tuples() {

--- a/relvar-core/src/algebra/semijoin.rs
+++ b/relvar-core/src/algebra/semijoin.rs
@@ -139,21 +139,21 @@ impl Relation {
             });
         }
 
-        let mut matched = Vec::new();
-
-        for tuple in self.tuples() {
-            let key = SemijoinKey {
-                tuple,
-                attributes: &common_attrs,
-            };
-
-            if other_keys.contains(&key) {
-                matched.push(tuple.clone());
-            }
-        }
-
-        Relation::from_tuples(self.relation_type().clone(), matched)
-            .expect("Semijoin tuples conform to self's relation type")
+        // Optimization: Pass an iterator directly to `from_tuples_unchecked` instead of
+        // collecting into an intermediate `Vec`. The tuples are guaranteed to be valid
+        // since they come from `self`.
+        Relation::from_tuples_unchecked(
+            self.relation_type().clone(),
+            self.tuples()
+                .filter(|tuple| {
+                    let key = SemijoinKey {
+                        tuple,
+                        attributes: &common_attrs,
+                    };
+                    other_keys.contains(&key)
+                })
+                .cloned(),
+        )
     }
 
     /// Alias for [`semijoin`](Self::semijoin) using Tutorial D naming (MATCHING).
@@ -237,21 +237,21 @@ impl Relation {
             });
         }
 
-        let mut non_matched = Vec::new();
-
-        for tuple in self.tuples() {
-            let key = SemijoinKey {
-                tuple,
-                attributes: &common_attrs,
-            };
-
-            if !other_keys.contains(&key) {
-                non_matched.push(tuple.clone());
-            }
-        }
-
-        Relation::from_tuples(self.relation_type().clone(), non_matched)
-            .expect("Semidifference tuples conform to self's relation type")
+        // Optimization: Pass an iterator directly to `from_tuples_unchecked` instead of
+        // collecting into an intermediate `Vec`. The tuples are guaranteed to be valid
+        // since they come from `self`.
+        Relation::from_tuples_unchecked(
+            self.relation_type().clone(),
+            self.tuples()
+                .filter(|tuple| {
+                    let key = SemijoinKey {
+                        tuple,
+                        attributes: &common_attrs,
+                    };
+                    !other_keys.contains(&key)
+                })
+                .cloned(),
+        )
     }
 
     /// Alias for [`semidifference`](Self::semidifference) using Tutorial D naming (NOT MATCHING).


### PR DESCRIPTION
💡 What: Swapped intermediate `Vec` tuple collection in `semijoin` and `semidifference` with a direct iterator using `Relation::from_tuples_unchecked`, and added `Vec::with_capacity` pre-allocation in `join.rs` based on relation cardinalities.

🎯 Why: To reduce unnecessary memory allocations and eliminate expensive vector resizing during hot-path tuple combinations in relational algebra operations. The semijoin operations created entire `Vec` copies strictly to pass into the relation constructor, which internally builds a `HashSet` anyways.

📊 Impact: Reduces heap allocations by passing chained iterators directly during `semijoin` operations, and reduces the number of re-allocations during `join` probe phases by correctly presizing vectors.

🔬 Measurement: Run `cargo test` to ensure correctness and benchmark the affected algebra operations with large relations.

---
*PR created automatically by Jules for task [12515305014294374400](https://jules.google.com/task/12515305014294374400) started by @madmax983*