### PR TITLE
🪒 Razor: Remove single-implementation `Pivot` trait

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,7 @@
 **Bloat:** `QueryExecutor` trait. It is a "One-Time Trait" implemented only by `Database`, adding unnecessary abstraction and indirection for speculative "Future Proofing".
 **Cut:** Removing `QueryExecutor` trait and updating `Query::execute` and virtual relvars to depend directly on `Database`.
 **Saved:** Removed `traits.rs`, removed ~20 lines of code, reduced cognitive load by removing an unnecessary abstraction layer.
+## [Reduction]
+**Bloat:** The `Pivot` trait in `relvar/src/experimental/pivot.rs` was a single-implementation trait applied only to `Relation`.
+**Cut:** Removed the `Pivot` trait and its `impl` block, converting it into a concrete, standalone function `pub fn pivot(relation: &Relation, ...)`.
+**Saved:** Reduced boilerplate, flattened abstraction, simplified method resolution, and removed a "One-Time Trait."

--- a/relvar/src/experimental/pivot.rs
+++ b/relvar/src/experimental/pivot.rs
@@ -37,169 +37,159 @@ use relvar_core::values::{Relation, ScalarValue, Tuple};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Trait extending Relation with pivot capabilities.
-pub trait Pivot {
-    /// Pivots a relation.
-    ///
-    /// Transforms unique values from the `on_attr` column into new column headers,
-    /// filling the cells with values from the `value_attr` column. All other attributes
-    /// become grouping keys.
-    ///
-    /// # Arguments
-    ///
-    /// * `on_attr` - The attribute whose values will become new column headers.
-    /// * `value_attr` - The attribute whose values will populate the cells.
-    /// * `default_value` - The value to use when a cell is missing (e.g., `0` or `false`).
-    ///   Must match the type of `value_attr`.
-    ///
-    /// # Conflict Resolution
-    ///
-    /// If multiple source tuples map to the same target cell (i.e., they have the same
-    /// grouping attributes and the same `on_attr` value), the **Last Write Wins** strategy
-    /// is applied. The source tuples are sorted, and the value from the last tuple is used.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar_core::types::{TupleType, RelationType, ScalarType};
-    /// use relvar_core::values::{Relation, ScalarValue};
-    /// use relvar_core::tuple;
-    /// use relvar::experimental::pivot::Pivot;
-    ///
-    /// // Create a relation: (Item, Color, Count)
-    /// let heading = TupleType::new()
-    ///     .with_attribute("Item", ScalarType::String)
-    ///     .with_attribute("Color", ScalarType::String)
-    ///     .with_attribute("Count", ScalarType::Int);
-    /// let mut relation = Relation::new(RelationType::new(heading));
-    ///
-    /// relation.insert(tuple! { Item: "Shirt", Color: "Red", Count: 10 }).unwrap();
-    /// relation.insert(tuple! { Item: "Shirt", Color: "Blue", Count: 5 }).unwrap();
-    /// relation.insert(tuple! { Item: "Pants", Color: "Blue", Count: 20 }).unwrap();
-    ///
-    /// // Pivot on 'Color', using 'Count' as values, default to 0
-    /// let pivoted = relation.pivot("Color", "Count", ScalarValue::Int(0)).unwrap();
-    ///
-    /// // Result: (Item, Red, Blue)
-    /// // Shirt: Red=10, Blue=5
-    /// // Pants: Red=0 (default), Blue=20
-    /// ```
-    fn pivot(
-        &self,
-        on_attr: &str,
-        value_attr: &str,
-        default_value: ScalarValue,
-    ) -> Result<Relation, DatabaseError>;
-}
+/// Pivots a relation.
+///
+/// Transforms unique values from the `on_attr` column into new column headers,
+/// filling the cells with values from the `value_attr` column. All other attributes
+/// become grouping keys.
+///
+/// # Arguments
+///
+/// * `relation` - The relation to pivot.
+/// * `on_attr` - The attribute whose values will become new column headers.
+/// * `value_attr` - The attribute whose values will populate the cells.
+/// * `default_value` - The value to use when a cell is missing (e.g., `0` or `false`).
+///   Must match the type of `value_attr`.
+///
+/// # Conflict Resolution
+///
+/// If multiple source tuples map to the same target cell (i.e., they have the same
+/// grouping attributes and the same `on_attr` value), the **Last Write Wins** strategy
+/// is applied. The source tuples are sorted, and the value from the last tuple is used.
+///
+/// # Examples
+///
+/// ```
+/// use relvar_core::types::{TupleType, RelationType, ScalarType};
+/// use relvar_core::values::{Relation, ScalarValue};
+/// use relvar_core::tuple;
+/// use relvar::experimental::pivot::pivot;
+///
+/// // Create a relation: (Item, Color, Count)
+/// let heading = TupleType::new()
+///     .with_attribute("Item", ScalarType::String)
+///     .with_attribute("Color", ScalarType::String)
+///     .with_attribute("Count", ScalarType::Int);
+/// let mut relation = Relation::new(RelationType::new(heading));
+///
+/// relation.insert(tuple! { Item: "Shirt", Color: "Red", Count: 10 }).unwrap();
+/// relation.insert(tuple! { Item: "Shirt", Color: "Blue", Count: 5 }).unwrap();
+/// relation.insert(tuple! { Item: "Pants", Color: "Blue", Count: 20 }).unwrap();
+///
+/// // Pivot on 'Color', using 'Count' as values, default to 0
+/// let pivoted = pivot(&relation, "Color", "Count", ScalarValue::Int(0)).unwrap();
+///
+/// // Result: (Item, Red, Blue)
+/// // Shirt: Red=10, Blue=5
+/// // Pants: Red=0 (default), Blue=20
+/// ```
+pub fn pivot(
+    relation: &Relation,
+    on_attr: &str,
+    value_attr: &str,
+    default_value: ScalarValue,
+) -> Result<Relation, DatabaseError> {
+    let heading = relation.relation_type().heading();
 
-impl Pivot for Relation {
-    fn pivot(
-        &self,
-        on_attr: &str,
-        value_attr: &str,
-        default_value: ScalarValue,
-    ) -> Result<Relation, DatabaseError> {
-        let heading = self.relation_type().heading();
+    if !heading.has_attribute(on_attr) {
+        return Err(DatabaseError::AttributeNotFound(
+            on_attr.to_string(),
+            "relation".to_string(),
+        ));
+    }
+    if !heading.has_attribute(value_attr) {
+        return Err(DatabaseError::AttributeNotFound(
+            value_attr.to_string(),
+            "relation".to_string(),
+        ));
+    }
 
-        if !heading.has_attribute(on_attr) {
-            return Err(DatabaseError::AttributeNotFound(
-                on_attr.to_string(),
-                "relation".to_string(),
-            ));
-        }
-        if !heading.has_attribute(value_attr) {
-            return Err(DatabaseError::AttributeNotFound(
-                value_attr.to_string(),
-                "relation".to_string(),
-            ));
-        }
+    let group_attrs: Vec<String> = heading
+        .attribute_names()
+        .filter(|&name| name != on_attr && name != value_attr)
+        .cloned()
+        .collect();
 
-        let group_attrs: Vec<String> = heading
-            .attribute_names()
-            .filter(|&name| name != on_attr && name != value_attr)
-            .cloned()
-            .collect();
+    // Scan for new columns
+    let mut new_columns = BTreeSet::new();
+    for tuple in relation.tuples() {
+        let val = tuple.get(on_attr).unwrap();
+        let col_name = scalar_to_string_key(val)?;
+        new_columns.insert(col_name);
+    }
 
-        // Scan for new columns
-        let mut new_columns = BTreeSet::new();
-        for tuple in self.tuples() {
-            let val = tuple.get(on_attr).unwrap();
-            let col_name = scalar_to_string_key(val)?;
-            new_columns.insert(col_name);
-        }
-
-        // Check collisions
-        for col in &new_columns {
-            if group_attrs.contains(col) {
-                return Err(DatabaseError::DuplicateAttributeName(format!(
-                    "Pivoted column '{}' conflicts with grouping attribute",
-                    col
-                )));
-            }
-        }
-
-        // Construct new heading
-        let mut new_heading = TupleType::new();
-        for attr in &group_attrs {
-            let ty = heading.get_attribute_type(attr).unwrap();
-            new_heading = new_heading.with_attribute(attr, ty.clone());
-        }
-
-        let value_type = heading.get_attribute_type(value_attr).unwrap();
-        if !default_value.is_type(value_type) {
-            return Err(DatabaseError::AlgebraError(format!(
-                "Default value type ({:?}) mismatch with value attribute ({:?})",
-                default_value.scalar_type(),
-                value_type
+    // Check collisions
+    for col in &new_columns {
+        if group_attrs.contains(col) {
+            return Err(DatabaseError::DuplicateAttributeName(format!(
+                "Pivoted column '{}' conflicts with grouping attribute",
+                col
             )));
         }
-
-        for col in &new_columns {
-            new_heading = new_heading.with_attribute(col, value_type.clone());
-        }
-
-        let new_rel_type = RelationType::new(new_heading);
-        let mut result_relation = Relation::new(new_rel_type.clone());
-
-        // Group data
-        let mut groups: BTreeMap<Vec<ScalarValue>, BTreeMap<String, ScalarValue>> = BTreeMap::new();
-
-        // Sort tuples for deterministic Last Write Wins
-        let mut sorted_tuples: Vec<&Tuple> = self.tuples().collect();
-        sorted_tuples.sort_by(|a, b| a.values().cmp(b.values()));
-
-        for tuple in sorted_tuples {
-            let mut group_key = Vec::with_capacity(group_attrs.len());
-            for attr in &group_attrs {
-                group_key.push(tuple.get(attr).unwrap().clone());
-            }
-
-            let pivot_val = tuple.get(on_attr).unwrap();
-            let col_name = scalar_to_string_key(pivot_val)?;
-            let cell_val = tuple.get(value_attr).unwrap().clone();
-
-            groups
-                .entry(group_key)
-                .or_default()
-                .insert(col_name, cell_val);
-        }
-
-        // Build result tuples
-        for (group_key, cell_map) in groups {
-            let mut tuple_values = BTreeMap::new();
-            for (i, attr) in group_attrs.iter().enumerate() {
-                tuple_values.insert(attr.clone(), group_key[i].clone());
-            }
-            for col in &new_columns {
-                let val = cell_map.get(col).unwrap_or(&default_value).clone();
-                tuple_values.insert(col.clone(), val);
-            }
-            let tuple = Tuple::new(new_rel_type.heading().clone(), tuple_values)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-            result_relation.insert(tuple)?;
-        }
-
-        Ok(result_relation)
     }
+
+    // Construct new heading
+    let mut new_heading = TupleType::new();
+    for attr in &group_attrs {
+        let ty = heading.get_attribute_type(attr).unwrap();
+        new_heading = new_heading.with_attribute(attr, ty.clone());
+    }
+
+    let value_type = heading.get_attribute_type(value_attr).unwrap();
+    if !default_value.is_type(value_type) {
+        return Err(DatabaseError::AlgebraError(format!(
+            "Default value type ({:?}) mismatch with value attribute ({:?})",
+            default_value.scalar_type(),
+            value_type
+        )));
+    }
+
+    for col in &new_columns {
+        new_heading = new_heading.with_attribute(col, value_type.clone());
+    }
+
+    let new_rel_type = RelationType::new(new_heading);
+    let mut result_relation = Relation::new(new_rel_type.clone());
+
+    // Group data
+    let mut groups: BTreeMap<Vec<ScalarValue>, BTreeMap<String, ScalarValue>> = BTreeMap::new();
+
+    // Sort tuples for deterministic Last Write Wins
+    let mut sorted_tuples: Vec<&Tuple> = relation.tuples().collect();
+    sorted_tuples.sort_by(|a, b| a.values().cmp(b.values()));
+
+    for tuple in sorted_tuples {
+        let mut group_key = Vec::with_capacity(group_attrs.len());
+        for attr in &group_attrs {
+            group_key.push(tuple.get(attr).unwrap().clone());
+        }
+
+        let pivot_val = tuple.get(on_attr).unwrap();
+        let col_name = scalar_to_string_key(pivot_val)?;
+        let cell_val = tuple.get(value_attr).unwrap().clone();
+
+        groups
+            .entry(group_key)
+            .or_default()
+            .insert(col_name, cell_val);
+    }
+
+    // Build result tuples
+    for (group_key, cell_map) in groups {
+        let mut tuple_values = BTreeMap::new();
+        for (i, attr) in group_attrs.iter().enumerate() {
+            tuple_values.insert(attr.clone(), group_key[i].clone());
+        }
+        for col in &new_columns {
+            let val = cell_map.get(col).unwrap_or(&default_value).clone();
+            tuple_values.insert(col.clone(), val);
+        }
+        let tuple = Tuple::new(new_rel_type.heading().clone(), tuple_values)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+        result_relation.insert(tuple)?;
+    }
+
+    Ok(result_relation)
 }
 
 fn scalar_to_string_key(val: &ScalarValue) -> Result<String, DatabaseError> {
@@ -232,7 +222,7 @@ mod tests {
         r.insert(tuple! { A: "X", M: "Feb", V: 20 }).unwrap();
         r.insert(tuple! { A: "Y", M: "Jan", V: 30 }).unwrap();
 
-        let p = r.pivot("M", "V", ScalarValue::Int(0)).unwrap();
+        let p = pivot(&r, "M", "V", ScalarValue::Int(0)).unwrap();
 
         // Expected: A, Jan, Feb
         assert_eq!(p.cardinality(), 2);
@@ -264,7 +254,7 @@ mod tests {
         r.insert(tuple! { K: "K1", P: "P1", V: 10 }).unwrap();
         r.insert(tuple! { K: "K1", P: "P1", V: 20 }).unwrap();
 
-        let p = r.pivot("P", "V", ScalarValue::Int(0)).unwrap();
+        let p = pivot(&r, "P", "V", ScalarValue::Int(0)).unwrap();
         assert_eq!(p.cardinality(), 1);
         let t = p.tuples().next().unwrap();
         assert_eq!(t.get("P1"), Some(&ScalarValue::Int(20)));
@@ -283,15 +273,15 @@ mod tests {
             .unwrap();
 
         // Missing on_attr
-        let err = r.pivot("Missing", "V", ScalarValue::Int(0)).unwrap_err();
+        let err = pivot(&r, "Missing", "V", ScalarValue::Int(0)).unwrap_err();
         assert!(matches!(err, DatabaseError::AttributeNotFound(..)));
 
         // Missing value_attr
-        let err = r.pivot("M", "Missing", ScalarValue::Int(0)).unwrap_err();
+        let err = pivot(&r, "M", "Missing", ScalarValue::Int(0)).unwrap_err();
         assert!(matches!(err, DatabaseError::AttributeNotFound(..)));
 
         // Conflicting column name
-        let err = r.pivot("M", "V", ScalarValue::Int(0)).unwrap_err();
+        let err = pivot(&r, "M", "V", ScalarValue::Int(0)).unwrap_err();
         assert!(matches!(err, DatabaseError::DuplicateAttributeName(..)));
 
         // Type mismatch for default value
@@ -302,9 +292,7 @@ mod tests {
         let mut r2 = Relation::new(RelationType::new(heading2));
         r2.insert(tuple! { A: "X", M: "Jan", V: 10 }).unwrap();
 
-        let err = r2
-            .pivot("M", "V", ScalarValue::String("0".to_string()))
-            .unwrap_err();
+        let err = pivot(&r2, "M", "V", ScalarValue::String("0".to_string())).unwrap_err();
         assert!(matches!(err, DatabaseError::AlgebraError(..)));
 
         // Unsupported type for pivot key
@@ -314,7 +302,7 @@ mod tests {
             .with_attribute("V", ScalarType::Int);
         let mut r3 = Relation::new(RelationType::new(heading3));
         r3.insert(tuple! { A: "X", M: 1.0, V: 10 }).unwrap();
-        let err = r3.pivot("M", "V", ScalarValue::Int(0)).unwrap_err();
+        let err = pivot(&r3, "M", "V", ScalarValue::Int(0)).unwrap_err();
         assert!(matches!(err, DatabaseError::AlgebraError(..)));
     }
 }


### PR DESCRIPTION
## [Reduction] 
**Bloat:** The `Pivot` trait in `relvar/src/experimental/pivot.rs` was a single-implementation trait applied only to `Relation`.
**Cut:** Removed the `Pivot` trait and its `impl` block, converting it into a concrete, standalone function `pub fn pivot(relation: &Relation, ...)`.
**Saved:** Reduced boilerplate, flattened abstraction, simplified method resolution, and removed a "One-Time Trait."

---
*PR created automatically by Jules for task [1906307437991926788](https://jules.google.com/task/1906307437991926788) started by @madmax983*