### PR TITLE
⚡ Bolt: Optimize `divide` operator to eliminate intermediate allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,6 @@
 ## 2024-03-01 - [Zero-Copy Primitive Extraction]
 **Learning:** `Tuple::get_typed<T>` was invoking `.clone()` on the `ScalarValue` enum purely to satisfy the `TryFrom<ScalarValue>` trait bound, causing a 24-byte enum copy for every extraction.
 **Action:** Changed trait bound to `T: for<'a> TryFrom<&'a ScalarValue>` to enable extraction by reference and avoid the enum wrapper clone, while preserving type safety.
+## 2026-03-07 - Avoiding Intermediate Allocations in Division Iterator
+**Learning:** The `filter_matching_candidates` helper in `relvar-core/src/algebra/divide.rs` originally used `.collect::<Vec<_>>()` to allocate a buffer of tuples before passing them to `Relation::from_tuples`.
+**Action:** Use `impl Iterator<Item = Tuple> + 'a` and add `move` to the `.filter` closure to return the iterator instead of allocating a `Vec`. Pass it directly into `Relation::from_tuples_unchecked` to eliminate validation overhead and allocation.

--- a/relvar-core/src/algebra/divide.rs
+++ b/relvar-core/src/algebra/divide.rs
@@ -148,8 +148,7 @@ impl Relation {
         // Return result relation
         use crate::types::RelationType;
         let result_type = RelationType::new(candidates.relation_type().heading().clone());
-        Ok(Relation::from_tuples(result_type, result_tuples)
-            .expect("Result tuples should conform to result type"))
+        Ok(Relation::from_tuples_unchecked(result_type, result_tuples))
     }
 }
 
@@ -204,12 +203,12 @@ fn project_onto_attrs(relation: &Relation, attrs: &[String]) -> Relation {
 
 /// Filter candidate tuples, keeping only those where ALL divisor tuples
 /// can be found when extended with the candidate.
-fn filter_matching_candidates(
-    candidates: &Relation,
-    divisor: &Relation,
-    dividend: &Relation,
-    dividend_heading: &crate::types::TupleType,
-) -> Vec<crate::values::Tuple> {
+fn filter_matching_candidates<'a>(
+    candidates: &'a Relation,
+    divisor: &'a Relation,
+    dividend: &'a Relation,
+    dividend_heading: &'a crate::types::TupleType,
+) -> impl Iterator<Item = crate::values::Tuple> + 'a {
     use std::collections::BTreeMap;
     use std::sync::Arc;
 
@@ -218,7 +217,7 @@ fn filter_matching_candidates(
 
     candidates
         .tuples()
-        .filter(|candidate| {
+        .filter(move |candidate| {
             // Check if ALL divisor tuples match when extended with this candidate
             divisor.tuples().all(|divisor_tuple| {
                 // Extend candidate with divisor tuple using iterator-based approach
@@ -240,7 +239,6 @@ fn filter_matching_candidates(
             })
         })
         .cloned()
-        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
💡 What: Replaced the intermediate `Vec<Tuple>` allocation in `filter_matching_candidates` within `relvar-core/src/algebra/divide.rs` with a zero-cost `impl Iterator`.
🎯 Why: `filter_matching_candidates` was collecting valid candidate tuples into a `Vec<Tuple>` just to pass them immediately into `Relation::from_tuples`. `Relation::from_tuples` also redundantly validated the tuples despite them originating from a safe projection.
📊 Impact: Completely eliminates the O(N) heap allocation for the intermediate `Vec` when computing relational division. Also bypasses unnecessary validation overhead.
🔬 Measurement: Run `cargo test` and `cargo bench --bench algebra`.

---
*PR created automatically by Jules for task [16862139637037103215](https://jules.google.com/task/16862139637037103215) started by @madmax983*