### PR TITLE
🌟 Nova: Relational Collaborative Filtering

### DIFF
--- a/relvar/src/experimental/mod.rs
+++ b/relvar/src/experimental/mod.rs
@@ -12,6 +12,7 @@
 //! - **[`matrix`](crate::experimental::matrix)**: Relational Linear Algebra (Sparse Matrices).
 //! - **[`mock`](crate::experimental::mock)**: Tools for generating random relations for testing.
 //! - **[`pivot`](crate::experimental::pivot)**: Operator to rotate unique values from one column into multiple columns.
+//! - **[`recommend`](crate::experimental::recommend)**: Relational Recommender System (Collaborative Filtering).
 //! - **[`search`](crate::experimental::search)**: Relational Full-Text Search.
 //! - **[`spatial`](crate::experimental::spatial)**: Spatial data types and operations.
 //! - **[`timeseries`](crate::experimental::timeseries)**: Relational Time Series Analysis (Moving Averages).
@@ -23,6 +24,7 @@ pub mod image;
 pub mod matrix;
 pub mod mock;
 pub mod pivot;
+pub mod recommend;
 pub mod search;
 pub mod spatial;
 pub mod timeseries;

--- a/relvar/src/experimental/recommend.rs
+++ b/relvar/src/experimental/recommend.rs
@@ -1,0 +1,285 @@
+//! Relational Recommender System.
+//!
+//! This module implements Collaborative Filtering using purely relational algebra
+//! operations. It demonstrates how complex analytical tasks like recommendations
+//! can be computed directly within a relational engine without extracting data.
+//!
+//! # Concept
+//!
+//! We represent user-item interactions (e.g., ratings or views) as a relation:
+//! `(user_id, item_id, score)`.
+//!
+//! Using relational operators, we can:
+//! 1. Find users who rated the same items (`Join`).
+//! 2. Compute similarity between items or users based on co-occurrence or ratings (`Extend`, `Summarize`).
+//! 3. Predict scores for unseen items for a target user.
+
+use relvar_core::algebra::Aggregation;
+use relvar_core::error::DatabaseError;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
+use relvar_core::values::{Relation, ScalarValue};
+
+/// A Collaborative Filtering Recommender.
+pub struct CollaborativeFilter {
+    /// The ratings relation. Schema: (user_id_attr, item_id_attr, score_attr)
+    ratings: Relation,
+    user_id_attr: String,
+    item_id_attr: String,
+    score_attr: String,
+}
+
+impl CollaborativeFilter {
+    /// Creates a new CollaborativeFilter.
+    ///
+    /// # Arguments
+    ///
+    /// * `ratings` - The relation containing user-item ratings.
+    /// * `user_id_attr` - The attribute name for the user identifier.
+    /// * `item_id_attr` - The attribute name for the item identifier.
+    /// * `score_attr` - The attribute name for the rating/score (must be numeric, ideally Float).
+    pub fn new(
+        ratings: Relation,
+        user_id_attr: &str,
+        item_id_attr: &str,
+        score_attr: &str,
+    ) -> Self {
+        Self {
+            ratings,
+            user_id_attr: user_id_attr.to_string(),
+            item_id_attr: item_id_attr.to_string(),
+            score_attr: score_attr.to_string(),
+        }
+    }
+
+    /// Recommends items for a target user using a User-Based Collaborative Filtering approach.
+    ///
+    /// Returns a relation with heading `(item_id_attr, predicted_score)` containing
+    /// items the user has not yet rated. (The caller must sort if ordering is desired).
+    pub fn recommend_user_based(
+        &self,
+        target_user_id: ScalarValue,
+    ) -> Result<Relation, DatabaseError> {
+        // Step 1: Find items the target user HAS rated
+        let target_user_ratings = self
+            .ratings
+            .restrict(|t| t.get(&self.user_id_attr) == Some(&target_user_id));
+
+        if target_user_ratings.is_empty() {
+            let heading = TupleType::new()
+                .with_attribute(
+                    self.item_id_attr.clone(),
+                    self.ratings
+                        .relation_type()
+                        .heading()
+                        .get_attribute_type(&self.item_id_attr)
+                        .unwrap()
+                        .clone(),
+                )
+                .with_attribute("predicted_score".to_string(), ScalarType::Float);
+            return Ok(Relation::new(RelationType::new(heading)));
+        }
+
+        // Project out target user ratings: (item_id, target_score)
+        let target_items = target_user_ratings
+            .project(&[self.item_id_attr.as_str(), self.score_attr.as_str()])
+            .rename(&[(self.score_attr.as_str(), "target_score")]);
+
+        // Step 2: Find all other users who rated those same items.
+        // Join target_items (item_id, target_score) with all ratings (user_id, item_id, score).
+        // Result: (user_id, item_id, target_score, score)
+        let similar_users_items = target_items.join(&self.ratings)?;
+
+        // Exclude the target user themselves from the similar users.
+        let similar_users_items =
+            similar_users_items.restrict(|t| t.get(&self.user_id_attr) != Some(&target_user_id));
+
+        // Compute similarity between target user and other users based on co-rated items.
+        // Sim(U_target, U_other) = SUM(target_score * score) / sqrt(SUM(target_score^2) * SUM(score^2))
+        //
+        // First, extend to compute products
+        let products = similar_users_items
+            .extend("products", ScalarType::Float, |t| {
+                let s1 = t.get_typed::<f64>("target_score").unwrap_or(0.0);
+                let s2 = t.get_typed::<f64>(&self.score_attr).unwrap_or(0.0);
+                ScalarValue::Float(s1 * s2)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
+            .extend("sq_target", ScalarType::Float, |t| {
+                let s = t.get_typed::<f64>("target_score").unwrap_or(0.0);
+                ScalarValue::Float(s * s)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
+            .extend("sq_other", ScalarType::Float, |t| {
+                let s = t.get_typed::<f64>(&self.score_attr).unwrap_or(0.0);
+                ScalarValue::Float(s * s)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        // Summarize by user_id
+        let user_similarity_sums = products
+            .summarize(
+                &[self.user_id_attr.as_str()],
+                &[
+                    Aggregation::sum_float("sum_products", "products"),
+                    Aggregation::sum_float("sum_sq_target", "sq_target"),
+                    Aggregation::sum_float("sum_sq_other", "sq_other"),
+                ],
+            )
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        // Compute final similarity score for each user
+        let user_similarity = user_similarity_sums
+            .extend("similarity", ScalarType::Float, |t| {
+                let sum_prod = t.get_typed::<f64>("sum_products").unwrap_or(0.0);
+                let sum_sq_t = t.get_typed::<f64>("sum_sq_target").unwrap_or(0.0);
+                let sum_sq_o = t.get_typed::<f64>("sum_sq_other").unwrap_or(0.0);
+
+                let denom = (sum_sq_t * sum_sq_o).sqrt();
+                let sim = if denom == 0.0 { 0.0 } else { sum_prod / denom };
+                ScalarValue::Float(sim)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
+            .project(&[self.user_id_attr.as_str(), "similarity"]);
+
+        // Step 3: Find items rated by these similar users, but NOT by the target user.
+        // target_items_ids: (item_id)
+        let target_item_ids = target_items.project(&[self.item_id_attr.as_str()]);
+
+        // all_other_ratings: (user_id, item_id, score)
+        // Restrict out target user's own ratings.
+        let other_users_ratings = self
+            .ratings
+            .restrict(|t| t.get(&self.user_id_attr) != Some(&target_user_id));
+
+        // Filter out items the target user already rated.
+        // To do this, we join with all items NOT in target_item_ids.
+        // Relational algebra difference:
+        // unseen_item_ids = all_item_ids MINUS target_item_ids
+        let all_item_ids = self.ratings.project(&[self.item_id_attr.as_str()]);
+        let unseen_item_ids = all_item_ids
+            .difference(&target_item_ids)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        // Join to keep only ratings for unseen items
+        // unseen_ratings: (user_id, item_id, score)
+        let unseen_ratings = other_users_ratings.join(&unseen_item_ids)?;
+
+        // Step 4: Predict score for unseen items based on similar users' ratings.
+        // prediction = SUM(similarity * score) / SUM(ABS(similarity))
+        //
+        // Join user_similarity (user_id, similarity) with unseen_ratings (user_id, item_id, score)
+        // Result: (user_id, similarity, item_id, score)
+        let similarity_ratings = unseen_ratings.join(&user_similarity)?;
+
+        // Extend: sim_score = similarity * score, abs_sim = abs(similarity)
+        let extended_ratings = similarity_ratings
+            .extend("sim_score", ScalarType::Float, |t| {
+                let sim = t.get_typed::<f64>("similarity").unwrap_or(0.0);
+                let s = t.get_typed::<f64>(&self.score_attr).unwrap_or(0.0);
+                ScalarValue::Float(sim * s)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
+            .extend("abs_sim", ScalarType::Float, |t| {
+                let sim = t.get_typed::<f64>("similarity").unwrap_or(0.0);
+                ScalarValue::Float(sim.abs())
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        // Summarize by item_id
+        let item_predictions = extended_ratings
+            .summarize(
+                &[self.item_id_attr.as_str()],
+                &[
+                    Aggregation::sum_float("sum_sim_score", "sim_score"),
+                    Aggregation::sum_float("sum_abs_sim", "abs_sim"),
+                ],
+            )
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        // Final prediction calculation
+        let final_predictions = item_predictions
+            .extend("predicted_score", ScalarType::Float, |t| {
+                let num = t.get_typed::<f64>("sum_sim_score").unwrap_or(0.0);
+                let den = t.get_typed::<f64>("sum_abs_sim").unwrap_or(0.0);
+
+                let pred = if den == 0.0 { 0.0 } else { num / den };
+                ScalarValue::Float(pred)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
+            .project(&[self.item_id_attr.as_str(), "predicted_score"]);
+
+        Ok(final_predictions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use relvar_core::tuple;
+
+    #[test]
+    fn test_recommend_collaborative_filtering() {
+        // Schema: (user_id: Int, item_id: Int, rating: Float)
+        let heading = TupleType::new()
+            .with_attribute("user_id", ScalarType::Int)
+            .with_attribute("item_id", ScalarType::Int)
+            .with_attribute("rating", ScalarType::Float);
+
+        let mut ratings = Relation::new(RelationType::new(heading));
+
+        // Dataset
+        // User 1 likes items 1 and 2
+        ratings
+            .insert(tuple! { user_id: 1i64, item_id: 1i64, rating: 5.0 })
+            .unwrap();
+        ratings
+            .insert(tuple! { user_id: 1i64, item_id: 2i64, rating: 4.0 })
+            .unwrap();
+
+        // User 2 likes items 1, 2, and 3
+        ratings
+            .insert(tuple! { user_id: 2i64, item_id: 1i64, rating: 4.5 })
+            .unwrap();
+        ratings
+            .insert(tuple! { user_id: 2i64, item_id: 2i64, rating: 4.0 })
+            .unwrap();
+        ratings
+            .insert(tuple! { user_id: 2i64, item_id: 3i64, rating: 5.0 })
+            .unwrap();
+
+        // User 3 likes items 2 and 4
+        ratings
+            .insert(tuple! { user_id: 3i64, item_id: 2i64, rating: 3.5 })
+            .unwrap();
+        ratings
+            .insert(tuple! { user_id: 3i64, item_id: 4i64, rating: 4.0 })
+            .unwrap();
+
+        let recommender = CollaborativeFilter::new(ratings, "user_id", "item_id", "rating");
+
+        // Recommend for User 1
+        // User 1 has high similarity with User 2 (co-rated 1 and 2).
+        // User 2 rated item 3 high.
+        // User 1 has moderate similarity with User 3 (co-rated 2).
+        // User 3 rated item 4 high.
+        // Expect recommendations to include item 3 and 4.
+
+        let recs = recommender
+            .recommend_user_based(ScalarValue::Int(1))
+            .unwrap();
+
+        assert_eq!(recs.cardinality(), 2);
+
+        let mut recs_vec: Vec<_> = recs.tuples().collect();
+        // Sort by item_id just for deterministic assertion
+        recs_vec.sort_by_key(|t| t.get_typed::<i64>("item_id").unwrap());
+
+        let t3 = recs_vec[0];
+        assert_eq!(t3.get_typed::<i64>("item_id").unwrap(), 3);
+        assert!(t3.get_typed::<f64>("predicted_score").unwrap() > 4.0);
+
+        let t4 = recs_vec[1];
+        assert_eq!(t4.get_typed::<i64>("item_id").unwrap(), 4);
+        assert!(t4.get_typed::<f64>("predicted_score").unwrap() > 3.0);
+    }
+}


### PR DESCRIPTION
💡 **The Spark:** We have several analytical tools (graph, automl, matrix) implemented purely via relational operations. I noticed we don't have a way to generate recommendations from user-item interactions using these same declarative principles.

🚀 **The Feature:** Implemented `CollaborativeFilter` in `src/experimental/recommend.rs`. It provides a `recommend_user_based` method that uses purely relational algebra operators (`Join`, `Summarize`, `Extend`, `Difference`) to calculate user similarities and predict scores for unseen items, functioning as a complete User-Based Collaborative Filtering engine.

🔮 **The Potential:** Proves that complex analytical workloads, like recommendation engines, can be expressed declaratively using Codd's relational algebra, bridging the gap between transactional databases and analytical machine learning pipelines. We can run recommendations entirely inside the database without extracting data to Python.

⚠️ **Risk:** Low. Isolated in `src/experimental/recommend.rs` with unit tests covering a dummy recommendation scenario.

---
*PR created automatically by Jules for task [8362977660888721898](https://jules.google.com/task/8362977660888721898) started by @madmax983*