### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/relvar-core/src/database/integrity.rs
+++ b/relvar-core/src/database/integrity.rs
@@ -28,8 +28,6 @@ impl<E: StorageEngine> Database<E> {
     /// let current_constraints = db.get_key_constraints("TEST").unwrap();
     /// assert!(current_constraints.primary_key().is_some());
     /// ```
-    /// assert!(current_constraints.primary_key().is_some());
-    /// ```
     pub fn get_key_constraints(&self, relation_name: &str) -> Option<&KeyConstraints> {
         self.constraints.get_key_constraints(relation_name)
     }


### PR DESCRIPTION
📖 Chapter: `database/integrity`
🔦 Insight: Cleaned up a redundant code block inside `get_key_constraints` that was triggering an invalid empty rust code block warning, ensuring cleaner `cargo doc` output.
🧪 Example: Removed duplicate code block and assert statement from `get_key_constraints` doc test.
🖼️ Preview: Documentation for `get_key_constraints` now properly renders without rustdoc empty block warnings.

---
*PR created automatically by Jules for task [524295070275805722](https://jules.google.com/task/524295070275805722) started by @madmax983*