### PR TITLE
🛡️ Sentry: [test coverage improvement] Fix Query::Restrict silent failure on constraint evaluation error

### DIFF
--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -172,15 +172,11 @@ impl Query {
             Query::Scan(table_name) => Ok(db.query(table_name)?),
             Query::Restrict { input, predicate } => {
                 let relation = input.execute(db)?;
-                // Note: Relation::restrict takes a closure that returns bool.
-                // We use evaluate() inside, but we must handle errors.
-                // Currently, we treat evaluation errors as false (exclude tuple).
-
                 // Pre-compute optimized structures (HashSet for IN, Vec<char> for LIKE)
                 // This prevents O(N*M) behavior for large IN lists or LIKE patterns
                 let prepared = predicate.prepare();
                 let result = relation
-                    .restrict_into(move |tuple| prepared.evaluate(tuple).unwrap_or_default());
+                    .restrict_into_result(move |tuple| prepared.evaluate(tuple))?;
                 Ok(result)
             }
             Query::Project { input, attributes } => {

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -503,6 +503,29 @@ impl Relation {
         self.body.retain(|tuple| predicate(tuple));
         self
     }
+
+    /// Restricts a relation based on a fallible predicate, consuming the relation in the process.
+    ///
+    /// This is an optimized version of `restrict` when the original relation
+    /// is no longer needed.
+    ///
+    /// # Arguments
+    ///
+    /// * `predicate` - A fallible function that returns `true` for tuples to keep
+    pub fn restrict_into_result<E, F>(mut self, mut predicate: F) -> Result<Self, E>
+    where
+        F: FnMut(&Tuple) -> Result<bool, E>,
+    {
+        // For short-circuiting on errors without iterating the rest of the body:
+        let mut new_body = std::collections::HashSet::with_capacity(self.body.len());
+        for tuple in self.body.into_iter() {
+            if predicate(&tuple)? {
+                new_body.insert(tuple);
+            }
+        }
+        self.body = new_body;
+        Ok(self)
+    }
 }
 
 #[cfg(test)]

--- a/relvar-core/tests/sentry_manager_unwrap_or_default.rs
+++ b/relvar-core/tests/sentry_manager_unwrap_or_default.rs
@@ -1,0 +1,18 @@
+use relvar_core::constraints::ConstraintManager;
+use relvar_core::storage_engine::InMemoryEngine;
+use relvar_core::tuple;
+
+#[test]
+fn test_validate_foreign_keys_single_tuple_no_constraints() {
+    let mut engine = InMemoryEngine::new();
+    let manager = ConstraintManager::new();
+
+    // We haven't added any constraints to manager
+
+    let tuple = tuple! { id: 1i64 };
+
+    // validate_foreign_keys_single_tuple uses unwrap_or_default()
+    // Let's ensure it doesn't fail when no constraints exist.
+    let res = manager.validate_foreign_keys_single_tuple(&mut engine, "USERS", &tuple);
+    assert!(res.is_ok());
+}

--- a/relvar-core/tests/sentry_unwrap_or_default.rs
+++ b/relvar-core/tests/sentry_unwrap_or_default.rs
@@ -1,0 +1,29 @@
+use relvar_core::constraints::{ConstraintExpression, CmpOp, ValueOrRef};
+use relvar_core::database::Database;
+use relvar_core::query::Query;
+use relvar_core::storage_engine::InMemoryEngine;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
+use relvar_core::tuple;
+
+#[test]
+fn test_query_restrict_unwrap_or_default_hides_errors() {
+    let mut db = Database::new(InMemoryEngine::new());
+    let heading = TupleType::new()
+        .with_attribute("id", ScalarType::Int)
+        .with_attribute("name", ScalarType::String);
+    db.create_relvar("USERS", RelationType::new(heading)).unwrap();
+    db.insert("USERS", tuple! { id: 1i64, name: "Alice".to_string() }).unwrap();
+    db.insert("USERS", tuple! { id: 2i64, name: "Bob".to_string() }).unwrap();
+
+    let bad_predicate = ConstraintExpression::Cmp {
+        left: "id".to_string(),
+        op: CmpOp::Eq,
+        right: ValueOrRef::Attribute("name".to_string()),
+    };
+
+    let query = Query::Scan("USERS".to_string()).restrict(bad_predicate);
+
+    let result = query.execute(&db);
+
+    assert!(result.is_err(), "Expected query execution to fail due to type mismatch in predicate, but it succeeded!");
+}


### PR DESCRIPTION
🎯 Target: `Query::execute` for `Restrict` variants in `relvar-core/src/query/mod.rs`
💣 Risk: `prepared.evaluate(tuple).unwrap_or_default()` was silently hiding type mismatch or evaluation errors by treating them as `false`, causing queries to silently fail and return empty results.
🧪 Strategy: Added a new `restrict_into_result` fallible method to `Relation` and used the `?` operator to properly bubble up `ExpressionError` as a `QueryError::Constraint`. Added a new integration test to reproduce and confirm the fix.
🔬 Verification: Run `cargo test --test sentry_unwrap_or_default -p relvar-core`

---
*PR created automatically by Jules for task [14945817255567564200](https://jules.google.com/task/14945817255567564200) started by @madmax983*