### PR TITLE
⚡ Bolt: Optimize grouping allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,7 @@
 ## 2026-03-07 - Avoiding Intermediate Allocations in Division Iterator
 **Learning:** The `filter_matching_candidates` helper in `relvar-core/src/algebra/divide.rs` originally used `.collect::<Vec<_>>()` to allocate a buffer of tuples before passing them to `Relation::from_tuples`.
 **Action:** Use `impl Iterator<Item = Tuple> + 'a` and add `move` to the `.filter` closure to return the iterator instead of allocating a `Vec`. Pass it directly into `Relation::from_tuples_unchecked` to eliminate validation overhead and allocation.
+
+## 2024-05-17 - Unnecessary Allocation during Group By
+**Learning:** Found that grouping attributes were being cloned `Vec<ScalarValue>` for use as `HashMap` keys during `group_tuples`. This resulted in `N` allocations per tuple when `N` attributes are grouped, simply to do a hash lookup.
+**Action:** Replaced `Vec<ScalarValue>` with `Vec<&ScalarValue>` to avoid cloning, which prevents `N` intermediate heap allocations and clones of variants during group by aggregations.

--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -246,6 +246,10 @@ fn build_group_result_heading(
     Ok((result_heading, rva_heading))
 }
 
+/// # Performance
+/// This function avoids intermediate heap allocations by using references
+/// `&ScalarValue` as grouping keys in the internal `HashMap`. This prevents
+/// `N` allocations and clones of `ScalarValue` variants per tuple processed.
 fn compute_grouped_tuples(
     relation: &Relation,
     grouping_attrs: &[String],
@@ -257,13 +261,13 @@ fn compute_grouped_tuples(
     let rva_heading_arc = std::sync::Arc::new(rva_heading.clone());
     let result_heading_arc = std::sync::Arc::new(result_heading.clone());
 
-    let mut groups: HashMap<Vec<ScalarValue>, Vec<Tuple>> = HashMap::new();
+    let mut groups: HashMap<Vec<&ScalarValue>, Vec<Tuple>> = HashMap::new();
 
     for tuple in relation.tuples() {
         // Extract grouping key
-        let key: Vec<ScalarValue> = grouping_attrs
+        let key: Vec<&ScalarValue> = grouping_attrs
             .iter()
-            .map(|attr| tuple.get(attr).unwrap().clone())
+            .map(|attr| tuple.get(attr).unwrap())
             .collect();
 
         // Extract grouped attributes for RVA


### PR DESCRIPTION
💡 **What**: Changed `HashMap` keys in `compute_grouped_tuples` from `Vec<ScalarValue>` to `Vec<&ScalarValue>`.
🎯 **Why**: When grouping a relation, the engine was iterating over each tuple and cloning the `ScalarValue` variants of every grouping attribute just to create a key for the `HashMap`. This caused `N` intermediate heap allocations per tuple.
📊 **Impact**: Prevents `N` (number of grouping attributes) allocations and clones per tuple processed during `group` and `summarize` operations.
🔬 **Measurement**: Run `cargo bench --bench tuple_creation` and profile the engine during large group by aggregations.

---
*PR created automatically by Jules for task [318389620254599882](https://jules.google.com/task/318389620254599882) started by @madmax983*