### PR TITLE
⚒️ Forge: Extract bulk constraint validation

### DIFF
--- a/relvar-core/src/constraints/manager.rs
+++ b/relvar-core/src/constraints/manager.rs
@@ -345,6 +345,19 @@ impl ConstraintManager {
         Ok(())
     }
 
+    /// Validate constraints that depend only on the tuple's content and foreign keys
+    /// against a full relation.
+    pub fn validate_tuple_content_constraints_bulk<E: StorageEngine>(
+        &self,
+        engine: &mut E,
+        relation_name: &str,
+        relation: &Relation,
+    ) -> Result<(), ConstraintManagerError> {
+        relation.tuples().try_for_each(|tuple| {
+            self.validate_tuple_content_constraints(engine, relation_name, tuple)
+        })
+    }
+
     /// Validate constraints that depend only on the tuple's content and foreign keys.
     ///
     /// This includes Type constraints, CHECK constraints, and Foreign Key constraints.

--- a/relvar-core/src/database/data.rs
+++ b/relvar-core/src/database/data.rs
@@ -250,13 +250,11 @@ impl<E: StorageEngine> Database<E> {
         // Validate other constraints (Type, CHECK, FK) on all tuples in the new relation
         // NOTE: In a production system we'd only validate changed tuples, but for now
         // we validate everything to ensure total consistency.
-        relation.tuples().try_for_each(|tuple| {
-            self.constraints.validate_tuple_content_constraints(
-                &mut self.engine,
-                relation_name,
-                tuple,
-            )
-        })?;
+        self.constraints.validate_tuple_content_constraints_bulk(
+            &mut self.engine,
+            relation_name,
+            relation,
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
🚮 Smell: `Database::validate_relation_constraints` manually iterating over tuples to perform bulk constraint validation, adding logic bloat to the `Database` God Object.
✨ Solution: Extracted the bulk tuple content validation logic into `ConstraintManager::validate_tuple_content_constraints_bulk`, matching the existing pattern of `validate_key_constraints_bulk`.
🧼 Benefit: Reduces the size of the `Database` struct, encapsulates constraint iteration logic inside `ConstraintManager`, and improves separation of concerns.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [2076219227644097674](https://jules.google.com/task/2076219227644097674) started by @madmax983*