### PR TITLE
⚒️ Forge: Flatten Ord implementations for ScalarType and ScalarValue

### DIFF
--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -371,6 +371,51 @@ impl PartialOrd for ScalarType {
     }
 }
 
+// Helper to compare relation types by their headings
+fn cmp_relation_types(
+    a: &crate::types::RelationType,
+    b: &crate::types::RelationType,
+) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+
+    // Since TupleType doesn't have Ord, we need a custom comparison
+    let a_attrs: Vec<_> = a
+        .heading()
+        .attribute_names()
+        .map(|n| (n, a.heading().get_attribute_type(n).unwrap()))
+        .collect();
+    let b_attrs: Vec<_> = b
+        .heading()
+        .attribute_names()
+        .map(|n| (n, b.heading().get_attribute_type(n).unwrap()))
+        .collect();
+
+    // Compare by count first, then by sorted attributes
+    let count_ord = a_attrs.len().cmp(&b_attrs.len());
+    if count_ord != Ordering::Equal {
+        return count_ord;
+    }
+
+    let mut a_sorted = a_attrs;
+    let mut b_sorted = b_attrs;
+    a_sorted.sort_by_key(|(name, _)| *name);
+    b_sorted.sort_by_key(|(name, _)| *name);
+
+    for ((a_name, a_ty), (b_name, b_ty)) in a_sorted.iter().zip(b_sorted.iter()) {
+        let name_ord = a_name.cmp(b_name);
+        if name_ord != Ordering::Equal {
+            return name_ord;
+        }
+
+        let ty_ord = a_ty.cmp(b_ty);
+        if ty_ord != Ordering::Equal {
+            return ty_ord;
+        }
+    }
+
+    Ordering::Equal
+}
+
 impl Ord for ScalarType {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         use std::cmp::Ordering;
@@ -386,70 +431,37 @@ impl Ord for ScalarType {
             ScalarType::UserDefined { .. } => 6,
         };
 
-        match disc_value(self).cmp(&disc_value(other)) {
-            Ordering::Equal => {
-                // Same variant, compare data
-                match (self, other) {
-                    (ScalarType::Int, ScalarType::Int)
-                    | (ScalarType::Float, ScalarType::Float)
-                    | (ScalarType::String, ScalarType::String)
-                    | (ScalarType::Bool, ScalarType::Bool)
-                    | (ScalarType::Bytes, ScalarType::Bytes) => Ordering::Equal,
-                    (ScalarType::Relation(a), ScalarType::Relation(b)) => {
-                        // Compare relation types by their headings
-                        // Since TupleType doesn't have Ord, we need a custom comparison
-                        let a_attrs: Vec<_> = a
-                            .heading()
-                            .attribute_names()
-                            .map(|n| (n, a.heading().get_attribute_type(n).unwrap()))
-                            .collect();
-                        let b_attrs: Vec<_> = b
-                            .heading()
-                            .attribute_names()
-                            .map(|n| (n, b.heading().get_attribute_type(n).unwrap()))
-                            .collect();
+        let order = disc_value(self).cmp(&disc_value(other));
+        if order != Ordering::Equal {
+            return order;
+        }
 
-                        // Compare by count first, then by sorted attributes
-                        match a_attrs.len().cmp(&b_attrs.len()) {
-                            Ordering::Equal => {
-                                let mut a_sorted = a_attrs;
-                                let mut b_sorted = b_attrs;
-                                a_sorted.sort_by_key(|(name, _)| *name);
-                                b_sorted.sort_by_key(|(name, _)| *name);
-
-                                for ((a_name, a_ty), (b_name, b_ty)) in
-                                    a_sorted.iter().zip(b_sorted.iter())
-                                {
-                                    match a_name.cmp(b_name) {
-                                        Ordering::Equal => match a_ty.cmp(b_ty) {
-                                            Ordering::Equal => continue,
-                                            other => return other,
-                                        },
-                                        other => return other,
-                                    }
-                                }
-                                Ordering::Equal
-                            }
-                            other => other,
-                        }
-                    }
-                    (
-                        ScalarType::UserDefined {
-                            name: a_name,
-                            representation: a_rep,
-                        },
-                        ScalarType::UserDefined {
-                            name: b_name,
-                            representation: b_rep,
-                        },
-                    ) => match a_name.cmp(b_name) {
-                        Ordering::Equal => a_rep.cmp(b_rep),
-                        other => other,
-                    },
-                    _ => unreachable!("Discriminants matched but variants don't"),
+        // Same variant, compare data
+        match (self, other) {
+            (ScalarType::Int, ScalarType::Int)
+            | (ScalarType::Float, ScalarType::Float)
+            | (ScalarType::String, ScalarType::String)
+            | (ScalarType::Bool, ScalarType::Bool)
+            | (ScalarType::Bytes, ScalarType::Bytes) => Ordering::Equal,
+            (ScalarType::Relation(a), ScalarType::Relation(b)) => cmp_relation_types(a, b),
+            (
+                ScalarType::UserDefined {
+                    name: a_name,
+                    representation: a_rep,
+                },
+                ScalarType::UserDefined {
+                    name: b_name,
+                    representation: b_rep,
+                },
+            ) => {
+                let name_ord = a_name.cmp(b_name);
+                if name_ord != Ordering::Equal {
+                    name_ord
+                } else {
+                    a_rep.cmp(b_rep)
                 }
             }
-            other => other,
+            _ => unreachable!("Discriminants matched but variants don't"),
         }
     }
 }

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -363,6 +363,45 @@ impl PartialOrd for ScalarValue {
     }
 }
 
+// Helper to compare floating point numbers
+fn cmp_floats(a: f64, b: f64) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+
+    // For floats, treat all NaNs as equal and greater than any other float
+    match (a.is_nan(), b.is_nan()) {
+        (true, true) => Ordering::Equal,
+        (true, false) => Ordering::Greater,
+        (false, true) => Ordering::Less,
+        (false, false) => {
+            // Correctly order floating point numbers using their bit representation
+            // This handles signed zeros (-0.0 < 0.0) and negative numbers correctly
+            let a_bits = a.to_bits();
+            let b_bits = b.to_bits();
+            let a_sign = a_bits >> 63;
+            let b_sign = b_bits >> 63;
+
+            if a_sign != b_sign {
+                // Different signs: negative < positive
+                if a_sign == 1 {
+                    Ordering::Less
+                } else {
+                    Ordering::Greater
+                }
+            } else {
+                // Same signs
+                if a_sign == 0 {
+                    // Both positive: larger magnitude is larger
+                    a_bits.cmp(&b_bits)
+                } else {
+                    // Both negative: larger magnitude is smaller (more negative)
+                    // e.g., -10.0 has larger bit representation than -1.0
+                    b_bits.cmp(&a_bits)
+                }
+            }
+        }
+    }
+}
+
 // Custom Ord implementation for use in BTreeMap
 // We order by type first, then by value within type
 // TTM: User-defined values are ordered by type identity first, then by representation value
@@ -384,101 +423,67 @@ impl Ord for ScalarValue {
         }
 
         // Compare types first
-        match type_order(self).cmp(&type_order(other)) {
-            Ordering::Equal => {
-                // Same type: order by value
-                match (self, other) {
-                    (ScalarValue::Int(a), ScalarValue::Int(b)) => a.cmp(b),
-                    (ScalarValue::Float(a), ScalarValue::Float(b)) => {
-                        // For floats, treat all NaNs as equal and greater than any other float
-                        match (a.is_nan(), b.is_nan()) {
-                            (true, true) => Ordering::Equal,
-                            (true, false) => Ordering::Greater,
-                            (false, true) => Ordering::Less,
-                            (false, false) => {
-                                // Correctly order floating point numbers using their bit representation
-                                // This handles signed zeros (-0.0 < 0.0) and negative numbers correctly
-                                let a_bits = a.to_bits();
-                                let b_bits = b.to_bits();
-                                let a_sign = a_bits >> 63;
-                                let b_sign = b_bits >> 63;
+        let order = type_order(self).cmp(&type_order(other));
+        if order != Ordering::Equal {
+            return order;
+        }
 
-                                if a_sign != b_sign {
-                                    // Different signs: negative < positive
-                                    if a_sign == 1 {
-                                        Ordering::Less
-                                    } else {
-                                        Ordering::Greater
-                                    }
-                                } else {
-                                    // Same signs
-                                    if a_sign == 0 {
-                                        // Both positive: larger magnitude is larger
-                                        a_bits.cmp(&b_bits)
-                                    } else {
-                                        // Both negative: larger magnitude is smaller (more negative)
-                                        // e.g., -10.0 has larger bit representation than -1.0
-                                        b_bits.cmp(&a_bits)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    (ScalarValue::String(a), ScalarValue::String(b)) => a.cmp(b),
-                    (ScalarValue::Bool(a), ScalarValue::Bool(b)) => a.cmp(b),
-                    (ScalarValue::Bytes(a), ScalarValue::Bytes(b)) => a.cmp(b),
-                    (ScalarValue::Relation(a), ScalarValue::Relation(b)) => {
-                        // For relations, order by cardinality first, then degree
-                        match a.cardinality().cmp(&b.cardinality()) {
-                            Ordering::Equal => a.degree().cmp(&b.degree()),
-                            other => other,
-                        }
-                    }
-                    (
-                        ScalarValue::UserDefined {
-                            type_def: type_a,
-                            value: val_a,
-                        },
-                        ScalarValue::UserDefined {
-                            type_def: type_b,
-                            value: val_b,
-                        },
-                    ) => {
-                        // Order by type identity first (structural comparison), then by value
-                        match type_a.cmp(type_b) {
-                            Ordering::Equal => {
-                                // Iterative comparison to prevent stack overflow
-                                let mut cur_a = val_a;
-                                let mut cur_b = val_b;
-                                loop {
-                                    match (&**cur_a, &**cur_b) {
-                                        (
-                                            ScalarValue::UserDefined {
-                                                type_def: ta,
-                                                value: va,
-                                            },
-                                            ScalarValue::UserDefined {
-                                                type_def: tb,
-                                                value: vb,
-                                            },
-                                        ) => match ta.cmp(tb) {
-                                            Ordering::Equal => {
-                                                cur_a = va;
-                                                cur_b = vb;
-                                            }
-                                            other => return other,
-                                        },
-                                        (a, b) => return a.cmp(b),
-                                    }
-                                }
-                            }
-                            other => other,
-                        }
-                    }
-                    _ => unreachable!("Type orders are equal but types don't match"),
+        // Same type: order by value
+        match (self, other) {
+            (ScalarValue::Int(a), ScalarValue::Int(b)) => a.cmp(b),
+            (ScalarValue::Float(a), ScalarValue::Float(b)) => cmp_floats(*a, *b),
+            (ScalarValue::String(a), ScalarValue::String(b)) => a.cmp(b),
+            (ScalarValue::Bool(a), ScalarValue::Bool(b)) => a.cmp(b),
+            (ScalarValue::Bytes(a), ScalarValue::Bytes(b)) => a.cmp(b),
+            (ScalarValue::Relation(a), ScalarValue::Relation(b)) => {
+                // For relations, order by cardinality first, then degree
+                match a.cardinality().cmp(&b.cardinality()) {
+                    Ordering::Equal => a.degree().cmp(&b.degree()),
+                    other => other,
                 }
             }
-            other => other,
+            (
+                ScalarValue::UserDefined {
+                    type_def: type_a,
+                    value: val_a,
+                },
+                ScalarValue::UserDefined {
+                    type_def: type_b,
+                    value: val_b,
+                },
+            ) => {
+                // Order by type identity first (structural comparison), then by value
+                match type_a.cmp(type_b) {
+                    Ordering::Equal => {
+                        // Iterative comparison to prevent stack overflow
+                        let mut cur_a = val_a;
+                        let mut cur_b = val_b;
+                        loop {
+                            match (&**cur_a, &**cur_b) {
+                                (
+                                    ScalarValue::UserDefined {
+                                        type_def: ta,
+                                        value: va,
+                                    },
+                                    ScalarValue::UserDefined {
+                                        type_def: tb,
+                                        value: vb,
+                                    },
+                                ) => match ta.cmp(tb) {
+                                    Ordering::Equal => {
+                                        cur_a = va;
+                                        cur_b = vb;
+                                    }
+                                    other => return other,
+                                },
+                                (a, b) => return a.cmp(b),
+                            }
+                        }
+                    }
+                    other => other,
+                }
+            }
+            _ => unreachable!("Type orders are equal but types don't match"),
         }
     }
 }


### PR DESCRIPTION
* 🚮 **Smell:** The `Ord::cmp` implementations in `relvar-core/src/values/scalar.rs` and `relvar-core/src/types/scalar.rs` suffered from the "Pyramid of Doom" anti-pattern, reaching up to 11 levels of nesting. This occurred because they matched on a type discriminator and then matched again on the variants, with highly complex logic embedded deep within the match arms.
* ✨ **Solution:** Extracted the complex float comparison logic into `cmp_floats` and the relation type comparison logic into `cmp_relation_types`. Inverted the initial type-order check into a guard clause that returns early if the types are not equal, eliminating a full level of nesting and allowing the subsequent logic to be flattened.
* 🧼 **Benefit:** Reduces cognitive load by eliminating deep nesting. The logic is now modularized into clear, named helper functions, making it significantly easier to read, understand, and maintain.
* 🛡️ **Verification:** `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all` all pass locally. No runtime behavior was altered.

---
*PR created automatically by Jules for task [2182799538776920043](https://jules.google.com/task/2182799538776920043) started by @madmax983*