### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -55,3 +55,7 @@ This ensures the map matches the territory.
 ## 2024-05-30 - Ghost "Returns the x" and "Gets the x" Docs Fixed
 **Confusion:** Some public functions (e.g. `lsn.rs`, `record.rs`, `manager.rs` and other areas) had auto-generated boilerplate `/// Returns the...` and `/// Gets the...` comments, acting as "noise".
 **Clarification:** I identified the remaining unhelpful documentation across the workspace and updated them with precise verbs and context, explaining what information is retrieved or processed, fully eradicating this boilerplate pattern.
+
+## 2024-06-03 - Cargo Doc Warnings Fixed
+**Confusion:** Rustdoc was emitting warnings because of redundant explicit link targets and an empty rust code block.
+**Clarification:** I updated `relvar-core/src/query/mod.rs` to remove redundant explicit links, letting rustdoc infer the link from the label name (`[`Database`]`). In `relvar-core/src/utils/recursion.rs`, I added the `text` modifier to a non-rust code block (conceptual example) so that it isn't parsed as valid Rust.

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides a serializable AST ([`Query`]) and a fluent builder API
 //! for constructing relational algebra queries. It allows queries to be
 //! defined data-driven (e.g., from JSON), optimized, inspected ([`Query::explain`]),
-//! and executed against a [`Database`](crate::database::Database).
+//! and executed against a [`Database`].
 //!
 //! # Example
 //!

--- a/relvar-core/src/utils/recursion.rs
+++ b/relvar-core/src/utils/recursion.rs
@@ -44,7 +44,7 @@ impl RecursionGuard {
     /// Returns an error if the current thread's recursion depth exceeds `MAX_RECURSION_DEPTH`.
     ///
     /// # Examples
-    /// ```
+    /// ```text
     /// // RecursionGuard is for internal use, but here is how it works conceptually:
     /// // let guard = RecursionGuard::new().expect("Should succeed at top level");
     /// // The guard automatically decrements the depth when it is dropped.


### PR DESCRIPTION
📖 Chapter
Fixed `cargo doc` warnings in `relvar-core/src/query/mod.rs` and `relvar-core/src/utils/recursion.rs`.

🔦 Insight
Rustdoc emits warnings for redundant explicit links (where the link label is the same as the target) and for empty code blocks that are parsed as Rust code. I removed a redundant explicit link `[`Database`](crate::database::Database)` -> `[`Database`]` and added the `text` modifier to a conceptual code block to resolve these warnings. 

🧪 Example
No new examples added, but the existing conceptual example in `utils/recursion.rs` now properly uses ````text` to avoid being parsed as Rust code.

🖼️ Preview
No visual preview applicable, but running `cargo doc --no-deps` now results in zero warnings.

---
*PR created automatically by Jules for task [10159069281161487077](https://jules.google.com/task/10159069281161487077) started by @madmax983*