### PR TITLE
⚡ Bolt: [performance improvement] Optimize heap allocations in group and ungroup algorithms

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -44,3 +44,7 @@ Without pre-allocating the vector for `extended_tuples` with `with_capacity()`, 
 ## 2026-03-09 - Double Reallocation in Relation Constructors
 **Learning:** `Relation::from_tuples_unchecked` consumed an iterator into a newly allocated `HashSet`. When operators like `extend` had already pre-allocated and built a `HashSet` of tuples, passing it to `from_tuples_unchecked` triggered an implicit `O(N)` loop to re-hash and re-allocate into a *second* `HashSet`, wasting CPU and memory bandwidth.
 **Action:** Created `Relation::from_body_unchecked` to directly take ownership of an existing `HashSet` when one is already available, achieving a true zero-cost transformation.
+
+## 2026-03-09 - Group Key and RVA Pre-allocation Optimization
+**Learning:** `compute_grouped_tuples` allocated and cloned heavy `ScalarValue` types repeatedly to build a `HashMap` key for each tuple, causing O(N_tuples) unnecessary allocations. `compute_ungrouped_tuples` lacked result vector pre-allocation based on the RVA cardinality.
+**Action:** Use `Vec<&'a ScalarValue>` as `HashMap` keys during aggregation passes. For collection transformations where sizes are variable but determinable (like ungrouping RVAs), always do an initial size accumulation pass to enable `Vec::with_capacity`.

--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -255,8 +255,8 @@ fn build_group_result_heading(
 /// Pre-allocates the `result_tuples` vector using `Vec::with_capacity(groups.len())`.
 /// Because the exact number of output tuples is known after grouping the input,
 /// this prevents dynamic heap reallocations when constructing the resulting relation.
-fn compute_grouped_tuples(
-    relation: &Relation,
+fn compute_grouped_tuples<'a>(
+    relation: &'a Relation,
     grouping_attrs: &[String],
     attrs_to_group: &[&str],
     result_heading: &TupleType,
@@ -266,13 +266,13 @@ fn compute_grouped_tuples(
     let rva_heading_arc = std::sync::Arc::new(rva_heading.clone());
     let result_heading_arc = std::sync::Arc::new(result_heading.clone());
 
-    let mut groups: HashMap<Vec<ScalarValue>, Vec<Tuple>> = HashMap::new();
+    let mut groups: HashMap<Vec<&'a ScalarValue>, Vec<Tuple>> = HashMap::new();
 
     for tuple in relation.tuples() {
         // Extract grouping key
-        let key: Vec<ScalarValue> = grouping_attrs
+        let key: Vec<&ScalarValue> = grouping_attrs
             .iter()
-            .map(|attr| tuple.get(attr).unwrap().clone())
+            .map(|attr| tuple.get(attr).unwrap())
             .collect();
 
         // Extract grouped attributes for RVA
@@ -294,7 +294,7 @@ fn compute_grouped_tuples(
 
         // Add grouping attribute values
         for (i, attr) in grouping_attrs.iter().enumerate() {
-            values.insert(attr.clone(), key[i].clone());
+            values.insert(attr.clone(), (*key[i]).clone());
         }
 
         // Create RVA relation
@@ -372,7 +372,16 @@ fn compute_ungrouped_tuples(
     result_heading: &TupleType,
     rva_relation_type: &RelationType,
 ) -> Result<Vec<Tuple>, UngroupError> {
-    let mut result_tuples = Vec::new();
+    // Perform an initial pass to sum the cardinality of the target RVAs
+    // to pre-allocate the exact needed capacity, avoiding dynamic heap reallocations.
+    let mut total_capacity = 0;
+    for tuple in relation.tuples() {
+        match tuple.get(rva_name).unwrap() {
+            ScalarValue::Relation(rel) => total_capacity += rel.cardinality(),
+            _ => return Err(UngroupError::NotRelationValued(rva_name.to_string())),
+        }
+    }
+    let mut result_tuples = Vec::with_capacity(total_capacity);
     let result_heading_arc = std::sync::Arc::new(result_heading.clone());
 
     for tuple in relation.tuples() {


### PR DESCRIPTION
💡 What: Reduced redundant cloning and allocations by converting grouping keys from `Vec<ScalarValue>` to `Vec<&ScalarValue>`. Additionally, implemented vector capacity pre-allocation in `compute_ungrouped_tuples`.
🎯 Why: Creating a `HashMap` key via `Vec<ScalarValue>` on every tuple evaluation required heavy heap allocations and cloning string payloads continuously across the grouping loop. Also, un-grouped results relied on dynamic `Vec` sizing.
📊 Impact: Reduces heap re-allocations substantially. Clones for groupings are shifted to the end of evaluation (from N_tuples to N_groups) and un-group reallocations are nullified.
🔬 Measurement: Run bench and `cargo test -p relvar-core -- group`.

---
*PR created automatically by Jules for task [10033083067286052930](https://jules.google.com/task/10033083067286052930) started by @madmax983*