### PR TITLE
🔒 Warden: Fix integer overflow vulnerabilities in heap bounds checking

### DIFF
--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -517,7 +517,21 @@ impl HeapFile {
                 let offset = entry.offset as usize;
                 let length = entry.length as usize;
                 if idx < tuples.len() && !tuples[idx].is_empty() {
-                    data[offset..offset + length].copy_from_slice(&tuples[idx]);
+                    // Validate that offset + length doesn't exceed buffer
+                    let end = offset.checked_add(length).ok_or_else(|| {
+                        HeapError::Serialization(format!(
+                            "Slot {} length overflow: offset={}, length={}",
+                            idx, offset, length
+                        ))
+                    })?;
+
+                    if end > data.len() {
+                        return Err(HeapError::Serialization(format!(
+                            "Slot {} points outside buffer: offset={}, length={}, buffer_len={}",
+                            idx, offset, length, data.len()
+                        )));
+                    }
+                    data[offset..end].copy_from_slice(&tuples[idx]);
                 }
             }
         }
@@ -546,7 +560,7 @@ impl HeapFile {
 
         // Extract tuple data from page
         let start = slot_entry.offset as usize;
-        let end = start + slot_entry.length as usize;
+        let end = start.checked_add(slot_entry.length as usize).ok_or(HeapError::TupleNotFound)?;
 
         if end > page.data().len() {
             return Err(HeapError::TupleNotFound);
@@ -581,7 +595,7 @@ impl HeapFile {
 
         // Extract tuple data from page
         let start = slot_entry.offset as usize;
-        let end = start + slot_entry.length as usize;
+        let end = start.checked_add(slot_entry.length as usize).ok_or(HeapError::TupleNotFound)?;
 
         if end > page.data().len() {
             return Err(HeapError::TupleNotFound);
@@ -895,16 +909,20 @@ impl HeapFile {
                 let length = entry.length as usize;
                 if idx < tuples.len() && !tuples[idx].is_empty() {
                     // Validate that offset + length doesn't exceed buffer
-                    if offset + length > data.len() {
+                    let end = offset.checked_add(length).ok_or_else(|| {
+                        HeapError::Serialization(format!(
+                            "Slot {} length overflow: offset={}, length={}",
+                            idx, offset, length
+                        ))
+                    })?;
+
+                    if end > data.len() {
                         return Err(HeapError::Serialization(format!(
                             "Slot {} points outside buffer: offset={}, length={}, buffer_len={}",
-                            idx,
-                            offset,
-                            length,
-                            data.len()
+                            idx, offset, length, data.len()
                         )));
                     }
-                    data[offset..offset + length].copy_from_slice(&tuples[idx]);
+                    data[offset..end].copy_from_slice(&tuples[idx]);
                 }
             }
         }
@@ -1011,19 +1029,8 @@ impl HeapFile {
         offset: u32,
         length: u32,
     ) -> Result<Vec<u8>, HeapError> {
-        let start = offset as usize;
-        let end = start
-            .checked_add(length as usize)
-            .ok_or_else(|| HeapError::Serialization("Tuple end offset overflow".to_string()))?;
-
-        if end <= page.data().len() {
-            Ok(page.data()[start..end].to_vec())
-        } else {
-            Err(HeapError::Serialization(format!(
-                "Corrupted slot on page {} points outside page data",
-                page.id()
-            )))
-        }
+        let (start, end) = self.validate_slot_bounds(page, offset, length)?;
+        Ok(page.data()[start..end].to_vec())
     }
 
     /// Updates a tuple by creating a new version and marking the old version as deleted.
@@ -1305,12 +1312,12 @@ impl HeapFile {
                 if crate::mvcc::visibility::is_visible(&version_metadata, snapshot, committed) {
                     // Extract tuple data from page
                     let start = slot_entry.offset as usize;
-                    let end = start + slot_entry.length as usize;
-
-                    if end <= page.data().len() {
-                        let tuple_data = &page.data()[start..end];
-                        let tuple: Tuple = deserialize_bounded(tuple_data)?;
-                        results.push(tuple);
+                    if let Some(end) = start.checked_add(slot_entry.length as usize) {
+                        if end <= page.data().len() {
+                            let tuple_data = &page.data()[start..end];
+                            let tuple: Tuple = deserialize_bounded(tuple_data)?;
+                            results.push(tuple);
+                        }
                     }
                 }
             }

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -1322,12 +1322,12 @@ impl HeapFile {
                 if crate::mvcc::visibility::is_visible(&version_metadata, snapshot, committed) {
                     // Extract tuple data from page
                     let start = slot_entry.offset as usize;
-                    if let Some(end) = start.checked_add(slot_entry.length as usize) {
-                        if end <= page.data().len() {
-                            let tuple_data = &page.data()[start..end];
-                            let tuple: Tuple = deserialize_bounded(tuple_data)?;
-                            results.push(tuple);
-                        }
+                    if let Some(end) = start.checked_add(slot_entry.length as usize)
+                        && end <= page.data().len()
+                    {
+                        let tuple_data = &page.data()[start..end];
+                        let tuple: Tuple = deserialize_bounded(tuple_data)?;
+                        results.push(tuple);
                     }
                 }
             }

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -528,7 +528,10 @@ impl HeapFile {
                     if end > data.len() {
                         return Err(HeapError::Serialization(format!(
                             "Slot {} points outside buffer: offset={}, length={}, buffer_len={}",
-                            idx, offset, length, data.len()
+                            idx,
+                            offset,
+                            length,
+                            data.len()
                         )));
                     }
                     data[offset..end].copy_from_slice(&tuples[idx]);
@@ -560,7 +563,9 @@ impl HeapFile {
 
         // Extract tuple data from page
         let start = slot_entry.offset as usize;
-        let end = start.checked_add(slot_entry.length as usize).ok_or(HeapError::TupleNotFound)?;
+        let end = start
+            .checked_add(slot_entry.length as usize)
+            .ok_or(HeapError::TupleNotFound)?;
 
         if end > page.data().len() {
             return Err(HeapError::TupleNotFound);
@@ -595,7 +600,9 @@ impl HeapFile {
 
         // Extract tuple data from page
         let start = slot_entry.offset as usize;
-        let end = start.checked_add(slot_entry.length as usize).ok_or(HeapError::TupleNotFound)?;
+        let end = start
+            .checked_add(slot_entry.length as usize)
+            .ok_or(HeapError::TupleNotFound)?;
 
         if end > page.data().len() {
             return Err(HeapError::TupleNotFound);
@@ -919,7 +926,10 @@ impl HeapFile {
                     if end > data.len() {
                         return Err(HeapError::Serialization(format!(
                             "Slot {} points outside buffer: offset={}, length={}, buffer_len={}",
-                            idx, offset, length, data.len()
+                            idx,
+                            offset,
+                            length,
+                            data.len()
                         )));
                     }
                     data[offset..end].copy_from_slice(&tuples[idx]);


### PR DESCRIPTION
🔒 Warden: Fix integer overflow vulnerabilities in heap bounds checking

🦠 **Threat:** 
Several methods in `relvar-storage/src/storage/heap.rs` relied on unchecked math (e.g., `let end = start + length`) to determine tuple data boundaries during serialization and deserialization. A crafted/corrupted page with extremely large `offset` or `length` values could trigger integer overflow, causing the bounds check to pass incorrectly. This could lead to a Denial of Service (DoS) panic when indexing `page.data()[start..end]` or, theoretically, out-of-bounds memory reading in unsafe contexts (if introduced later).

🛡️ **Defense:** 
Replaced unsafe addition with `checked_add` for all slot boundary calculations. If an overflow is detected or the resulting `end` exceeds the buffer capacity, the method correctly returns a `HeapError::Serialization` or `HeapError::TupleNotFound` rather than blindly proceeding with slice indexing. Redundant logic in `extract_raw_tuple_data` was replaced with a centralized call to `validate_slot_bounds`.

💥 **Severity:** 
Medium/High. Unchecked math on potentially corrupted on-disk data can lead directly to server-crashing panics upon loading relations. 

🧪 **Verification:** 
Ran the full test suite and benchmark suite (`cargo test --all-targets --all-features` and `cargo bench -p relvar-storage`) to guarantee functional equivalence and rule out regressions. Verified that `clippy` raises no issues with the new idiomatic bounds-checking.

---
*PR created automatically by Jules for task [12027858801370350956](https://jules.google.com/task/12027858801370350956) started by @madmax983*