### PR TITLE
🛡️ Sentry: [test coverage improvement] for automl, mock, and pivot

### DIFF
--- a/relvar/src/experimental/automl.rs
+++ b/relvar/src/experimental/automl.rs
@@ -301,4 +301,47 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_train_error_handling() -> Result<(), DatabaseError> {
+        let mut db = Database::new(InMemoryEngine::new());
+        let heading = TupleType::new()
+            .with_attribute("outlook", ScalarType::String)
+            .with_attribute("play", ScalarType::String);
+        db.create_relvar("GOLF", RelationType::new(heading))?;
+        db.insert("GOLF", tuple! { outlook: "sunny", play: "no" })?;
+
+        let golf = db.query("GOLF")?;
+
+        let err = NaiveBayesClassifier::train(&golf, "missing_target");
+        assert!(matches!(err, Err(DatabaseError::AttributeNotFound(..))));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_predict_unseen_values() -> Result<(), DatabaseError> {
+        let mut db = Database::new(InMemoryEngine::new());
+        let heading = TupleType::new()
+            .with_attribute("f1", ScalarType::Int)
+            .with_attribute("f2", ScalarType::Float)
+            .with_attribute("f3", ScalarType::Bool)
+            .with_attribute("target", ScalarType::String);
+        db.create_relvar("DATA", RelationType::new(heading))?;
+        db.insert("DATA", tuple! { f1: 1, f2: 1.0, f3: true, target: "A" })?;
+        db.insert("DATA", tuple! { f1: 2, f2: 2.0, f3: false, target: "B" })?;
+
+        let data = db.query("DATA")?;
+        let model = NaiveBayesClassifier::train(&data, "target")?;
+
+        // Prediction with completely unseen values
+        let t = tuple! { f1: 99, f2: 99.0, f3: true };
+        let p = model.predict(&t);
+        // Should still predict something without panicking
+        assert!(
+            p == ScalarValue::String("A".to_string()) || p == ScalarValue::String("B".to_string())
+        );
+
+        Ok(())
+    }
 }

--- a/relvar/src/experimental/mock.rs
+++ b/relvar/src/experimental/mock.rs
@@ -174,6 +174,33 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_all_types() {
+        let nested_rel_type =
+            RelationType::new(TupleType::new().with_attribute("inner", ScalarType::Int));
+
+        let user_defined_type = ScalarType::UserDefined {
+            name: "MyType".to_string(),
+            representation: Box::new(ScalarType::Int),
+        };
+
+        let rel_type = RelationType::new(
+            TupleType::new()
+                .with_attribute("int_val", ScalarType::Int)
+                .with_attribute("float_val", ScalarType::Float)
+                .with_attribute("str_val", ScalarType::String)
+                .with_attribute("bool_val", ScalarType::Bool)
+                .with_attribute("bytes_val", ScalarType::Bytes)
+                .with_attribute("rel_val", ScalarType::Relation(Box::new(nested_rel_type)))
+                .with_attribute("user_val", user_defined_type),
+        );
+
+        let relation = MockRelation::new(rel_type).count(10).seed(42).generate();
+
+        assert_eq!(relation.degree(), 7);
+        assert_eq!(relation.cardinality(), 10);
+    }
+
+    #[test]
     fn test_determinism() {
         let rel_type = RelationType::new(TupleType::new().with_attribute("val", ScalarType::Float));
 

--- a/relvar/src/experimental/pivot.rs
+++ b/relvar/src/experimental/pivot.rs
@@ -269,4 +269,52 @@ mod tests {
         let t = p.tuples().next().unwrap();
         assert_eq!(t.get("P1"), Some(&ScalarValue::Int(20)));
     }
+
+    #[test]
+    fn test_pivot_errors() {
+        use relvar_core::error::DatabaseError;
+        let heading = TupleType::new()
+            .with_attribute("A", ScalarType::String)
+            .with_attribute("M", ScalarType::String)
+            .with_attribute("V", ScalarType::Int)
+            .with_attribute("Jan", ScalarType::String);
+        let mut r = Relation::new(RelationType::new(heading));
+        r.insert(tuple! { A: "X", M: "Jan", V: 10, Jan: "Y" })
+            .unwrap();
+
+        // Missing on_attr
+        let err = r.pivot("Missing", "V", ScalarValue::Int(0)).unwrap_err();
+        assert!(matches!(err, DatabaseError::AttributeNotFound(..)));
+
+        // Missing value_attr
+        let err = r.pivot("M", "Missing", ScalarValue::Int(0)).unwrap_err();
+        assert!(matches!(err, DatabaseError::AttributeNotFound(..)));
+
+        // Conflicting column name
+        let err = r.pivot("M", "V", ScalarValue::Int(0)).unwrap_err();
+        assert!(matches!(err, DatabaseError::DuplicateAttributeName(..)));
+
+        // Type mismatch for default value
+        let heading2 = TupleType::new()
+            .with_attribute("A", ScalarType::String)
+            .with_attribute("M", ScalarType::String)
+            .with_attribute("V", ScalarType::Int);
+        let mut r2 = Relation::new(RelationType::new(heading2));
+        r2.insert(tuple! { A: "X", M: "Jan", V: 10 }).unwrap();
+
+        let err = r2
+            .pivot("M", "V", ScalarValue::String("0".to_string()))
+            .unwrap_err();
+        assert!(matches!(err, DatabaseError::AlgebraError(..)));
+
+        // Unsupported type for pivot key
+        let heading3 = TupleType::new()
+            .with_attribute("A", ScalarType::String)
+            .with_attribute("M", ScalarType::Float)
+            .with_attribute("V", ScalarType::Int);
+        let mut r3 = Relation::new(RelationType::new(heading3));
+        r3.insert(tuple! { A: "X", M: 1.0, V: 10 }).unwrap();
+        let err = r3.pivot("M", "V", ScalarValue::Int(0)).unwrap_err();
+        assert!(matches!(err, DatabaseError::AlgebraError(..)));
+    }
 }


### PR DESCRIPTION
* 🎯 Target: `relvar/src/experimental/mock.rs`, `relvar/src/experimental/pivot.rs`, `relvar/src/experimental/automl.rs` 
* 💣 Risk: Missing attribute errors, invalid default pivots, missing value edge cases during prediction were unexercised, potentially masking runtime panics. 
* 🧪 Strategy: Wrote pure unit tests covering the exact missing branches detected by `cargo-llvm-cov`. Added coverage for every supported scalar type dynamically generated by mocks. 
* 🔬 Verification: Checked with `cargo llvm-cov test`, ensuring the previously missing line hits went to 0. Code also passed standard `cargo test` and `cargo clippy`.

---
*PR created automatically by Jules for task [14037153606272682209](https://jules.google.com/task/14037153606272682209) started by @madmax983*