### PR TITLE
⚒️ Forge: Refactor tclose to Three-Phase Operator pattern

### DIFF
--- a/relvar-core/src/algebra/tclose.rs
+++ b/relvar-core/src/algebra/tclose.rs
@@ -71,6 +71,15 @@ impl Relation {
     /// - The attributes have different types.
     /// - An algebraic operation fails.
     pub fn tclose(&self, from_attr: &str, to_attr: &str) -> Result<Relation, DatabaseError> {
+        self.validate_tclose_attributes(from_attr, to_attr)?;
+        self.compute_tclose(from_attr, to_attr)
+    }
+
+    fn validate_tclose_attributes(
+        &self,
+        from_attr: &str,
+        to_attr: &str,
+    ) -> Result<(), DatabaseError> {
         // 1. Validation
         if self.degree() != 2 {
             return Err(DatabaseError::AlgebraError(format!(
@@ -102,7 +111,10 @@ impl Relation {
                 from_attr, to_attr, from_type, to_type
             )));
         }
+        Ok(())
+    }
 
+    fn compute_tclose(&self, from_attr: &str, to_attr: &str) -> Result<Relation, DatabaseError> {
         // Semi-naive algorithm setup
         let mut r_total = self.clone();
         let mut r_delta = self.clone(); // Newly discovered paths


### PR DESCRIPTION
This PR refactors the Transitive Closure (`tclose`) operator implementation to follow the established Three-Phase Operator pattern. 

🚮 **Smell:** The `tclose` operator in `relvar-core/src/algebra/tclose.rs` mixed attribute validation, error handling, and the core semi-naive algebraic evaluation loop into a single long function, increasing cognitive load.
✨ **Solution:** Extracted `validate_tclose_attributes` and `compute_tclose` into private helper methods. The main `tclose` function now simply orchestrates these phases.
🧼 **Benefit:** Significantly improves readability by flattening logic and clearly separating validation from computation, making it consistent with other complex operators like `summarize` and `group`.
🛡️ **Verification:** Ran `cargo fmt`, `cargo clippy`, and `cargo test`. All checks passed, ensuring zero behavior change.

---
*PR created automatically by Jules for task [10119744505824161943](https://jules.google.com/task/10119744505824161943) started by @madmax983*