### PR TITLE
🛡️ Sentry: [test coverage improvement] Database error paths

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -59,3 +59,6 @@
 ## 2025-03-14 - ConstraintManager Coverage Gaps
 **Learning:** Multiple functions in `ConstraintManager` relating to evaluating constraints natively against individual tuples, checking constraint preconditions prior to setup, and handling dependent foreign key updates via `validate_referencing_foreign_keys` were completely unexercised. This leaves open logic flaws where an update sequence may evaluate validations improperly.
 **Action:** When implementing database or storage engine layers, constraint logic generally needs comprehensive functional integration tests since unit tests on the constraint primitives rarely stress the engine orchestration itself, leading to gaps in `manager.rs`.
+## 2025-03-16 - Virtual Relvars Evaluation and Database Error Coverage
+**Learning:** Found several untested code paths regarding the mutability limitations of `VirtualRelvarDefinition` (preventing mutation because `evaluator` takes an immutable reference but error mapping missing tests), and transaction nesting issues inside `relvar-core/src/database/mod.rs` mapping to `DatabaseError::TransactionError`.
+**Action:** When working on APIs containing view-like concepts (`virtual_relvars`), ensure the evaluation error paths are fully tested. When implementing Database transactions, ensure explicit testing for double-begin and missing-begin cases for commits and rollbacks.

--- a/relvar-core/src/database/tests.rs
+++ b/relvar-core/src/database/tests.rs
@@ -1127,3 +1127,79 @@ fn test_virtual_relvar_immutability_enforcement() {
     // Query the view
     assert!(db.query("SAFE_VIEW").is_ok());
 }
+
+#[test]
+fn test_get_relvar_type() {
+    let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
+
+    // Test base relvar
+    db.create_relvar("BASE", test_rel_type()).unwrap();
+    let base_type = db.get_relvar_type("BASE").unwrap();
+    assert_eq!(base_type, test_rel_type());
+
+    // Test virtual relvar
+    db.define_virtual_relvar("VIRTUAL", test_rel_type(), |db| db.query("BASE"))
+        .unwrap();
+    let virtual_type = db.get_relvar_type("VIRTUAL").unwrap();
+    assert_eq!(virtual_type, test_rel_type());
+
+    // Test missing relvar
+    let result = db.get_relvar_type("NONEXISTENT");
+    assert!(result.is_err());
+    assert!(matches!(result, Err(DatabaseError::Storage(_))));
+}
+
+#[test]
+fn test_transaction_errors() {
+    let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
+
+    // Test commit when not in transaction
+    let result = db.commit();
+    assert!(result.is_err());
+    assert!(
+        matches!(result, Err(DatabaseError::TransactionError(msg)) if msg == "No transaction in progress")
+    );
+
+    // Test rollback when not in transaction
+    let result = db.rollback();
+    assert!(result.is_err());
+    assert!(
+        matches!(result, Err(DatabaseError::TransactionError(msg)) if msg == "No transaction in progress")
+    );
+
+    // Test nested begin
+    db.begin().unwrap();
+    let result = db.begin();
+    assert!(result.is_err());
+    assert!(
+        matches!(result, Err(DatabaseError::TransactionError(msg)) if msg == "Transaction already in progress")
+    );
+}
+
+#[test]
+fn test_define_virtual_relvar_already_exists() {
+    let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
+
+    // Create base relvar
+    db.create_relvar("BASE", test_rel_type()).unwrap();
+
+    // Define virtual relvar
+    db.define_virtual_relvar("VIRTUAL", test_rel_type(), |db| db.query("BASE"))
+        .unwrap();
+
+    // Try to redefine virtual relvar
+    let result = db.define_virtual_relvar("VIRTUAL", test_rel_type(), |db| db.query("BASE"));
+    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(DatabaseError::RelationAlreadyExists(_))
+    ));
+
+    // Try to define virtual relvar with same name as base relvar
+    let result = db.define_virtual_relvar("BASE", test_rel_type(), |db| db.query("BASE"));
+    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(DatabaseError::RelationAlreadyExists(_))
+    ));
+}


### PR DESCRIPTION
🛡️ Sentry: Database error path coverage improvement

🎯 Target: `relvar-core/src/database/mod.rs` error paths.
💣 Risk: Transaction mismatch states (`DatabaseError::TransactionError`), virtual relvar redeclaration bugs (`DatabaseError::RelationAlreadyExists`), and untested fallback metadata loading (`get_relvar_type` errors) could mask logic errors in consuming applications relying on precise database engine responses.
🧪 Strategy: Added specific unit tests targeting `test_get_relvar_type`, `test_transaction_errors`, and `test_define_virtual_relvar_already_exists`. 
🔬 Verification: Run `cargo test --manifest-path relvar-core/Cargo.toml` to verify.

(Cleaned up all coverage report artifacts previously generated during testing.)

---
*PR created automatically by Jules for task [3655176681383010618](https://jules.google.com/task/3655176681383010618) started by @madmax983*