### PR TITLE
⚡ Bolt: [performance improvement] Optimize extend array allocation and validation overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,7 @@
 Without pre-allocating the vector for `extended_tuples` with `with_capacity()`, the underlying vector will repeatedly reallocate as tuples are computed and pushed onto it, which is especially noticeable for large relations.
 
 **Action:** When implementing operations like `extend` or `project` that have a 1:1 input-to-output tuple mapping or have a known upper bound, use an iterator with a `size_hint` or explicitly allocate `Vec::with_capacity(self.cardinality())` before iterating, or verify that the returned iterator properly implements `size_hint` so that `collect()` can optimize the allocation.
+
+## 2026-03-08 - Tuple Pre-allocation and Validation bypass in Extend
+**Learning:** The `extend` operator previously allocated a `Vec` for intermediate tuple storage and then used `Relation::from_tuples` which reallocated into a `HashSet` and performed O(N*M) validation against the heading for every tuple, despite the tuples already being valid by construction.
+**Action:** Iterate directly into a pre-allocated `HashSet::with_capacity(self.cardinality())` to avoid the intermediate `Vec` allocation, and use `Relation::from_tuples_unchecked` to safely bypass redundant validation overhead when tuples are known to conform to the new heading.

--- a/relvar-core/src/algebra/extend.rs
+++ b/relvar-core/src/algebra/extend.rs
@@ -102,11 +102,13 @@ impl Relation {
         //
         // # Performance
         // We know exactly how many tuples will be produced because `extend` computes
-        // exactly one new tuple for each input tuple. Pre-allocating the vector
+        // exactly one new tuple for each input tuple. Pre-allocating the HashSet
         // avoids dynamic heap reallocations when collecting the results.
-        let mut extended_tuples = Vec::with_capacity(self.cardinality());
+        // We iterate directly into a pre-sized HashSet and construct the relation
+        // using `from_tuples_unchecked` to safely bypass redundant O(N) validation overhead.
+        let mut extended_tuples = std::collections::HashSet::with_capacity(self.cardinality());
         for tuple in self.tuples() {
-            extended_tuples.push(create_extended_tuple(
+            extended_tuples.insert(create_extended_tuple(
                 tuple,
                 attr_name,
                 &attr_type,
@@ -115,8 +117,15 @@ impl Relation {
             )?);
         }
 
-        Ok(Relation::from_tuples(new_rel_type, extended_tuples)
-            .expect("Extended tuples should conform to new relation type"))
+        // Safety:
+        // We guarantee that extended_tuples conform to new_rel_type because:
+        // - new_rel_type uses new_heading
+        // - Tuples are created with new_heading in create_extended_tuple
+        // - create_extended_tuple ensures the computed value type matches
+        Ok(Relation::from_tuples_unchecked(
+            new_rel_type,
+            extended_tuples,
+        ))
     }
 }
 


### PR DESCRIPTION
💡 What: Eliminated the intermediate `Vec` allocation and bypassing the `O(N*M)` validation bottleneck in `Relation::extend` by directly inserting tuples into a pre-sized `HashSet` and utilizing `Relation::from_tuples_unchecked`.

🎯 Why: In relational algebra operations like `extend`, we compute exactly one new tuple for each input tuple. Collecting these results into a `Vec`, only to pass it to `Relation::from_tuples`, resulted in double heap-allocations and a heavy validation step iterating through every attribute of every tuple. Since `create_extended_tuple` properly validates the new values dynamically, the resulting tuples are guaranteed by construction to conform to the heading. 

📊 Impact: Reduces intermediate collection heap allocations by 100% and completely drops validation overhead from `O(N*M)` to `O(1)`, noticeably optimizing bulk operations when chaining long algebraic sequences.

🔭 Measurement: Run unit tests and benchmark `extend` operator.

---
*PR created automatically by Jules for task [15150116143860356450](https://jules.google.com/task/15150116143860356450) started by @madmax983*