### PR TITLE
🛡️ Sentry: [test coverage improvement] for DML primitives

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -52,3 +52,6 @@
 ## 2025-03-04 - ScalarType Coverage Gaps
 **Learning:** Certain `ScalarType` recursive boundaries and unreachable trait implementations (`Ord` match) were entirely missing coverage, masking potential issues if the type structure were to change. Additionally, type mismatch errors in the `selector` logic lacked tests verifying correct error string output.
 **Action:** Always ensure full trait coverage, including unreachable branches when logic relies on matched enum variants, and systematically test recursion depth guards with deep structures.
+## 2025-03-07 - DML Functions Coverage
+**Learning:** `relvar-core/src/database/dml.rs` contained pure computation logic for updates and deletes (`compute_relation_after_delete` and `compute_relation_after_update`), but completely lacked unit test coverage for filtering logic and error paths like `DatabaseError::TupleMismatch`.
+**Action:** When extracting pure logic into standalone modules (like `dml.rs`), always ensure they have dedicated unit test blocks (`mod tests`) validating both their success permutations and error boundaries, completely separated from integration tests.

--- a/relvar-core/src/database/dml.rs
+++ b/relvar-core/src/database/dml.rs
@@ -72,3 +72,146 @@ where
 
     Ok((new_relation, update_count))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tuple;
+    use crate::types::{RelationType, ScalarType, TupleType};
+    use crate::values::ScalarValue;
+    use std::sync::Arc;
+
+    fn get_test_relation_type() -> RelationType {
+        let heading = TupleType::new()
+            .with_attribute("id", ScalarType::Int)
+            .with_attribute("name", ScalarType::String);
+        RelationType::new(heading)
+    }
+
+    fn get_test_relation() -> Relation {
+        let mut rel = Relation::new(get_test_relation_type());
+        rel.insert(tuple! { id: 1i64, name: "Alice" }).unwrap();
+        rel.insert(tuple! { id: 2i64, name: "Bob" }).unwrap();
+        rel.insert(tuple! { id: 3i64, name: "Charlie" }).unwrap();
+        rel
+    }
+
+    #[test]
+    fn test_compute_relation_after_delete_all() {
+        let rel = get_test_relation();
+        let (new_rel, delete_count) = compute_relation_after_delete(rel, |_| true).unwrap();
+
+        assert_eq!(delete_count, 3);
+        assert_eq!(new_rel.cardinality(), 0);
+    }
+
+    #[test]
+    fn test_compute_relation_after_delete_none() {
+        let rel = get_test_relation();
+        let (new_rel, delete_count) = compute_relation_after_delete(rel, |_| false).unwrap();
+
+        assert_eq!(delete_count, 0);
+        assert_eq!(new_rel.cardinality(), 3);
+    }
+
+    #[test]
+    fn test_compute_relation_after_delete_some() {
+        let rel = get_test_relation();
+        let (new_rel, delete_count) =
+            compute_relation_after_delete(rel, |t| t.get("id") == Some(&ScalarValue::Int(2)))
+                .unwrap();
+
+        assert_eq!(delete_count, 1);
+        assert_eq!(new_rel.cardinality(), 2);
+        assert!(new_rel.contains(&tuple! { id: 1i64, name: "Alice" }));
+        assert!(!new_rel.contains(&tuple! { id: 2i64, name: "Bob" }));
+        assert!(new_rel.contains(&tuple! { id: 3i64, name: "Charlie" }));
+    }
+
+    #[test]
+    fn test_compute_relation_after_update_all() {
+        let rel = get_test_relation();
+        let rel_type = rel.relation_type().clone();
+        let heading_arc = Arc::new(rel_type.tuple_type().clone());
+
+        let (new_rel, update_count) = compute_relation_after_update(
+            rel,
+            |_| true,
+            |t| {
+                let mut values = t.clone().values().clone();
+                values.insert(
+                    "name".to_string(),
+                    ScalarValue::String("Updated".to_string()),
+                );
+                Tuple::new_unchecked(heading_arc.clone(), values)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(update_count, 3);
+        assert_eq!(new_rel.cardinality(), 3);
+        assert!(new_rel.contains(&tuple! { id: 1i64, name: "Updated" }));
+        assert!(new_rel.contains(&tuple! { id: 2i64, name: "Updated" }));
+        assert!(new_rel.contains(&tuple! { id: 3i64, name: "Updated" }));
+    }
+
+    #[test]
+    fn test_compute_relation_after_update_none() {
+        let rel = get_test_relation();
+        let (new_rel, update_count) =
+            compute_relation_after_update(rel.clone(), |_| false, |t| t.clone()).unwrap();
+
+        assert_eq!(update_count, 0);
+        assert_eq!(new_rel, rel);
+    }
+
+    #[test]
+    fn test_compute_relation_after_update_some() {
+        let rel = get_test_relation();
+        let rel_type = rel.relation_type().clone();
+        let heading_arc = Arc::new(rel_type.tuple_type().clone());
+
+        let (new_rel, update_count) = compute_relation_after_update(
+            rel,
+            |t| t.get("id") == Some(&ScalarValue::Int(2)),
+            |t| {
+                let mut values = t.clone().values().clone();
+                values.insert(
+                    "name".to_string(),
+                    ScalarValue::String("Robert".to_string()),
+                );
+                Tuple::new_unchecked(heading_arc.clone(), values)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(update_count, 1);
+        assert_eq!(new_rel.cardinality(), 3);
+        assert!(new_rel.contains(&tuple! { id: 1i64, name: "Alice" }));
+        assert!(new_rel.contains(&tuple! { id: 2i64, name: "Robert" }));
+        assert!(new_rel.contains(&tuple! { id: 3i64, name: "Charlie" }));
+    }
+
+    #[test]
+    fn test_compute_relation_after_update_type_mismatch() {
+        let rel = get_test_relation();
+
+        let result = compute_relation_after_update(
+            rel,
+            |_| true,
+            |t| {
+                let mut values = t.clone().values().clone();
+                // Wrong type for name (Int instead of String)
+                values.insert("name".to_string(), ScalarValue::Int(42));
+                // We construct the tuple directly to bypass `Tuple::new` validation
+                // in order to test `compute_relation_after_update`'s explicit `conforms_to` check
+                let bad_heading = TupleType::new()
+                    .with_attribute("id", ScalarType::Int)
+                    .with_attribute("name", ScalarType::Int);
+                Tuple::new_unchecked(Arc::new(bad_heading), values)
+            },
+        );
+
+        assert!(matches!(result, Err(DatabaseError::TupleMismatch)));
+    }
+}


### PR DESCRIPTION
🎯 **Target:** `relvar-core/src/database/dml.rs` (`compute_relation_after_delete`, `compute_relation_after_update`)

💣 **Risk:** The pure tuple-processing logic extracted for `UPDATE` and `DELETE` commands had no direct unit test validation, leaving the data truncation and error boundary checks vulnerable to regressions.

🧪 **Strategy:** Created a `#[cfg(test)] mod tests` block to comprehensively evaluate both primitive DML operations against specific tuple matching criteria (all, some, none) while intentionally forcing the `DatabaseError::TupleMismatch` path during an update scenario.

🔬 **Verification:** `cargo test -p relvar-core -- test_compute_relation`

---
*PR created automatically by Jules for task [8374543893726243283](https://jules.google.com/task/8374543893726243283) started by @madmax983*