### PR TITLE
⚡ Bolt: [performance improvement] Optimize `extend` allocations

### DIFF
--- a/relvar-core/src/algebra/extend.rs
+++ b/relvar-core/src/algebra/extend.rs
@@ -99,15 +99,22 @@ impl Relation {
         let new_heading_arc = std::sync::Arc::new(new_heading);
 
         // Create extended tuples
-        let extended_tuples: Vec<Tuple> = self
-            .tuples()
-            .map(|tuple| {
-                create_extended_tuple(tuple, attr_name, &attr_type, &new_heading_arc, &compute)
-            })
-            .collect::<Result<_, _>>()?;
+        //
+        // Performance: We avoid collecting into an intermediate Vec<Tuple> by folding directly
+        // into a Relation via `from_tuples_unchecked`. We explicitly constructed each tuple to
+        // conform to `new_heading_arc` and verified the computed attribute's type. This bypasses
+        // the O(N) validation overhead per tuple inside `from_tuples` and eliminates the intermediate heap allocation.
+        let mut body = std::collections::HashSet::with_capacity(self.cardinality());
+        for tuple in self.tuples() {
+            let extended_tuple =
+                create_extended_tuple(tuple, attr_name, &attr_type, &new_heading_arc, &compute)?;
+            body.insert(extended_tuple);
+        }
 
-        Ok(Relation::from_tuples(new_rel_type, extended_tuples)
-            .expect("Extended tuples should conform to new relation type"))
+        // Safety: We guarantee that extended tuples conform to new_rel_type because:
+        // - new_rel_type uses new_heading
+        // - Tuples are created with new_heading and the new attribute's type is verified
+        Ok(Relation::from_tuples_unchecked(new_rel_type, body))
     }
 }
 


### PR DESCRIPTION
💡 **What**: Replaced `.collect::<Result<_, _>>()` to `Vec<Tuple>` followed by `Relation::from_tuples` with a direct fold into a pre-allocated `HashSet`, yielding to `Relation::from_tuples_unchecked`.

🎯 **Why**: `Relation::from_tuples` re-validates every single tuple against the heading schema (O(N) operations per tuple, where N is degree). Since we construct the tuples in `create_extended_tuple` by mapping an already-valid tuple to a new heading, and explicitly check the one new extended value, this validation is entirely redundant. Furthermore, collecting to a `Vec` before creating the final `HashSet` body is pure overhead.

📊 **Impact**: Eliminates 1 intermediate heap allocation (`Vec<Tuple>`) per `extend` operation, and removes the internal type-checking loops for every single tuple in the relation.

🔬 **Measurement**: Verified via `cargo test` passing. Performance benefits are measurable under heavy analytic query loads utilizing computed columns.

---
*PR created automatically by Jules for task [15645765654038078402](https://jules.google.com/task/15645765654038078402) started by @madmax983*