### PR TITLE
⚒️ Forge: Remove Pivot trait bloat

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,8 @@
 **Bloat:** `QueryExecutor` trait. It is a "One-Time Trait" implemented only by `Database`, adding unnecessary abstraction and indirection for speculative "Future Proofing".
 **Cut:** Removing `QueryExecutor` trait and updating `Query::execute` and virtual relvars to depend directly on `Database`.
 **Saved:** Removed `traits.rs`, removed ~20 lines of code, reduced cognitive load by removing an unnecessary abstraction layer.
+
+## [Reduction]
+**Bloat:** `Pivot` trait. It was a "One-Time Trait" implemented only by `Relation`, adding unnecessary abstraction.
+**Cut:** Removed `Pivot` trait and updated `pivot` to be a standalone function.
+**Saved:** Removed the trait abstraction, simplified API usage slightly.

--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,8 +12,3 @@
 **Bloat:** `QueryExecutor` trait. It is a "One-Time Trait" implemented only by `Database`, adding unnecessary abstraction and indirection for speculative "Future Proofing".
 **Cut:** Removing `QueryExecutor` trait and updating `Query::execute` and virtual relvars to depend directly on `Database`.
 **Saved:** Removed `traits.rs`, removed ~20 lines of code, reduced cognitive load by removing an unnecessary abstraction layer.
-
-## [Reduction]
-**Bloat:** `Pivot` trait. It was a "One-Time Trait" implemented only by `Relation`, adding unnecessary abstraction.
-**Cut:** Removed `Pivot` trait and updated `pivot` to be a standalone function.
-**Saved:** Removed the trait abstraction, simplified API usage slightly.

--- a/relvar/src/experimental/automl.rs
+++ b/relvar/src/experimental/automl.rs
@@ -301,4 +301,47 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_train_error_handling() -> Result<(), DatabaseError> {
+        let mut db = Database::new(InMemoryEngine::new());
+        let heading = TupleType::new()
+            .with_attribute("outlook", ScalarType::String)
+            .with_attribute("play", ScalarType::String);
+        db.create_relvar("GOLF", RelationType::new(heading))?;
+        db.insert("GOLF", tuple! { outlook: "sunny", play: "no" })?;
+
+        let golf = db.query("GOLF")?;
+
+        let err = NaiveBayesClassifier::train(&golf, "missing_target");
+        assert!(matches!(err, Err(DatabaseError::AttributeNotFound(..))));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_predict_unseen_values() -> Result<(), DatabaseError> {
+        let mut db = Database::new(InMemoryEngine::new());
+        let heading = TupleType::new()
+            .with_attribute("f1", ScalarType::Int)
+            .with_attribute("f2", ScalarType::Float)
+            .with_attribute("f3", ScalarType::Bool)
+            .with_attribute("target", ScalarType::String);
+        db.create_relvar("DATA", RelationType::new(heading))?;
+        db.insert("DATA", tuple! { f1: 1, f2: 1.0, f3: true, target: "A" })?;
+        db.insert("DATA", tuple! { f1: 2, f2: 2.0, f3: false, target: "B" })?;
+
+        let data = db.query("DATA")?;
+        let model = NaiveBayesClassifier::train(&data, "target")?;
+
+        // Prediction with completely unseen values
+        let t = tuple! { f1: 99, f2: 99.0, f3: true };
+        let p = model.predict(&t);
+        // Should still predict something without panicking
+        assert!(
+            p == ScalarValue::String("A".to_string()) || p == ScalarValue::String("B".to_string())
+        );
+
+        Ok(())
+    }
 }

--- a/relvar/src/experimental/mock.rs
+++ b/relvar/src/experimental/mock.rs
@@ -174,6 +174,33 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_all_types() {
+        let nested_rel_type =
+            RelationType::new(TupleType::new().with_attribute("inner", ScalarType::Int));
+
+        let user_defined_type = ScalarType::UserDefined {
+            name: "MyType".to_string(),
+            representation: Box::new(ScalarType::Int),
+        };
+
+        let rel_type = RelationType::new(
+            TupleType::new()
+                .with_attribute("int_val", ScalarType::Int)
+                .with_attribute("float_val", ScalarType::Float)
+                .with_attribute("str_val", ScalarType::String)
+                .with_attribute("bool_val", ScalarType::Bool)
+                .with_attribute("bytes_val", ScalarType::Bytes)
+                .with_attribute("rel_val", ScalarType::Relation(Box::new(nested_rel_type)))
+                .with_attribute("user_val", user_defined_type),
+        );
+
+        let relation = MockRelation::new(rel_type).count(10).seed(42).generate();
+
+        assert_eq!(relation.degree(), 7);
+        assert_eq!(relation.cardinality(), 10);
+    }
+
+    #[test]
     fn test_determinism() {
         let rel_type = RelationType::new(TupleType::new().with_attribute("val", ScalarType::Float));
 

--- a/relvar/src/experimental/pivot.rs
+++ b/relvar/src/experimental/pivot.rs
@@ -36,170 +36,159 @@ use relvar_core::types::{RelationType, TupleType};
 use relvar_core::values::{Relation, ScalarValue, Tuple};
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Trait extending Relation with pivot capabilities.
-pub trait Pivot {
-    /// Pivots a relation.
-    ///
-    /// Transforms unique values from the `on_attr` column into new column headers,
-    /// filling the cells with values from the `value_attr` column. All other attributes
-    /// become grouping keys.
-    ///
-    /// # Arguments
-    ///
-    /// * `on_attr` - The attribute whose values will become new column headers.
-    /// * `value_attr` - The attribute whose values will populate the cells.
-    /// * `default_value` - The value to use when a cell is missing (e.g., `0` or `false`).
-    ///   Must match the type of `value_attr`.
-    ///
-    /// # Conflict Resolution
-    ///
-    /// If multiple source tuples map to the same target cell (i.e., they have the same
-    /// grouping attributes and the same `on_attr` value), the **Last Write Wins** strategy
-    /// is applied. The source tuples are sorted, and the value from the last tuple is used.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar_core::types::{TupleType, RelationType, ScalarType};
-    /// use relvar_core::values::{Relation, ScalarValue};
-    /// use relvar_core::tuple;
-    /// use relvar::experimental::pivot::Pivot;
-    ///
-    /// // Create a relation: (Item, Color, Count)
-    /// let heading = TupleType::new()
-    ///     .with_attribute("Item", ScalarType::String)
-    ///     .with_attribute("Color", ScalarType::String)
-    ///     .with_attribute("Count", ScalarType::Int);
-    /// let mut relation = Relation::new(RelationType::new(heading));
-    ///
-    /// relation.insert(tuple! { Item: "Shirt", Color: "Red", Count: 10 }).unwrap();
-    /// relation.insert(tuple! { Item: "Shirt", Color: "Blue", Count: 5 }).unwrap();
-    /// relation.insert(tuple! { Item: "Pants", Color: "Blue", Count: 20 }).unwrap();
-    ///
-    /// // Pivot on 'Color', using 'Count' as values, default to 0
-    /// let pivoted = relation.pivot("Color", "Count", ScalarValue::Int(0)).unwrap();
-    ///
-    /// // Result: (Item, Red, Blue)
-    /// // Shirt: Red=10, Blue=5
-    /// // Pants: Red=0 (default), Blue=20
-    /// ```
-    fn pivot(
-        &self,
-        on_attr: &str,
-        value_attr: &str,
-        default_value: ScalarValue,
-    ) -> Result<Relation, DatabaseError>;
-}
+/// Pivots a relation.
+///
+/// Transforms unique values from the `on_attr` column into new column headers,
+/// filling the cells with values from the `value_attr` column. All other attributes
+/// become grouping keys.
+///
+/// # Arguments
+///
+/// * `relation` - The relation to pivot.
+/// * `on_attr` - The attribute whose values will become new column headers.
+/// * `value_attr` - The attribute whose values will populate the cells.
+/// * `default_value` - The value to use when a cell is missing (e.g., `0` or `false`).
+///   Must match the type of `value_attr`.
+///
+/// # Conflict Resolution
+///
+/// If multiple source tuples map to the same target cell (i.e., they have the same
+/// grouping attributes and the same `on_attr` value), the **Last Write Wins** strategy
+/// is applied. The source tuples are sorted, and the value from the last tuple is used.
+///
+/// # Examples
+///
+/// ```
+/// use relvar_core::types::{TupleType, RelationType, ScalarType};
+/// use relvar_core::values::{Relation, ScalarValue};
+/// use relvar_core::tuple;
+/// use relvar::experimental::pivot::pivot;
+///
+/// // Create a relation: (Item, Color, Count)
+/// let heading = TupleType::new()
+///     .with_attribute("Item", ScalarType::String)
+///     .with_attribute("Color", ScalarType::String)
+///     .with_attribute("Count", ScalarType::Int);
+/// let mut relation = Relation::new(RelationType::new(heading));
+///
+/// relation.insert(tuple! { Item: "Shirt", Color: "Red", Count: 10 }).unwrap();
+/// relation.insert(tuple! { Item: "Shirt", Color: "Blue", Count: 5 }).unwrap();
+/// relation.insert(tuple! { Item: "Pants", Color: "Blue", Count: 20 }).unwrap();
+///
+/// // Pivot on 'Color', using 'Count' as values, default to 0
+/// let pivoted = pivot(&relation, "Color", "Count", ScalarValue::Int(0)).unwrap();
+///
+/// // Result: (Item, Red, Blue)
+/// // Shirt: Red=10, Blue=5
+/// // Pants: Red=0 (default), Blue=20
+/// ```
+pub fn pivot(
+    relation: &Relation,
+    on_attr: &str,
+    value_attr: &str,
+    default_value: ScalarValue,
+) -> Result<Relation, DatabaseError> {
+    let heading = relation.relation_type().heading();
 
-impl Pivot for Relation {
-    fn pivot(
-        &self,
-        on_attr: &str,
-        value_attr: &str,
-        default_value: ScalarValue,
-    ) -> Result<Relation, DatabaseError> {
-        let heading = self.relation_type().heading();
+    if !heading.has_attribute(on_attr) {
+        return Err(DatabaseError::AttributeNotFound(
+            on_attr.to_string(),
+            "relation".to_string(),
+        ));
+    }
+    if !heading.has_attribute(value_attr) {
+        return Err(DatabaseError::AttributeNotFound(
+            value_attr.to_string(),
+            "relation".to_string(),
+        ));
+    }
 
-        if !heading.has_attribute(on_attr) {
-            return Err(DatabaseError::AttributeNotFound(
-                on_attr.to_string(),
-                "relation".to_string(),
-            ));
-        }
-        if !heading.has_attribute(value_attr) {
-            return Err(DatabaseError::AttributeNotFound(
-                value_attr.to_string(),
-                "relation".to_string(),
-            ));
-        }
+    let group_attrs: Vec<String> = heading
+        .attribute_names()
+        .filter(|&name| name != on_attr && name != value_attr)
+        .cloned()
+        .collect();
 
-        let group_attrs: Vec<String> = heading
-            .attribute_names()
-            .filter(|&name| name != on_attr && name != value_attr)
-            .cloned()
-            .collect();
+    // Scan for new columns
+    let mut new_columns = BTreeSet::new();
+    for tuple in relation.tuples() {
+        let val = tuple.get(on_attr).unwrap();
+        let col_name = scalar_to_string_key(val)?;
+        new_columns.insert(col_name);
+    }
 
-        // Scan for new columns
-        let mut new_columns = BTreeSet::new();
-        for tuple in self.tuples() {
-            let val = tuple.get(on_attr).unwrap();
-            let col_name = scalar_to_string_key(val)?;
-            new_columns.insert(col_name);
-        }
-
-        // Check collisions
-        for col in &new_columns {
-            if group_attrs.contains(col) {
-                return Err(DatabaseError::DuplicateAttributeName(format!(
-                    "Pivoted column '{}' conflicts with grouping attribute",
-                    col
-                )));
-            }
-        }
-
-        // Construct new heading
-        let mut new_heading = TupleType::new();
-        for attr in &group_attrs {
-            let ty = heading.get_attribute_type(attr).unwrap();
-            new_heading = new_heading.with_attribute(attr, ty.clone());
-        }
-
-        let value_type = heading.get_attribute_type(value_attr).unwrap();
-        if !default_value.is_type(value_type) {
-            return Err(DatabaseError::AlgebraError(format!(
-                "Default value type ({:?}) mismatch with value attribute ({:?})",
-                default_value.scalar_type(),
-                value_type
+    // Check collisions
+    for col in &new_columns {
+        if group_attrs.contains(col) {
+            return Err(DatabaseError::DuplicateAttributeName(format!(
+                "Pivoted column '{}' conflicts with grouping attribute",
+                col
             )));
         }
-
-        for col in &new_columns {
-            new_heading = new_heading.with_attribute(col, value_type.clone());
-        }
-
-        let new_rel_type = RelationType::new(new_heading);
-        let mut result_relation = Relation::new(new_rel_type.clone());
-
-        // Group data
-        let mut groups: BTreeMap<Vec<ScalarValue>, BTreeMap<String, ScalarValue>> = BTreeMap::new();
-
-        // Sort tuples for deterministic Last Write Wins
-        let mut sorted_tuples: Vec<&Tuple> = self.tuples().collect();
-        sorted_tuples.sort_by(|a, b| a.values().cmp(b.values()));
-
-        for tuple in sorted_tuples {
-            let mut group_key = Vec::with_capacity(group_attrs.len());
-            for attr in &group_attrs {
-                group_key.push(tuple.get(attr).unwrap().clone());
-            }
-
-            let pivot_val = tuple.get(on_attr).unwrap();
-            let col_name = scalar_to_string_key(pivot_val)?;
-            let cell_val = tuple.get(value_attr).unwrap().clone();
-
-            groups
-                .entry(group_key)
-                .or_default()
-                .insert(col_name, cell_val);
-        }
-
-        // Build result tuples
-        for (group_key, cell_map) in groups {
-            let mut tuple_values = BTreeMap::new();
-            for (i, attr) in group_attrs.iter().enumerate() {
-                tuple_values.insert(attr.clone(), group_key[i].clone());
-            }
-            for col in &new_columns {
-                let val = cell_map.get(col).unwrap_or(&default_value).clone();
-                tuple_values.insert(col.clone(), val);
-            }
-            let tuple = Tuple::new(new_rel_type.heading().clone(), tuple_values)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-            result_relation.insert(tuple)?;
-        }
-
-        Ok(result_relation)
     }
+
+    // Construct new heading
+    let mut new_heading = TupleType::new();
+    for attr in &group_attrs {
+        let ty = heading.get_attribute_type(attr).unwrap();
+        new_heading = new_heading.with_attribute(attr, ty.clone());
+    }
+
+    let value_type = heading.get_attribute_type(value_attr).unwrap();
+    if !default_value.is_type(value_type) {
+        return Err(DatabaseError::AlgebraError(format!(
+            "Default value type ({:?}) mismatch with value attribute ({:?})",
+            default_value.scalar_type(),
+            value_type
+        )));
+    }
+
+    for col in &new_columns {
+        new_heading = new_heading.with_attribute(col, value_type.clone());
+    }
+
+    let new_rel_type = RelationType::new(new_heading);
+    let mut result_relation = Relation::new(new_rel_type.clone());
+
+    // Group data
+    let mut groups: BTreeMap<Vec<ScalarValue>, BTreeMap<String, ScalarValue>> = BTreeMap::new();
+
+    // Sort tuples for deterministic Last Write Wins
+    let mut sorted_tuples: Vec<&Tuple> = relation.tuples().collect();
+    sorted_tuples.sort_by(|a, b| a.values().cmp(b.values()));
+
+    for tuple in sorted_tuples {
+        let mut group_key = Vec::with_capacity(group_attrs.len());
+        for attr in &group_attrs {
+            group_key.push(tuple.get(attr).unwrap().clone());
+        }
+
+        let pivot_val = tuple.get(on_attr).unwrap();
+        let col_name = scalar_to_string_key(pivot_val)?;
+        let cell_val = tuple.get(value_attr).unwrap().clone();
+
+        groups
+            .entry(group_key)
+            .or_default()
+            .insert(col_name, cell_val);
+    }
+
+    // Build result tuples
+    for (group_key, cell_map) in groups {
+        let mut tuple_values = BTreeMap::new();
+        for (i, attr) in group_attrs.iter().enumerate() {
+            tuple_values.insert(attr.clone(), group_key[i].clone());
+        }
+        for col in &new_columns {
+            let val = cell_map.get(col).unwrap_or(&default_value).clone();
+            tuple_values.insert(col.clone(), val);
+        }
+        let tuple = Tuple::new(new_rel_type.heading().clone(), tuple_values)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+        result_relation.insert(tuple)?;
+    }
+
+    Ok(result_relation)
 }
 
 fn scalar_to_string_key(val: &ScalarValue) -> Result<String, DatabaseError> {
@@ -232,7 +221,7 @@ mod tests {
         r.insert(tuple! { A: "X", M: "Feb", V: 20 }).unwrap();
         r.insert(tuple! { A: "Y", M: "Jan", V: 30 }).unwrap();
 
-        let p = r.pivot("M", "V", ScalarValue::Int(0)).unwrap();
+        let p = pivot(&r, "M", "V", ScalarValue::Int(0)).unwrap();
 
         // Expected: A, Jan, Feb
         assert_eq!(p.cardinality(), 2);
@@ -264,7 +253,7 @@ mod tests {
         r.insert(tuple! { K: "K1", P: "P1", V: 10 }).unwrap();
         r.insert(tuple! { K: "K1", P: "P1", V: 20 }).unwrap();
 
-        let p = r.pivot("P", "V", ScalarValue::Int(0)).unwrap();
+        let p = pivot(&r, "P", "V", ScalarValue::Int(0)).unwrap();
         assert_eq!(p.cardinality(), 1);
         let t = p.tuples().next().unwrap();
         assert_eq!(t.get("P1"), Some(&ScalarValue::Int(20)));

--- a/relvar/src/experimental/pivot.rs
+++ b/relvar/src/experimental/pivot.rs
@@ -258,4 +258,50 @@ mod tests {
         let t = p.tuples().next().unwrap();
         assert_eq!(t.get("P1"), Some(&ScalarValue::Int(20)));
     }
+
+    #[test]
+    fn test_pivot_errors() {
+        use relvar_core::error::DatabaseError;
+        let heading = TupleType::new()
+            .with_attribute("A", ScalarType::String)
+            .with_attribute("M", ScalarType::String)
+            .with_attribute("V", ScalarType::Int)
+            .with_attribute("Jan", ScalarType::String);
+        let mut r = Relation::new(RelationType::new(heading));
+        r.insert(tuple! { A: "X", M: "Jan", V: 10, Jan: "Y" })
+            .unwrap();
+
+        // Missing on_attr
+        let err = pivot(&r, "Missing", "V", ScalarValue::Int(0)).unwrap_err();
+        assert!(matches!(err, DatabaseError::AttributeNotFound(..)));
+
+        // Missing value_attr
+        let err = pivot(&r, "M", "Missing", ScalarValue::Int(0)).unwrap_err();
+        assert!(matches!(err, DatabaseError::AttributeNotFound(..)));
+
+        // Conflicting column name
+        let err = pivot(&r, "M", "V", ScalarValue::Int(0)).unwrap_err();
+        assert!(matches!(err, DatabaseError::DuplicateAttributeName(..)));
+
+        // Type mismatch for default value
+        let heading2 = TupleType::new()
+            .with_attribute("A", ScalarType::String)
+            .with_attribute("M", ScalarType::String)
+            .with_attribute("V", ScalarType::Int);
+        let mut r2 = Relation::new(RelationType::new(heading2));
+        r2.insert(tuple! { A: "X", M: "Jan", V: 10 }).unwrap();
+
+        let err = pivot(&r2, "M", "V", ScalarValue::String("0".to_string())).unwrap_err();
+        assert!(matches!(err, DatabaseError::AlgebraError(..)));
+
+        // Unsupported type for pivot key
+        let heading3 = TupleType::new()
+            .with_attribute("A", ScalarType::String)
+            .with_attribute("M", ScalarType::Float)
+            .with_attribute("V", ScalarType::Int);
+        let mut r3 = Relation::new(RelationType::new(heading3));
+        r3.insert(tuple! { A: "X", M: 1.0, V: 10 }).unwrap();
+        let err = pivot(&r3, "M", "V", ScalarValue::Int(0)).unwrap_err();
+        assert!(matches!(err, DatabaseError::AlgebraError(..)));
+    }
 }


### PR DESCRIPTION
🚯 Smell: `Pivot` was a "One-Time Trait" only implemented for `Relation`, violating the "De-Abstract" principle.
✨ Solution: Replaced the `Pivot` trait with a standalone `pivot` function.
🧼 Benefit: Reduced code bloat and eliminated an unnecessary layer of indirection/abstraction.
🛡️ Verification: Ran `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all`. All checks pass.

---
*PR created automatically by Jules for task [3442695422048465314](https://jules.google.com/task/3442695422048465314) started by @madmax983*