### PR TITLE
⚡ Bolt: [performance improvement] Optimize Vector Allocation in extend Operator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,8 @@
 ## 2026-03-06 - [Zero-Copy String Extraction]
 **Learning:** `Tuple::get_typed<T>` was invoking `.clone()` on the `ScalarValue::String` enum purely to satisfy the `TryFrom<&'a ScalarValue> for String` trait bound. This caused unnecessary heap allocations when borrowing as `&str` was sufficient.
 **Action:** Implemented `TryFrom<&'a ScalarValue> for &'a str` to enable zero-copy string extraction via `Tuple::get_typed::<&str>`, saving a heap allocation on every hot-path string extraction.
+## 2026-03-08 - Tuple Pre-allocation in Extend
+**Learning:** The `extend` operator iterates over `self.tuples()` and builds a completely new `Vec<Tuple>` by calling `collect()`. However, we know that the cardinality of an extended relation will always exactly match the cardinality of the input relation, because `extend` adds exactly one attribute to every existing tuple without adding or removing any tuples.
+Without pre-allocating the vector for `extended_tuples` with `with_capacity()`, the underlying vector will repeatedly reallocate as tuples are computed and pushed onto it, which is especially noticeable for large relations.
+
+**Action:** When implementing operations like `extend` or `project` that have a 1:1 input-to-output tuple mapping or have a known upper bound, use an iterator with a `size_hint` or explicitly allocate `Vec::with_capacity(self.cardinality())` before iterating, or verify that the returned iterator properly implements `size_hint` so that `collect()` can optimize the allocation.

--- a/relvar-core/src/algebra/extend.rs
+++ b/relvar-core/src/algebra/extend.rs
@@ -99,12 +99,21 @@ impl Relation {
         let new_heading_arc = std::sync::Arc::new(new_heading);
 
         // Create extended tuples
-        let extended_tuples: Vec<Tuple> = self
-            .tuples()
-            .map(|tuple| {
-                create_extended_tuple(tuple, attr_name, &attr_type, &new_heading_arc, &compute)
-            })
-            .collect::<Result<_, _>>()?;
+        //
+        // # Performance
+        // We know exactly how many tuples will be produced because `extend` computes
+        // exactly one new tuple for each input tuple. Pre-allocating the vector
+        // avoids dynamic heap reallocations when collecting the results.
+        let mut extended_tuples = Vec::with_capacity(self.cardinality());
+        for tuple in self.tuples() {
+            extended_tuples.push(create_extended_tuple(
+                tuple,
+                attr_name,
+                &attr_type,
+                &new_heading_arc,
+                &compute,
+            )?);
+        }
 
         Ok(Relation::from_tuples(new_rel_type, extended_tuples)
             .expect("Extended tuples should conform to new relation type"))


### PR DESCRIPTION
💡 **What:** Replaced dynamic vector collection (`.collect::<Result<_, _>>()?`) with explicit pre-allocation `Vec::with_capacity(self.cardinality())` in the `Relation::extend` operator.

🎯 **Why:** The `extend` operator iterates over `self.tuples()` to produce exactly one output tuple for each input tuple. While standard iterators over collections usually provide good `size_hint`s that `collect()` can use, operations over chained `map()` iterators traversing custom structures (like `HashSet::Iter` mapped over by custom logic returning `Result`) can sometimes drop or obfuscate the exact size hint. Explicitly declaring `with_capacity()` guarantees a single heap allocation for the output vector, avoiding costly dynamic memory reallocations inside the hot loop as tuples are computed.

📊 **Impact:** Reduces dynamic heap reallocations when extending relations. For large relations, guarantees O(1) allocations for the vector container instead of O(log N) reallocations.

🔬 **Measurement:** Run `cargo bench` and observe any workloads heavy in `extend` operations; heap allocations for the result vectors are now strictly bounded to 1 per `extend` call.

---
*PR created automatically by Jules for task [9663662695649860624](https://jules.google.com/task/9663662695649860624) started by @madmax983*