### PR TITLE
🔒 Warden: Fix WAL Manager Allocation Bomb DoS

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -187,3 +187,12 @@ The `postcard` dependency (version 1.1.3) enabled the `heapless-cas` and `heaple
 
 **Defense:**
 Modified `Cargo.toml` to disable the default features of `postcard` by specifying `default-features = false`, explicitly only retaining the required `alloc` and `use-std` features. This eliminates the `heapless` and `atomic-polyfill` dependencies entirely, mitigating the risk of relying on an unmaintained crate.
+
+## 2026-03-05 - WAL Manager Allocation Bomb DoS
+**Threat:**
+The WAL manager in `relvar-storage/src/wal/manager.rs` used `std::io::Read::read_to_end` to read the entire Write-Ahead Log into memory when recovering or scanning for the last LSN (`scan_for_last_lsn` and `recover`). An attacker could cause a Denial of Service (DoS) via an Allocation Bomb (OOM) by providing a massive, unbounded WAL file (e.g. 10GB+). `read_to_end` would blindly attempt to allocate enough memory to load the entire file, potentially crashing the application or the system.
+
+**Defense:**
+1. Added `MAX_WAL_SIZE` constant (2GB) to `relvar-storage/src/wal/manager.rs`.
+2. Modified `recover` and `scan_for_last_lsn` to read the file length from `metadata()` before attempting to allocate a buffer or read the file.
+3. If the length exceeds `MAX_WAL_SIZE`, it returns an explicit `WalError::Io` error (`std::io::ErrorKind::FileTooLarge`) instead of silently truncating (which causes data loss) or allowing unbounded memory allocation.

--- a/relvar-storage/src/wal/manager.rs
+++ b/relvar-storage/src/wal/manager.rs
@@ -16,6 +16,9 @@ use std::path::Path;
 /// This allows batching many small records before flushing to disk.
 pub const DEFAULT_BUFFER_SIZE: usize = 1024 * 1024;
 
+/// Maximum WAL file size to read into memory (2GB) to prevent Allocation Bomb DoS attacks.
+pub const MAX_WAL_SIZE: u64 = 2 * 1024 * 1024 * 1024;
+
 /// Header written at the start of each WAL file.
 ///
 /// Used for basic validation and version checking during recovery.
@@ -224,15 +227,27 @@ impl WalManager {
         // Flush any buffered records first
         self.flush()?;
 
+        let file_len = self.log_file.metadata()?.len();
+        if file_len > MAX_WAL_SIZE {
+            return Err(WalError::Io(std::io::Error::new(
+                std::io::ErrorKind::FileTooLarge,
+                format!(
+                    "WAL file size ({} bytes) exceeds safety limit ({} bytes) to prevent OOM DoS",
+                    file_len, MAX_WAL_SIZE
+                ),
+            )));
+        }
+
         // Seek to start of records (after magic header)
         self.log_file
             .seek(SeekFrom::Start(WAL_MAGIC.len() as u64))?;
 
         let mut records = Vec::new();
-        let mut buffer = Vec::new();
+        let mut buffer =
+            Vec::with_capacity(file_len.saturating_sub(WAL_MAGIC.len() as u64) as usize);
 
-        // Read entire file into buffer
-        self.log_file.read_to_end(&mut buffer)?;
+        // Read up to MAX_WAL_SIZE into buffer to prevent Allocation Bomb DoS
+        std::io::Read::take(&mut self.log_file, MAX_WAL_SIZE).read_to_end(&mut buffer)?;
 
         let mut offset = 0;
         while offset < buffer.len() {
@@ -294,11 +309,24 @@ impl WalManager {
     fn scan_for_last_lsn(log_file: &mut File) -> Result<(Lsn, Lsn), WalError> {
         use std::io::Read;
 
+        let file_len = log_file.metadata()?.len();
+        if file_len > MAX_WAL_SIZE {
+            return Err(WalError::Io(std::io::Error::new(
+                std::io::ErrorKind::FileTooLarge,
+                format!(
+                    "WAL file size ({} bytes) exceeds safety limit ({} bytes) to prevent OOM DoS",
+                    file_len, MAX_WAL_SIZE
+                ),
+            )));
+        }
+
         // Seek to start of records (after magic header)
         log_file.seek(SeekFrom::Start(WAL_MAGIC.len() as u64))?;
 
-        let mut buffer = Vec::new();
-        log_file.read_to_end(&mut buffer)?;
+        let mut buffer =
+            Vec::with_capacity(file_len.saturating_sub(WAL_MAGIC.len() as u64) as usize);
+        // Read up to MAX_WAL_SIZE into buffer to prevent Allocation Bomb DoS
+        std::io::Read::take(&mut *log_file, MAX_WAL_SIZE).read_to_end(&mut buffer)?;
 
         let mut last_lsn = Lsn::new(0);
         let mut offset = 0;

--- a/relvar-storage/src/wal/mod.rs
+++ b/relvar-storage/src/wal/mod.rs
@@ -53,6 +53,6 @@ pub(crate) mod recovery;
 
 pub(crate) use error::WalError;
 pub use lsn::{Lsn, TransactionId, TransactionIdGenerator};
-pub(crate) use manager::{DEFAULT_BUFFER_SIZE, WalManager};
+pub(crate) use manager::{DEFAULT_BUFFER_SIZE, MAX_WAL_SIZE, WalManager};
 pub(crate) use record::{MAX_RECORD_SIZE, WalRecord, WalRecordError};
 pub(crate) use recovery::{AnalysisResult, UncommittedInsert, recover};

--- a/relvar-storage/tests/warden_wal_allocation.rs
+++ b/relvar-storage/tests/warden_wal_allocation.rs
@@ -1,0 +1,51 @@
+// Warden Integration Test for WAL Allocation Bomb DoS
+// This validates that our mitigation prevents unbounded allocation.
+// Since WalManager is internal, we trigger it through PersistentEngine.
+
+use relvar_storage::PersistentEngine;
+use std::fs::OpenOptions;
+use tempfile::TempDir;
+
+#[test]
+fn test_wal_allocation_bomb_prevention_explicit_error() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path();
+    let wal_path = db_path.join("wal.log");
+
+    // Initialize an empty database
+    let engine = PersistentEngine::open(db_path).unwrap();
+    drop(engine); // Closes DB
+
+    // The WAL file (wal.log) should now exist. We maliciously increase its size using sparse files.
+    // 2GB + 1024 bytes
+    let max_wal_size: u64 = 2 * 1024 * 1024 * 1024;
+    let file = OpenOptions::new().write(true).open(&wal_path).unwrap();
+
+    // Set file length without allocating real disk space (sparse file)
+    file.set_len(max_wal_size + 1024).unwrap();
+    drop(file);
+
+    // Re-opening the engine triggers recovery, which should hit the `take(MAX_WAL_SIZE)` limit
+    // and fail explicitly with an Io error for FileTooLarge, rather than an OOM crash.
+    let result = PersistentEngine::open(db_path);
+
+    match result {
+        Err(e) => {
+            let msg = e.to_string();
+            // Assert we got the specific error message added in our defense
+            assert!(
+                msg.contains("WAL file size"),
+                "Expected WAL size error, got: {}",
+                msg
+            );
+            assert!(
+                msg.contains("exceeds safety limit"),
+                "Expected safety limit text in error"
+            );
+            assert!(msg.contains("OOM DoS"), "Expected OOM DoS mention in error");
+        }
+        Ok(_) => {
+            panic!("Engine unexpectedly opened successfully despite massive corrupted WAL file!")
+        }
+    }
+}


### PR DESCRIPTION
🦠 **Threat:**
The WAL manager in `relvar-storage` used `std::io::Read::read_to_end` without checking the file size when opening a database to recover the WAL. An attacker could exploit this by supplying a massive (e.g., 10GB+) corrupted `data.wal` file. Since `read_to_end` blindly attempts to allocate memory to load the entire file, this would lead to memory exhaustion and crash the application (OOM DoS). 

🛡️ **Defense:**
1. Introduced a `MAX_WAL_SIZE` limit (2GB) in `relvar-storage/src/wal/manager.rs`.
2. Modified `recover` and `scan_for_last_lsn` to check the `log_file.metadata()?.len()` before attempting to allocate a buffer or read data.
3. If the file size exceeds the limit, it immediately returns a structured `WalError::Io` error with `std::io::ErrorKind::FileTooLarge` and a descriptive message. This prevents unbounded allocation while ensuring we don't silently truncate data (which would lead to data loss/corruption).
4. Pre-allocated the vector (`Vec::with_capacity`) using the bounded file size to prevent continuous reallocation overhead during reads.

💥 **Severity:**
**High**. A local attacker or anyone capable of dropping a large dummy file could crash the database process deterministically upon startup.

🧪 **Verification:**
- Ran `cargo audit` (no new issues).
- Wrote an integration test `test_wal_allocation_bomb_prevention_explicit_error` in `relvar-storage/tests/warden_wal_allocation.rs`. This test generates a massive sparse file using `file.set_len(2GB + 1024)` and verifies that `PersistentEngine::open` correctly returns the targeted safety limit IO error instead of attempting an unbounded read or silent truncation.
- Verified zero warnings in `cargo clippy`.
- Verified all tests pass.
- Logged the findings in `.jules/warden.md`.

---
*PR created automatically by Jules for task [2195861972216872324](https://jules.google.com/task/2195861972216872324) started by @madmax983*