### PR TITLE
⚒️ Forge: [Refactor Ord::cmp for ScalarType and ScalarValue]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -530,3 +530,7 @@ Build it right, make it fast, keep it simple.
 ## 2025-06-03 - Summarize operator Three-Phase refactoring
 **Learning:** Extracting `compute_summarized_tuples` from `Relation::summarize` improves readability by separating tuple calculation from validation and heading construction logic. The extraction uses `&HashMap<Vec<&ScalarValue>, Vec<&Tuple>>` which matches `group_tuples`'s return type.
 **Action:** When extracting functions handling grouped data, match the signature of the grouping function (`group_tuples` here) exactly.
+
+## 2026-03-14 - Extract Complex Type Comparison Logic
+**Learning:** `Ord::cmp` implementations in `relvar-core/src/types/scalar.rs` (`ScalarType`) and `relvar-core/src/values/scalar.rs` (`ScalarValue`) had deeply nested `match` branches (up to 12 levels) for complex variant comparisons like `Relation` and `UserDefined`.
+**Action:** Replace nested `match` inside `Ord::cmp` with a guard clause on discriminant/type mismatch first, and then extract complex variant match arms into private helper functions like `cmp_relation_types` and `cmp_user_defined_types`.

--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -386,69 +386,82 @@ impl Ord for ScalarType {
             ScalarType::UserDefined { .. } => 6,
         };
 
-        match disc_value(self).cmp(&disc_value(other)) {
+        let cmp_disc = disc_value(self).cmp(&disc_value(other));
+        if cmp_disc != Ordering::Equal {
+            return cmp_disc;
+        }
+
+        // Same variant, compare data
+        match (self, other) {
+            (ScalarType::Int, ScalarType::Int)
+            | (ScalarType::Float, ScalarType::Float)
+            | (ScalarType::String, ScalarType::String)
+            | (ScalarType::Bool, ScalarType::Bool)
+            | (ScalarType::Bytes, ScalarType::Bytes) => Ordering::Equal,
+            (ScalarType::Relation(a), ScalarType::Relation(b)) => Self::cmp_relation_types(a, b),
+            (
+                ScalarType::UserDefined {
+                    name: a_name,
+                    representation: a_rep,
+                },
+                ScalarType::UserDefined {
+                    name: b_name,
+                    representation: b_rep,
+                },
+            ) => Self::cmp_user_defined_types(a_name, a_rep, b_name, b_rep),
+            _ => unreachable!("Discriminants matched but variants don't"),
+        }
+    }
+}
+
+impl ScalarType {
+    fn cmp_relation_types(
+        a: &crate::types::RelationType,
+        b: &crate::types::RelationType,
+    ) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        let a_attrs: Vec<_> = a
+            .heading()
+            .attribute_names()
+            .map(|n| (n, a.heading().get_attribute_type(n).unwrap()))
+            .collect();
+        let b_attrs: Vec<_> = b
+            .heading()
+            .attribute_names()
+            .map(|n| (n, b.heading().get_attribute_type(n).unwrap()))
+            .collect();
+
+        match a_attrs.len().cmp(&b_attrs.len()) {
             Ordering::Equal => {
-                // Same variant, compare data
-                match (self, other) {
-                    (ScalarType::Int, ScalarType::Int)
-                    | (ScalarType::Float, ScalarType::Float)
-                    | (ScalarType::String, ScalarType::String)
-                    | (ScalarType::Bool, ScalarType::Bool)
-                    | (ScalarType::Bytes, ScalarType::Bytes) => Ordering::Equal,
-                    (ScalarType::Relation(a), ScalarType::Relation(b)) => {
-                        // Compare relation types by their headings
-                        // Since TupleType doesn't have Ord, we need a custom comparison
-                        let a_attrs: Vec<_> = a
-                            .heading()
-                            .attribute_names()
-                            .map(|n| (n, a.heading().get_attribute_type(n).unwrap()))
-                            .collect();
-                        let b_attrs: Vec<_> = b
-                            .heading()
-                            .attribute_names()
-                            .map(|n| (n, b.heading().get_attribute_type(n).unwrap()))
-                            .collect();
+                let mut a_sorted = a_attrs;
+                let mut b_sorted = b_attrs;
+                a_sorted.sort_by_key(|(name, _)| *name);
+                b_sorted.sort_by_key(|(name, _)| *name);
 
-                        // Compare by count first, then by sorted attributes
-                        match a_attrs.len().cmp(&b_attrs.len()) {
-                            Ordering::Equal => {
-                                let mut a_sorted = a_attrs;
-                                let mut b_sorted = b_attrs;
-                                a_sorted.sort_by_key(|(name, _)| *name);
-                                b_sorted.sort_by_key(|(name, _)| *name);
-
-                                for ((a_name, a_ty), (b_name, b_ty)) in
-                                    a_sorted.iter().zip(b_sorted.iter())
-                                {
-                                    match a_name.cmp(b_name) {
-                                        Ordering::Equal => match a_ty.cmp(b_ty) {
-                                            Ordering::Equal => continue,
-                                            other => return other,
-                                        },
-                                        other => return other,
-                                    }
-                                }
-                                Ordering::Equal
-                            }
-                            other => other,
-                        }
+                for ((a_name, a_ty), (b_name, b_ty)) in a_sorted.iter().zip(b_sorted.iter()) {
+                    match a_name.cmp(b_name) {
+                        Ordering::Equal => match a_ty.cmp(b_ty) {
+                            Ordering::Equal => continue,
+                            other => return other,
+                        },
+                        other => return other,
                     }
-                    (
-                        ScalarType::UserDefined {
-                            name: a_name,
-                            representation: a_rep,
-                        },
-                        ScalarType::UserDefined {
-                            name: b_name,
-                            representation: b_rep,
-                        },
-                    ) => match a_name.cmp(b_name) {
-                        Ordering::Equal => a_rep.cmp(b_rep),
-                        other => other,
-                    },
-                    _ => unreachable!("Discriminants matched but variants don't"),
                 }
+                Ordering::Equal
             }
+            other => other,
+        }
+    }
+
+    fn cmp_user_defined_types(
+        a_name: &str,
+        a_rep: &ScalarType,
+        b_name: &str,
+        b_rep: &ScalarType,
+    ) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match a_name.cmp(b_name) {
+            Ordering::Equal => a_rep.cmp(b_rep),
             other => other,
         }
     }

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -383,99 +383,117 @@ impl Ord for ScalarValue {
             }
         }
 
-        // Compare types first
-        match type_order(self).cmp(&type_order(other)) {
-            Ordering::Equal => {
-                // Same type: order by value
-                match (self, other) {
-                    (ScalarValue::Int(a), ScalarValue::Int(b)) => a.cmp(b),
-                    (ScalarValue::Float(a), ScalarValue::Float(b)) => {
-                        // For floats, treat all NaNs as equal and greater than any other float
-                        match (a.is_nan(), b.is_nan()) {
-                            (true, true) => Ordering::Equal,
-                            (true, false) => Ordering::Greater,
-                            (false, true) => Ordering::Less,
-                            (false, false) => {
-                                // Correctly order floating point numbers using their bit representation
-                                // This handles signed zeros (-0.0 < 0.0) and negative numbers correctly
-                                let a_bits = a.to_bits();
-                                let b_bits = b.to_bits();
-                                let a_sign = a_bits >> 63;
-                                let b_sign = b_bits >> 63;
+        let cmp_type = type_order(self).cmp(&type_order(other));
+        if cmp_type != Ordering::Equal {
+            return cmp_type;
+        }
 
-                                if a_sign != b_sign {
-                                    // Different signs: negative < positive
-                                    if a_sign == 1 {
-                                        Ordering::Less
-                                    } else {
-                                        Ordering::Greater
-                                    }
-                                } else {
-                                    // Same signs
-                                    if a_sign == 0 {
-                                        // Both positive: larger magnitude is larger
-                                        a_bits.cmp(&b_bits)
-                                    } else {
-                                        // Both negative: larger magnitude is smaller (more negative)
-                                        // e.g., -10.0 has larger bit representation than -1.0
-                                        b_bits.cmp(&a_bits)
-                                    }
-                                }
-                            }
-                        }
+        // Same type: order by value
+        match (self, other) {
+            (ScalarValue::Int(a), ScalarValue::Int(b)) => a.cmp(b),
+            (ScalarValue::Float(a), ScalarValue::Float(b)) => Self::cmp_floats(*a, *b),
+            (ScalarValue::String(a), ScalarValue::String(b)) => a.cmp(b),
+            (ScalarValue::Bool(a), ScalarValue::Bool(b)) => a.cmp(b),
+            (ScalarValue::Bytes(a), ScalarValue::Bytes(b)) => a.cmp(b),
+            (ScalarValue::Relation(a), ScalarValue::Relation(b)) => Self::cmp_relations(a, b),
+            (
+                ScalarValue::UserDefined {
+                    type_def: type_a,
+                    value: val_a,
+                },
+                ScalarValue::UserDefined {
+                    type_def: type_b,
+                    value: val_b,
+                },
+            ) => Self::cmp_user_defined_values(type_a, val_a, type_b, val_b),
+            _ => unreachable!("Type orders are equal but types don't match"),
+        }
+    }
+}
+
+impl ScalarValue {
+    fn cmp_floats(a: f64, b: f64) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        // For floats, treat all NaNs as equal and greater than any other float
+        match (a.is_nan(), b.is_nan()) {
+            (true, true) => Ordering::Equal,
+            (true, false) => Ordering::Greater,
+            (false, true) => Ordering::Less,
+            (false, false) => {
+                // Correctly order floating point numbers using their bit representation
+                // This handles signed zeros (-0.0 < 0.0) and negative numbers correctly
+                let a_bits = a.to_bits();
+                let b_bits = b.to_bits();
+                let a_sign = a_bits >> 63;
+                let b_sign = b_bits >> 63;
+
+                if a_sign != b_sign {
+                    // Different signs: negative < positive
+                    if a_sign == 1 {
+                        Ordering::Less
+                    } else {
+                        Ordering::Greater
                     }
-                    (ScalarValue::String(a), ScalarValue::String(b)) => a.cmp(b),
-                    (ScalarValue::Bool(a), ScalarValue::Bool(b)) => a.cmp(b),
-                    (ScalarValue::Bytes(a), ScalarValue::Bytes(b)) => a.cmp(b),
-                    (ScalarValue::Relation(a), ScalarValue::Relation(b)) => {
-                        // For relations, order by cardinality first, then degree
-                        match a.cardinality().cmp(&b.cardinality()) {
-                            Ordering::Equal => a.degree().cmp(&b.degree()),
-                            other => other,
-                        }
+                } else {
+                    // Same signs
+                    if a_sign == 0 {
+                        // Both positive: larger magnitude is larger
+                        a_bits.cmp(&b_bits)
+                    } else {
+                        // Both negative: larger magnitude is smaller (more negative)
+                        // e.g., -10.0 has larger bit representation than -1.0
+                        b_bits.cmp(&a_bits)
                     }
-                    (
-                        ScalarValue::UserDefined {
-                            type_def: type_a,
-                            value: val_a,
-                        },
-                        ScalarValue::UserDefined {
-                            type_def: type_b,
-                            value: val_b,
-                        },
-                    ) => {
-                        // Order by type identity first (structural comparison), then by value
-                        match type_a.cmp(type_b) {
+                }
+            }
+        }
+    }
+
+    fn cmp_relations(
+        a: &crate::values::Relation,
+        b: &crate::values::Relation,
+    ) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        // For relations, order by cardinality first, then degree
+        match a.cardinality().cmp(&b.cardinality()) {
+            Ordering::Equal => a.degree().cmp(&b.degree()),
+            other => other,
+        }
+    }
+
+    fn cmp_user_defined_values(
+        type_a: &ScalarType,
+        val_a: &ScalarValue,
+        type_b: &ScalarType,
+        val_b: &ScalarValue,
+    ) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        // Order by type identity first (structural comparison), then by value
+        match type_a.cmp(type_b) {
+            Ordering::Equal => {
+                // Iterative comparison to prevent stack overflow
+                let mut cur_a = val_a;
+                let mut cur_b = val_b;
+                loop {
+                    match (cur_a, cur_b) {
+                        (
+                            ScalarValue::UserDefined {
+                                type_def: ta,
+                                value: va,
+                            },
+                            ScalarValue::UserDefined {
+                                type_def: tb,
+                                value: vb,
+                            },
+                        ) => match ta.cmp(tb) {
                             Ordering::Equal => {
-                                // Iterative comparison to prevent stack overflow
-                                let mut cur_a = val_a;
-                                let mut cur_b = val_b;
-                                loop {
-                                    match (&**cur_a, &**cur_b) {
-                                        (
-                                            ScalarValue::UserDefined {
-                                                type_def: ta,
-                                                value: va,
-                                            },
-                                            ScalarValue::UserDefined {
-                                                type_def: tb,
-                                                value: vb,
-                                            },
-                                        ) => match ta.cmp(tb) {
-                                            Ordering::Equal => {
-                                                cur_a = va;
-                                                cur_b = vb;
-                                            }
-                                            other => return other,
-                                        },
-                                        (a, b) => return a.cmp(b),
-                                    }
-                                }
+                                cur_a = va;
+                                cur_b = vb;
                             }
-                            other => other,
-                        }
+                            other => return other,
+                        },
+                        (a, b) => return a.cmp(b),
                     }
-                    _ => unreachable!("Type orders are equal but types don't match"),
                 }
             }
             other => other,


### PR DESCRIPTION
🚮 Smell: `Ord::cmp` implementations in `relvar-core/src/types/scalar.rs` (`ScalarType`) and `relvar-core/src/values/scalar.rs` (`ScalarValue`) had deeply nested `match` branches (up to 12 levels deep - Pyramid of Doom) when comparing complex variants like `Relation` and `UserDefined`.
✨ Solution: Replaced the large nested `match` inside `Ord::cmp` with early returns (guard clauses) on discriminant/type mismatches. Extracted complex variant comparisons into cleanly isolated private helper functions (`cmp_relation_types`, `cmp_user_defined_types`, `cmp_floats`, `cmp_relations`, `cmp_user_defined_values`).
🧼 Benefit: Significantly flattens the code structure and improves readability by isolating complex variant matching from the core outer matching loop.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [2251306003138740726](https://jules.google.com/task/2251306003138740726) started by @madmax983*