### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/relvar-core/tests/sentry_tuple_type_coverage.rs
+++ b/relvar-core/tests/sentry_tuple_type_coverage.rs
@@ -1,14 +1,29 @@
-use relvar_core::types::{RelationType, ScalarType, TupleType};
+#[cfg(test)]
+mod tests {
+    use relvar_core::types::{ScalarType, TupleType};
 
-#[test]
-#[should_panic(expected = "Type nesting too deep")]
-fn test_tuple_type_depth_limit() {
-    let mut current_type = ScalarType::Int;
-    for i in 0..relvar_core::types::MAX_TYPE_DEPTH {
-        let heading = TupleType::new().with_attribute(format!("a{}", i), current_type);
-        current_type = ScalarType::Relation(Box::new(RelationType::new(heading)));
+    #[test]
+    #[should_panic(expected = "Type nesting too deep")]
+    fn test_tuple_type_with_attribute_nesting_too_deep() {
+        let mut ty = ScalarType::Int;
+
+        // Build up to exactly MAX_TYPE_DEPTH
+        // ScalarType::Int is depth 1
+        for i in 0..(relvar_core::types::MAX_TYPE_DEPTH - 1) {
+            ty = ScalarType::user_defined(format!("Type{}", i), ty);
+        }
+
+        // ty.depth() is now MAX_TYPE_DEPTH
+        assert_eq!(ty.depth(), relvar_core::types::MAX_TYPE_DEPTH);
+
+        // This should panic inside `with_attribute` because:
+        // ty.depth() + 1 = MAX_TYPE_DEPTH + 1 > MAX_TYPE_DEPTH
+        let _ = TupleType::new().with_attribute("attr", ty);
     }
 
-    // This should panic
-    let _ = TupleType::new().with_attribute("deep", current_type);
+    #[test]
+    fn test_tuple_type_default() {
+        let t = TupleType::default();
+        assert_eq!(t.degree(), 0);
+    }
 }


### PR DESCRIPTION
🎯 Target: `relvar-core/src/types/tuple_type.rs` (`TupleType::with_attribute` depth guard and `TupleType::default()`)
💣 Risk: Ensures the stack overflow prevention limit (`MAX_TYPE_DEPTH`) correctly panics when nesting limits are exceeded within attributes. Also guarantees `TupleType::default()` creates valid empty tuple types.
🧪 Strategy: Wrote integration tests that iteratively build `ScalarType` to the boundary limit and then attempt to assign it to an attribute via `with_attribute` asserting it `should_panic`. Added a unit test validating default initialization.
🔬 Verification: Run `cargo test --test sentry_tuple_type_coverage`

---
*PR created automatically by Jules for task [9898901838631802815](https://jules.google.com/task/9898901838631802815) started by @madmax983*