### PR TITLE
🪒 Razor: Eliminate Single-Use Traits and Generic Abstractions

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,7 @@
 **Bloat:** `RelationSource` trait. It was a "One-Time Trait" implemented only by `Database`, adding unnecessary abstraction and indirection for speculative "Future Proofing".
 **Cut:** Removed `RelationSource` trait and updated `Query::execute` to depend directly on `Database`.
 **Saved:** Removed 1 file (`traits.rs`), removed ~20 lines of code, reduced cognitive load by removing an unnecessary abstraction layer.
+## [Reduction]
+**Bloat:** `QueryExecutor` trait, `Pivot` trait, `SlotDescriptor`, `MutableSlot`. One-Time Traits implemented by only one object.
+**Cut:** Replaced `QueryExecutor` with concrete `Database<E>`, turned `Pivot` into a free function, manually duplicated small slot helpers.
+**Saved:** Removed 1 file (`traits.rs`), simplified generics, improved code locality.

--- a/relvar/src/experimental/pivot.rs
+++ b/relvar/src/experimental/pivot.rs
@@ -36,170 +36,159 @@ use relvar_core::types::{RelationType, TupleType};
 use relvar_core::values::{Relation, ScalarValue, Tuple};
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Trait extending Relation with pivot capabilities.
-pub trait Pivot {
-    /// Pivots a relation.
-    ///
-    /// Transforms unique values from the `on_attr` column into new column headers,
-    /// filling the cells with values from the `value_attr` column. All other attributes
-    /// become grouping keys.
-    ///
-    /// # Arguments
-    ///
-    /// * `on_attr` - The attribute whose values will become new column headers.
-    /// * `value_attr` - The attribute whose values will populate the cells.
-    /// * `default_value` - The value to use when a cell is missing (e.g., `0` or `false`).
-    ///   Must match the type of `value_attr`.
-    ///
-    /// # Conflict Resolution
-    ///
-    /// If multiple source tuples map to the same target cell (i.e., they have the same
-    /// grouping attributes and the same `on_attr` value), the **Last Write Wins** strategy
-    /// is applied. The source tuples are sorted, and the value from the last tuple is used.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar_core::types::{TupleType, RelationType, ScalarType};
-    /// use relvar_core::values::{Relation, ScalarValue};
-    /// use relvar_core::tuple;
-    /// use relvar::experimental::pivot::Pivot;
-    ///
-    /// // Create a relation: (Item, Color, Count)
-    /// let heading = TupleType::new()
-    ///     .with_attribute("Item", ScalarType::String)
-    ///     .with_attribute("Color", ScalarType::String)
-    ///     .with_attribute("Count", ScalarType::Int);
-    /// let mut relation = Relation::new(RelationType::new(heading));
-    ///
-    /// relation.insert(tuple! { Item: "Shirt", Color: "Red", Count: 10 }).unwrap();
-    /// relation.insert(tuple! { Item: "Shirt", Color: "Blue", Count: 5 }).unwrap();
-    /// relation.insert(tuple! { Item: "Pants", Color: "Blue", Count: 20 }).unwrap();
-    ///
-    /// // Pivot on 'Color', using 'Count' as values, default to 0
-    /// let pivoted = relation.pivot("Color", "Count", ScalarValue::Int(0)).unwrap();
-    ///
-    /// // Result: (Item, Red, Blue)
-    /// // Shirt: Red=10, Blue=5
-    /// // Pants: Red=0 (default), Blue=20
-    /// ```
-    fn pivot(
-        &self,
-        on_attr: &str,
-        value_attr: &str,
-        default_value: ScalarValue,
-    ) -> Result<Relation, DatabaseError>;
-}
+/// Pivots a relation.
+///
+/// Transforms unique values from the `on_attr` column into new column headers,
+/// filling the cells with values from the `value_attr` column. All other attributes
+/// become grouping keys.
+///
+/// # Arguments
+///
+/// * `relation` - The relation to pivot.
+/// * `on_attr` - The attribute whose values will become new column headers.
+/// * `value_attr` - The attribute whose values will populate the cells.
+/// * `default_value` - The value to use when a cell is missing (e.g., `0` or `false`).
+///   Must match the type of `value_attr`.
+///
+/// # Conflict Resolution
+///
+/// If multiple source tuples map to the same target cell (i.e., they have the same
+/// grouping attributes and the same `on_attr` value), the **Last Write Wins** strategy
+/// is applied. The source tuples are sorted, and the value from the last tuple is used.
+///
+/// # Examples
+///
+/// ```
+/// use relvar_core::types::{TupleType, RelationType, ScalarType};
+/// use relvar_core::values::{Relation, ScalarValue};
+/// use relvar_core::tuple;
+/// use relvar::experimental::pivot::pivot;
+///
+/// // Create a relation: (Item, Color, Count)
+/// let heading = TupleType::new()
+///     .with_attribute("Item", ScalarType::String)
+///     .with_attribute("Color", ScalarType::String)
+///     .with_attribute("Count", ScalarType::Int);
+/// let mut relation = Relation::new(RelationType::new(heading));
+///
+/// relation.insert(tuple! { Item: "Shirt", Color: "Red", Count: 10 }).unwrap();
+/// relation.insert(tuple! { Item: "Shirt", Color: "Blue", Count: 5 }).unwrap();
+/// relation.insert(tuple! { Item: "Pants", Color: "Blue", Count: 20 }).unwrap();
+///
+/// // Pivot on 'Color', using 'Count' as values, default to 0
+/// let pivoted = pivot(&relation, "Color", "Count", ScalarValue::Int(0)).unwrap();
+///
+/// // Result: (Item, Red, Blue)
+/// // Shirt: Red=10, Blue=5
+/// // Pants: Red=0 (default), Blue=20
+/// ```
+pub fn pivot(
+    relation: &Relation,
+    on_attr: &str,
+    value_attr: &str,
+    default_value: ScalarValue,
+) -> Result<Relation, DatabaseError> {
+    let heading = relation.relation_type().heading();
 
-impl Pivot for Relation {
-    fn pivot(
-        &self,
-        on_attr: &str,
-        value_attr: &str,
-        default_value: ScalarValue,
-    ) -> Result<Relation, DatabaseError> {
-        let heading = self.relation_type().heading();
+    if !heading.has_attribute(on_attr) {
+        return Err(DatabaseError::AttributeNotFound(
+            on_attr.to_string(),
+            "relation".to_string(),
+        ));
+    }
+    if !heading.has_attribute(value_attr) {
+        return Err(DatabaseError::AttributeNotFound(
+            value_attr.to_string(),
+            "relation".to_string(),
+        ));
+    }
 
-        if !heading.has_attribute(on_attr) {
-            return Err(DatabaseError::AttributeNotFound(
-                on_attr.to_string(),
-                "relation".to_string(),
-            ));
-        }
-        if !heading.has_attribute(value_attr) {
-            return Err(DatabaseError::AttributeNotFound(
-                value_attr.to_string(),
-                "relation".to_string(),
-            ));
-        }
+    let group_attrs: Vec<String> = heading
+        .attribute_names()
+        .filter(|&name| name != on_attr && name != value_attr)
+        .cloned()
+        .collect();
 
-        let group_attrs: Vec<String> = heading
-            .attribute_names()
-            .filter(|&name| name != on_attr && name != value_attr)
-            .cloned()
-            .collect();
+    // Scan for new columns
+    let mut new_columns = BTreeSet::new();
+    for tuple in relation.tuples() {
+        let val = tuple.get(on_attr).unwrap();
+        let col_name = scalar_to_string_key(val)?;
+        new_columns.insert(col_name);
+    }
 
-        // Scan for new columns
-        let mut new_columns = BTreeSet::new();
-        for tuple in self.tuples() {
-            let val = tuple.get(on_attr).unwrap();
-            let col_name = scalar_to_string_key(val)?;
-            new_columns.insert(col_name);
-        }
-
-        // Check collisions
-        for col in &new_columns {
-            if group_attrs.contains(col) {
-                return Err(DatabaseError::DuplicateAttributeName(format!(
-                    "Pivoted column '{}' conflicts with grouping attribute",
-                    col
-                )));
-            }
-        }
-
-        // Construct new heading
-        let mut new_heading = TupleType::new();
-        for attr in &group_attrs {
-            let ty = heading.get_attribute_type(attr).unwrap();
-            new_heading = new_heading.with_attribute(attr, ty.clone());
-        }
-
-        let value_type = heading.get_attribute_type(value_attr).unwrap();
-        if !default_value.is_type(value_type) {
-            return Err(DatabaseError::AlgebraError(format!(
-                "Default value type ({:?}) mismatch with value attribute ({:?})",
-                default_value.scalar_type(),
-                value_type
+    // Check collisions
+    for col in &new_columns {
+        if group_attrs.contains(col) {
+            return Err(DatabaseError::DuplicateAttributeName(format!(
+                "Pivoted column '{}' conflicts with grouping attribute",
+                col
             )));
         }
-
-        for col in &new_columns {
-            new_heading = new_heading.with_attribute(col, value_type.clone());
-        }
-
-        let new_rel_type = RelationType::new(new_heading);
-        let mut result_relation = Relation::new(new_rel_type.clone());
-
-        // Group data
-        let mut groups: BTreeMap<Vec<ScalarValue>, BTreeMap<String, ScalarValue>> = BTreeMap::new();
-
-        // Sort tuples for deterministic Last Write Wins
-        let mut sorted_tuples: Vec<&Tuple> = self.tuples().collect();
-        sorted_tuples.sort_by(|a, b| a.values().cmp(b.values()));
-
-        for tuple in sorted_tuples {
-            let mut group_key = Vec::with_capacity(group_attrs.len());
-            for attr in &group_attrs {
-                group_key.push(tuple.get(attr).unwrap().clone());
-            }
-
-            let pivot_val = tuple.get(on_attr).unwrap();
-            let col_name = scalar_to_string_key(pivot_val)?;
-            let cell_val = tuple.get(value_attr).unwrap().clone();
-
-            groups
-                .entry(group_key)
-                .or_default()
-                .insert(col_name, cell_val);
-        }
-
-        // Build result tuples
-        for (group_key, cell_map) in groups {
-            let mut tuple_values = BTreeMap::new();
-            for (i, attr) in group_attrs.iter().enumerate() {
-                tuple_values.insert(attr.clone(), group_key[i].clone());
-            }
-            for col in &new_columns {
-                let val = cell_map.get(col).unwrap_or(&default_value).clone();
-                tuple_values.insert(col.clone(), val);
-            }
-            let tuple = Tuple::new(new_rel_type.heading().clone(), tuple_values)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-            result_relation.insert(tuple)?;
-        }
-
-        Ok(result_relation)
     }
+
+    // Construct new heading
+    let mut new_heading = TupleType::new();
+    for attr in &group_attrs {
+        let ty = heading.get_attribute_type(attr).unwrap();
+        new_heading = new_heading.with_attribute(attr, ty.clone());
+    }
+
+    let value_type = heading.get_attribute_type(value_attr).unwrap();
+    if !default_value.is_type(value_type) {
+        return Err(DatabaseError::AlgebraError(format!(
+            "Default value type ({:?}) mismatch with value attribute ({:?})",
+            default_value.scalar_type(),
+            value_type
+        )));
+    }
+
+    for col in &new_columns {
+        new_heading = new_heading.with_attribute(col, value_type.clone());
+    }
+
+    let new_rel_type = RelationType::new(new_heading);
+    let mut result_relation = Relation::new(new_rel_type.clone());
+
+    // Group data
+    let mut groups: BTreeMap<Vec<ScalarValue>, BTreeMap<String, ScalarValue>> = BTreeMap::new();
+
+    // Sort tuples for deterministic Last Write Wins
+    let mut sorted_tuples: Vec<&Tuple> = relation.tuples().collect();
+    sorted_tuples.sort_by(|a, b| a.values().cmp(b.values()));
+
+    for tuple in sorted_tuples {
+        let mut group_key = Vec::with_capacity(group_attrs.len());
+        for attr in &group_attrs {
+            group_key.push(tuple.get(attr).unwrap().clone());
+        }
+
+        let pivot_val = tuple.get(on_attr).unwrap();
+        let col_name = scalar_to_string_key(pivot_val)?;
+        let cell_val = tuple.get(value_attr).unwrap().clone();
+
+        groups
+            .entry(group_key)
+            .or_default()
+            .insert(col_name, cell_val);
+    }
+
+    // Build result tuples
+    for (group_key, cell_map) in groups {
+        let mut tuple_values = BTreeMap::new();
+        for (i, attr) in group_attrs.iter().enumerate() {
+            tuple_values.insert(attr.clone(), group_key[i].clone());
+        }
+        for col in &new_columns {
+            let val = cell_map.get(col).unwrap_or(&default_value).clone();
+            tuple_values.insert(col.clone(), val);
+        }
+        let tuple = Tuple::new(new_rel_type.heading().clone(), tuple_values)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+        result_relation.insert(tuple)?;
+    }
+
+    Ok(result_relation)
 }
 
 fn scalar_to_string_key(val: &ScalarValue) -> Result<String, DatabaseError> {
@@ -232,7 +221,7 @@ mod tests {
         r.insert(tuple! { A: "X", M: "Feb", V: 20 }).unwrap();
         r.insert(tuple! { A: "Y", M: "Jan", V: 30 }).unwrap();
 
-        let p = r.pivot("M", "V", ScalarValue::Int(0)).unwrap();
+        let p = pivot(&r, "M", "V", ScalarValue::Int(0)).unwrap();
 
         // Expected: A, Jan, Feb
         assert_eq!(p.cardinality(), 2);
@@ -264,7 +253,7 @@ mod tests {
         r.insert(tuple! { K: "K1", P: "P1", V: 10 }).unwrap();
         r.insert(tuple! { K: "K1", P: "P1", V: 20 }).unwrap();
 
-        let p = r.pivot("P", "V", ScalarValue::Int(0)).unwrap();
+        let p = pivot(&r, "P", "V", ScalarValue::Int(0)).unwrap();
         assert_eq!(p.cardinality(), 1);
         let t = p.tuples().next().unwrap();
         assert_eq!(t.get("P1"), Some(&ScalarValue::Int(20)));


### PR DESCRIPTION
**Bloat:** "One-Time Traits" - `QueryExecutor`, `SlotDescriptor`, `MutableSlot`, `Pivot`. These traits were implemented by exactly one (or two highly coupled internal) structs, adding unnecessary abstraction layers and "speculative generality".
**Cut:** 
- `QueryExecutor` is removed. Dependent structures now use the concrete `Database<E>` type directly.
- `SlotDescriptor` and `MutableSlot` removed from `relvar-storage` heap files. Small helper functions were duplicated explicitly for the two slot types, avoiding generic trait bounds for simple offset logic.
- `Pivot` trait removed and transformed into a simple free function.
**Saved:** Removed `traits.rs`, eliminated unnecessary mental overhead for understanding system boundaries, and made the code strictly concrete and simpler.

---
*PR created automatically by Jules for task [99332814891514582](https://jules.google.com/task/99332814891514582) started by @madmax983*