### PR TITLE
⚡ Bolt: [performance improvement] Optimize Vec allocation in group and summarize

### DIFF
--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -246,6 +246,11 @@ fn build_group_result_heading(
     Ok((result_heading, rva_heading))
 }
 
+/// # Performance
+///
+/// Pre-allocates the `result_tuples` vector using `Vec::with_capacity(groups.len())`.
+/// Because the exact number of output tuples is known after grouping the input,
+/// this prevents dynamic heap reallocations when constructing the resulting relation.
 fn compute_grouped_tuples(
     relation: &Relation,
     grouping_attrs: &[String],
@@ -278,7 +283,7 @@ fn compute_grouped_tuples(
     }
 
     // Build result tuples
-    let mut result_tuples = Vec::new();
+    let mut result_tuples = Vec::with_capacity(groups.len());
     let rva_relation_type = RelationType::new(rva_heading.clone());
     for (key, rva_tuples) in groups {
         let mut values = std::collections::BTreeMap::new();

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -449,6 +449,12 @@ impl Relation {
     ///   conflicts with a grouping attribute
     /// - [`SummarizeError::AggregationError`] - An aggregation failed (e.g.,
     ///   MIN/MAX on empty set)
+    ///
+    /// # Performance
+    ///
+    /// Pre-allocates the `result_tuples` vector using `Vec::with_capacity(groups.len())`.
+    /// Because the exact number of output tuples is known after grouping the input,
+    /// this prevents dynamic heap reallocations when constructing the resulting relation.
     pub fn summarize(
         &self,
         group_by: &[&str],
@@ -462,7 +468,7 @@ impl Relation {
         let groups = self.group_tuples(group_by);
 
         // Compute aggregations for each group
-        let mut result_tuples = Vec::new();
+        let mut result_tuples = Vec::with_capacity(groups.len());
         for (key, group_tuples) in groups {
             let mut values = std::collections::BTreeMap::new();
 


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(groups.len())` when constructing result tuples in `group` and `summarize` relational operations. Added `/// # Performance` doc comments to explain the optimization.
🎯 Why: Constructing the final relations after grouping elements causes unnecessary dynamic heap reallocations because the resulting number of tuples (the number of distinct groups) is already known.
📊 Impact: Eliminates multiple dynamic heap reallocations per `group()` and `summarize()` operation.
🔬 Measurement: Run `cargo bench` or profile queries utilizing heavily grouped datasets.

---
*PR created automatically by Jules for task [10622150437345094316](https://jules.google.com/task/10622150437345094316) started by @madmax983*