### PR TITLE
⚒️ Forge: Extract MVCC Deletion Logic & Flatten Guard Clauses

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -526,3 +526,7 @@ Build it right, make it fast, keep it simple.
 ## 2025-06-03 - Algebraic Operator Refactoring
 **Learning:** Complex algebraic operators like `group` and `ungroup` often mix validation, schema derivation, and tuple processing. Extracting these into distinct phases (`validate`, `build_heading`, `compute_tuples`) improves readability and testability.
 **Action:** Apply this "Three-Phase Operator" pattern when refactoring other complex operators like `join` or `summarize`.
+
+## 2025-10-24 - MVCC Deletion Duplication
+**Learning:** The implementation of MVCC soft-deletes within `HeapFile` (`delete_tuple_versioned` and `update_tuple_versioned`) contained identically duplicated logic for reading, marking `xmax`, and rewriting pages. This was a recurring anti-pattern whenever tuple metadata needed updates.
+**Action:** Extracted the core "mark deleted" phase into a shared `mark_version_deleted` helper, standardizing the soft-delete sequence and reducing boilerplate copy-pasting.

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -1033,32 +1033,7 @@ impl HeapFile {
         txn_id: crate::wal::TransactionId,
     ) -> Result<TupleId, HeapError> {
         // Step 1: Mark old version's xmax
-        let page = self.page_file.read_page(old_tuple_id.page_id)?;
-
-        if page.is_empty() {
-            return Err(HeapError::TupleNotFound);
-        }
-
-        let mut versioned_page = self.deserialize_versioned_page(&page)?;
-
-        // Find the old slot
-        let old_slot = versioned_page
-            .slots
-            .get_mut(old_tuple_id.slot as usize)
-            .and_then(|s| s.as_mut())
-            .ok_or(HeapError::TupleNotFound)?;
-
-        // Mark old version as deleted by this transaction
-        old_slot.xmax = Some(txn_id);
-
-        // Extract all existing tuple data
-        let existing_tuples = self.extract_all_tuples(&page, &versioned_page.slots)?;
-
-        // Serialize and write updated page with old version marked
-        let page_data =
-            self.serialize_versioned_page_with_tuples(&versioned_page, &existing_tuples)?;
-        let updated_page = Page::from_data(old_tuple_id.page_id, page_data)?;
-        self.page_file.write_page(&updated_page)?;
+        self.mark_version_deleted(old_tuple_id, txn_id)?;
 
         // Step 2: Insert new version
         let new_tuple_data = serialize_compat(new_tuple)?;
@@ -1102,7 +1077,15 @@ impl HeapFile {
         tuple_id: TupleId,
         txn_id: crate::wal::TransactionId,
     ) -> Result<(), HeapError> {
-        // Read the page containing the tuple
+        self.mark_version_deleted(tuple_id, txn_id)
+    }
+
+    /// Helper to mark a specific versioned tuple as deleted (sets its `xmax` to `txn_id`).
+    fn mark_version_deleted(
+        &mut self,
+        tuple_id: TupleId,
+        txn_id: crate::wal::TransactionId,
+    ) -> Result<(), HeapError> {
         let page = self.page_file.read_page(tuple_id.page_id)?;
 
         if page.is_empty() {
@@ -1111,20 +1094,16 @@ impl HeapFile {
 
         let mut versioned_page = self.deserialize_versioned_page(&page)?;
 
-        // Find and mark the tuple
         let slot = versioned_page
             .slots
             .get_mut(tuple_id.slot as usize)
             .and_then(|s| s.as_mut())
             .ok_or(HeapError::TupleNotFound)?;
 
-        // Mark as deleted by this transaction
         slot.xmax = Some(txn_id);
 
-        // Extract all existing tuple data
         let existing_tuples = self.extract_all_tuples(&page, &versioned_page.slots)?;
 
-        // Serialize and write updated page
         let page_data =
             self.serialize_versioned_page_with_tuples(&versioned_page, &existing_tuples)?;
         let updated_page = Page::from_data(tuple_id.page_id, page_data)?;
@@ -1186,25 +1165,24 @@ impl HeapFile {
 
             // Check each slot for dead versions
             for (idx, slot_option) in versioned_page.slots.iter_mut().enumerate() {
-                if let Some(slot) = slot_option {
-                    // Check if this version is dead
-                    if let Some(xmax) = slot.xmax {
-                        // Has xmax - was deleted or updated
-                        if committed.contains(&xmax) {
-                            // xmax transaction committed
-                            // Check if it's old enough (before oldest active)
-                            // Note: We need to compare transaction IDs as proxy for LSN
-                            // since we don't track commit LSNs yet
-                            if xmax.value() < oldest_active_lsn.value() {
-                                // This version is dead - remove it
-                                *slot_option = None;
-                                existing_tuples[idx] = Vec::new();
-                                removed_count += 1;
-                                page_modified = true;
-                            }
-                        }
-                    }
+                let Some(slot) = slot_option else {
+                    continue;
+                };
+                let Some(xmax) = slot.xmax else {
+                    continue;
+                };
+                if !committed.contains(&xmax) {
+                    continue;
                 }
+                if xmax.value() >= oldest_active_lsn.value() {
+                    continue;
+                }
+
+                // This version is dead - remove it
+                *slot_option = None;
+                existing_tuples[idx] = Vec::new();
+                removed_count += 1;
+                page_modified = true;
             }
 
             // Write page back if modified
@@ -1273,24 +1251,25 @@ impl HeapFile {
 
             // Check each slot for visibility
             for slot_entry in versioned_page.slots.iter().flatten() {
-                // Create version metadata
                 let version_metadata = crate::mvcc::VersionMetadata {
                     xmin: slot_entry.xmin,
                     xmax: slot_entry.xmax,
                 };
 
-                // Check visibility
-                if crate::mvcc::visibility::is_visible(&version_metadata, snapshot, committed) {
-                    // Extract tuple data from page
-                    let start = slot_entry.offset as usize;
-                    let end = start + slot_entry.length as usize;
-
-                    if end <= page.data().len() {
-                        let tuple_data = &page.data()[start..end];
-                        let tuple: Tuple = deserialize_bounded(tuple_data)?;
-                        results.push(tuple);
-                    }
+                if !crate::mvcc::visibility::is_visible(&version_metadata, snapshot, committed) {
+                    continue;
                 }
+
+                let start = slot_entry.offset as usize;
+                let end = start + slot_entry.length as usize;
+
+                if end > page.data().len() {
+                    continue;
+                }
+
+                let tuple_data = &page.data()[start..end];
+                let tuple: Tuple = deserialize_bounded(tuple_data)?;
+                results.push(tuple);
             }
 
             page_id += 1;


### PR DESCRIPTION
🚮 Smell: `HeapFile` contained duplicated boilerplate for marking tuple versions as deleted (loading page, finding slot, setting `xmax`, re-serializing). Additionally, `gc_remove_dead_versions` and `scan_visible` had deeply nested 'Pyramid of Doom' `if` conditions.
✨ Solution: Extracted the deletion logic into `mark_version_deleted` and utilized it in both `update_tuple_versioned` and `delete_tuple_versioned`. Flattened the nested `if` statements into clean guard clauses (`let Some(x) = y else { continue; }`).
🧼 Benefit: Significantly reduces boilerplate duplication, making MVCC state changes much easier to reason about. Reduces cognitive load by un-nesting long iteration blocks.
🛡️ Verification: `cargo clippy`, `cargo fmt`, and `cargo test` all passed. Zero change to runtime logic or tests.

---
*PR created automatically by Jules for task [3745512843428830078](https://jules.google.com/task/3745512843428830078) started by @madmax983*