### PR TITLE
⚒️ Forge: [Remove OperationType]

### DIFF
--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -56,13 +56,6 @@ pub(crate) struct TupleId {
     pub(crate) slot: u32,
 }
 
-/// Operation type for size checking (Insert vs Update)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OperationType {
-    Insert,
-    Update,
-}
-
 /// Errors that can occur during heap file operations.
 #[derive(Debug, Error)]
 pub enum HeapError {
@@ -679,7 +672,7 @@ impl HeapFile {
 
         // Check if tuple is too large to ever fit
         // New inserts have no previous version (prev_version = None)
-        self.check_versioned_tuple_size_limit(tuple_data.len(), OperationType::Insert)?;
+        self.check_versioned_tuple_size_limit(tuple_data.len(), false)?;
 
         // Find a page with enough space, or create a new one
         self.find_page_for_insertion(|heap, page_id| {
@@ -692,7 +685,7 @@ impl HeapFile {
     fn check_versioned_tuple_size_limit(
         &self,
         tuple_data_len: usize,
-        op_type: OperationType,
+        has_prev_version: bool,
     ) -> Result<(), HeapError> {
         // Create a dummy versioned page with one slot
         let dummy_page = VersionedSlottedPage {
@@ -703,12 +696,13 @@ impl HeapFile {
                 length: tuple_data_len as u32,
                 xmin: crate::wal::TransactionId::new(0),
                 xmax: None,
-                prev_version: match op_type {
-                    OperationType::Update => Some(TupleId {
+                prev_version: if has_prev_version {
+                    Some(TupleId {
                         page_id: 0,
                         slot: 0,
-                    }),
-                    OperationType::Insert => None,
+                    })
+                } else {
+                    None
                 },
             })],
         };
@@ -1027,7 +1021,7 @@ impl HeapFile {
 
         // Check if new tuple is too large
         // Updates link to previous version (prev_version = Some(...))
-        self.check_versioned_tuple_size_limit(new_tuple_data.len(), OperationType::Update)?;
+        self.check_versioned_tuple_size_limit(new_tuple_data.len(), true)?;
 
         // Find a page with space for new version
         self.find_page_for_insertion(|heap, page_id| {
@@ -3544,12 +3538,12 @@ mod security_tests {
 
             // Check if it fits with None (insert)
             let fits_insert = heap
-                .check_versioned_tuple_size_limit(tuple_data_len, OperationType::Insert)
+                .check_versioned_tuple_size_limit(tuple_data_len, false)
                 .is_ok();
 
             // Check if it fits with Some (update)
             let fits_update = heap
-                .check_versioned_tuple_size_limit(tuple_data_len, OperationType::Update)
+                .check_versioned_tuple_size_limit(tuple_data_len, true)
                 .is_ok();
 
             if fits_insert && !fits_update {


### PR DESCRIPTION
This PR applies the Razor essentialist persona to simplify the `OperationType` enum in `relvar-storage/src/storage/heap.rs`. The enum was essentially just a boolean toggle to check if a tuple had a previous version. This PR removes the enum and replaces it with a `has_prev_version: bool` parameter, updating all call sites and the Razor journal.

---
*PR created automatically by Jules for task [5705687940858207250](https://jules.google.com/task/5705687940858207250) started by @madmax983*