### PR TITLE
🔒 Warden: [security fix] Prevent OOM DoS when scanning massive WAL files

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -187,3 +187,12 @@ The `postcard` dependency (version 1.1.3) enabled the `heapless-cas` and `heaple
 
 **Defense:**
 Modified `Cargo.toml` to disable the default features of `postcard` by specifying `default-features = false`, explicitly only retaining the required `alloc` and `use-std` features. This eliminates the `heapless` and `atomic-polyfill` dependencies entirely, mitigating the risk of relying on an unmaintained crate.
+## 2026-03-05 - WAL Manager OOM Allocation Bomb DoS
+**Threat:**
+The `WalManager::open` and `WalManager::scan` methods used `read_to_end` to read the entire Write-Ahead Log (WAL) file into memory during recovery, without checking its size. An attacker could potentially supply or corrupt a WAL file to be massively large (e.g., via sparse file techniques or continuous append), causing the database server to exhaust memory (OOM DoS) and crash upon startup.
+
+**Defense:**
+1. Introduced a `MAX_WAL_SIZE` constant capped at 2GB in `relvar-storage/src/wal/manager.rs`.
+2. Modified `WalManager::scan` and `scan_for_last_lsn` to check `log_file.metadata()?.len()` before reading.
+3. If the file length exceeds `MAX_WAL_SIZE`, it returns an explicit `WalError::Corrupted` rather than attempting to allocate memory.
+4. Added `test_open_allocation_bomb_prevention` in `relvar-storage/src/wal/manager_test.rs` using sparse files to verify the defense without using actual disk space.

--- a/relvar-storage/src/wal/manager.rs
+++ b/relvar-storage/src/wal/manager.rs
@@ -16,6 +16,11 @@ use std::path::Path;
 /// This allows batching many small records before flushing to disk.
 pub const DEFAULT_BUFFER_SIZE: usize = 1024 * 1024;
 
+/// Maximum allowed WAL file size (2GB).
+///
+/// This prevents memory exhaustion (DoS) when reading the WAL file into memory during recovery.
+pub const MAX_WAL_SIZE: u64 = 2 * 1024 * 1024 * 1024;
+
 /// Header written at the start of each WAL file.
 ///
 /// Used for basic validation and version checking during recovery.
@@ -224,6 +229,18 @@ impl WalManager {
         // Flush any buffered records first
         self.flush()?;
 
+        // Prevent OOM DoS: check file size before reading into memory
+        let file_len = self.log_file.metadata()?.len();
+        if file_len > MAX_WAL_SIZE {
+            return Err(WalError::Corrupted(
+                Lsn::new(0),
+                format!(
+                    "WAL file too large: {} bytes (max: {})",
+                    file_len, MAX_WAL_SIZE
+                ),
+            ));
+        }
+
         // Seek to start of records (after magic header)
         self.log_file
             .seek(SeekFrom::Start(WAL_MAGIC.len() as u64))?;
@@ -293,6 +310,18 @@ impl WalManager {
     /// This is necessary because WAL records are variable-length.
     fn scan_for_last_lsn(log_file: &mut File) -> Result<(Lsn, Lsn), WalError> {
         use std::io::Read;
+
+        // Prevent OOM DoS: check file size before reading into memory
+        let file_len = log_file.metadata()?.len();
+        if file_len > MAX_WAL_SIZE {
+            return Err(WalError::Corrupted(
+                Lsn::new(0),
+                format!(
+                    "WAL file too large: {} bytes (max: {})",
+                    file_len, MAX_WAL_SIZE
+                ),
+            ));
+        }
 
         // Seek to start of records (after magic header)
         log_file.seek(SeekFrom::Start(WAL_MAGIC.len() as u64))?;

--- a/relvar-storage/src/wal/manager_test.rs
+++ b/relvar-storage/src/wal/manager_test.rs
@@ -91,3 +91,36 @@ fn test_scan_partial_record() {
     assert!(result.is_ok());
     assert!(result.unwrap().is_empty());
 }
+
+#[test]
+fn test_open_allocation_bomb_prevention() {
+    let temp = NamedTempFile::new().unwrap();
+    let path = temp.path().to_path_buf();
+
+    {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap();
+        use std::io::Write;
+
+        // Write magic header
+        file.write_all(WAL_MAGIC).unwrap();
+
+        // Simulate a massive file size (e.g., 3GB) to trigger DoS protection
+        // without actually writing 3GB to disk.
+        file.set_len(3 * 1024 * 1024 * 1024).unwrap();
+    }
+
+    let result = WalManager::open(&path);
+
+    assert!(result.is_err());
+    match result {
+        Err(WalError::Corrupted(_, msg)) => {
+            assert!(msg.contains("WAL file too large"));
+        }
+        _ => panic!("Expected Corrupted error due to large file"),
+    }
+}


### PR DESCRIPTION
🦠 Threat: The `WalManager` previously read the entire Write-Ahead Log (WAL) into memory using `read_to_end()` during `open` and `scan` without checking the file's size first. An attacker who can artificially inflate the WAL file (e.g., via sparse files, continuous uncommitted transactions, or direct file tampering) could cause the database to exhaust memory and crash with an OOM panic upon startup.

🛡️ Defense: Implemented a strict `MAX_WAL_SIZE` limit of 2GB. `WalManager::scan` and `WalManager::scan_for_last_lsn` now proactively check `metadata()?.len()` against this limit before attempting to allocate memory or read the file. If the file is too large, it safely returns a `WalError::Corrupted` instead of crashing.

💥 Severity: High - A Denial of Service (DoS) vector that could permanently prevent the database from starting up if the WAL file becomes maliciously or accidentally oversized.

🧪 Verification: Added a test case `test_open_allocation_bomb_prevention` that uses `file.set_len()` to safely simulate a massive file, verifying the error is returned immediately. All existing tests pass, and code has been checked with `clippy`.

---
*PR created automatically by Jules for task [9873406843522915965](https://jules.google.com/task/9873406843522915965) started by @madmax983*