### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -62,3 +62,7 @@
 ## 2025-03-16 - Virtual Relvars Evaluation and Database Error Coverage
 **Learning:** Found several untested code paths regarding the mutability limitations of `VirtualRelvarDefinition` (preventing mutation because `evaluator` takes an immutable reference but error mapping missing tests), and transaction nesting issues inside `relvar-core/src/database/mod.rs` mapping to `DatabaseError::TransactionError`.
 **Action:** When working on APIs containing view-like concepts (`virtual_relvars`), ensure the evaluation error paths are fully tested. When implementing Database transactions, ensure explicit testing for double-begin and missing-begin cases for commits and rollbacks.
+
+## 2025-03-20 - Unvalidated Referencing Foreign Keys on Update
+**Learning:** `Database::update` in `relvar-core/src/database/data.rs` applies updates and validates the updated relation against its own constraints, but crucially forgets to validate referencing foreign keys (i.e. if this relation is a parent to another relation, and a primary key was updated, the child relation's foreign keys might be violated). The `delete` method correctly calls `self.constraints.validate_referencing_foreign_keys`, but `update` does not.
+**Action:** Always validate `validate_referencing_foreign_keys` in both `delete` and `update` logic paths for relational systems.

--- a/relvar-core/src/database/data.rs
+++ b/relvar-core/src/database/data.rs
@@ -193,6 +193,12 @@ impl<E: StorageEngine> Database<E> {
 
         self.validate_relation_constraints(relation_name, &new_relation)?;
 
+        self.constraints.validate_referencing_foreign_keys(
+            &mut self.engine,
+            relation_name,
+            &new_relation,
+        )?;
+
         // Store the new relation
         self.engine.store_relation(relation_name, &new_relation)?;
         Ok(update_count)

--- a/relvar-core/tests/sentry_database_data_coverage.rs
+++ b/relvar-core/tests/sentry_database_data_coverage.rs
@@ -136,3 +136,150 @@ fn test_database_insert_duplicate_primary_key() {
     assert!(result.is_err());
     assert!(matches!(result, Err(DatabaseError::Constraint(_))));
 }
+
+#[test]
+fn test_database_update_referencing_foreign_keys_violation() {
+    let mut db = setup();
+
+    // Create parent table (TEST is already created)
+
+    // Create child table
+    let child_type = RelationType::new(
+        TupleType::new()
+            .with_attribute("child_id", ScalarType::Int)
+            .with_attribute("test_id", ScalarType::Int),
+    );
+    db.create_relvar("CHILD", child_type).unwrap();
+
+    let fk = relvar_core::constraints::ForeignKey::new(
+        vec!["test_id".to_string()],
+        "TEST".to_string(),
+        vec!["id".to_string()],
+    )
+    .unwrap();
+    let fk_constraints =
+        relvar_core::constraints::ForeignKeyConstraints::new().with_foreign_key(fk);
+    db.set_foreign_key_constraints("CHILD", fk_constraints)
+        .unwrap();
+
+    db.insert("CHILD", tuple! { child_id: 100i64, test_id: 1i64 })
+        .unwrap();
+
+    // This update should fail due to foreign key constraint (updating the PK of the parent which is referenced)
+    let result = db.update(
+        "TEST",
+        |t| t.get_typed::<i64>("id").unwrap() == 1,
+        |_t| tuple! { id: 2i64, val: 10i64 },
+    );
+    assert!(result.is_err());
+    assert!(matches!(result, Err(DatabaseError::Constraint(_))));
+}
+
+#[test]
+fn test_database_update_key_constraint_violation() {
+    let mut db = setup();
+
+    let pk = relvar_core::constraints::PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let key_constraints = relvar_core::constraints::KeyConstraints::new().with_primary_key(pk);
+    db.set_key_constraints("TEST", key_constraints).unwrap();
+
+    db.insert("TEST", tuple! { id: 2i64, val: 20i64 }).unwrap();
+
+    // Update should fail due to duplicate primary key
+    let result = db.update(
+        "TEST",
+        |t| t.get_typed::<i64>("id").unwrap() == 2,
+        |_t| tuple! { id: 1i64, val: 20i64 }, // duplicate id 1
+    );
+    assert!(result.is_err());
+    assert!(matches!(result, Err(DatabaseError::Constraint(_))));
+}
+
+#[test]
+fn test_database_update_check_constraint_violation() {
+    let mut db = setup();
+
+    let check_expr = ConstraintExpression::Cmp {
+        left: "val".to_string(),
+        op: CmpOp::Gt,
+        right: ValueOrRef::Value(ScalarValue::Int(0)),
+    };
+    let checks = CheckConstraints::new().with_constraint(CheckConstraint::new(
+        "val_positive".to_string(),
+        "must be positive".to_string(),
+        check_expr,
+    ));
+    db.set_check_constraints("TEST", checks).unwrap();
+
+    // Update should fail due to check constraint
+    let result = db.update(
+        "TEST",
+        |t| t.get_typed::<i64>("id").unwrap() == 1,
+        |_t| tuple! { id: 1i64, val: -10i64 },
+    );
+    assert!(result.is_err());
+    assert!(matches!(result, Err(DatabaseError::Constraint(_))));
+}
+
+#[test]
+fn test_database_insert_foreign_key_violation() {
+    let mut db = setup();
+
+    let child_type = RelationType::new(
+        TupleType::new()
+            .with_attribute("child_id", ScalarType::Int)
+            .with_attribute("test_id", ScalarType::Int),
+    );
+    db.create_relvar("CHILD", child_type).unwrap();
+
+    let fk = relvar_core::constraints::ForeignKey::new(
+        vec!["test_id".to_string()],
+        "TEST".to_string(),
+        vec!["id".to_string()],
+    )
+    .unwrap();
+    let fk_constraints =
+        relvar_core::constraints::ForeignKeyConstraints::new().with_foreign_key(fk);
+    db.set_foreign_key_constraints("CHILD", fk_constraints)
+        .unwrap();
+
+    // Insert should fail due to missing parent key (id = 999)
+    let result = db.insert("CHILD", tuple! { child_id: 100i64, test_id: 999i64 });
+    assert!(result.is_err());
+    assert!(matches!(result, Err(DatabaseError::Constraint(_))));
+}
+
+#[test]
+fn test_database_update_foreign_key_violation() {
+    let mut db = setup();
+
+    let child_type = RelationType::new(
+        TupleType::new()
+            .with_attribute("child_id", ScalarType::Int)
+            .with_attribute("test_id", ScalarType::Int),
+    );
+    db.create_relvar("CHILD", child_type).unwrap();
+
+    let fk = relvar_core::constraints::ForeignKey::new(
+        vec!["test_id".to_string()],
+        "TEST".to_string(),
+        vec!["id".to_string()],
+    )
+    .unwrap();
+    let fk_constraints =
+        relvar_core::constraints::ForeignKeyConstraints::new().with_foreign_key(fk);
+    db.set_foreign_key_constraints("CHILD", fk_constraints)
+        .unwrap();
+
+    db.insert("CHILD", tuple! { child_id: 100i64, test_id: 1i64 })
+        .unwrap();
+
+    // Update should fail due to missing parent key (id = 999)
+    let result = db.update(
+        "CHILD",
+        |t| t.get_typed::<i64>("child_id").unwrap() == 100,
+        |_t| tuple! { child_id: 100i64, test_id: 999i64 },
+    );
+    assert!(result.is_err());
+    assert!(matches!(result, Err(DatabaseError::Constraint(_))));
+}


### PR DESCRIPTION
🎯 Target: `Database::update` in `relvar-core/src/database/data.rs`
💣 Risk: Updating a parent relation's primary key without validating referencing child relations could lead to orphaned records and broken relational integrity.
🧪 Strategy: Added the missing `self.constraints.validate_referencing_foreign_keys` validation step during the `update` process, mirroring the logic found in `delete`. Added exhaustive tests for all update constraints, including the referencing foreign key violation.
🔬 Verification: Run `cargo test -p relvar-core --test sentry_database_data_coverage` to verify constraints are properly handled during updates.

---
*PR created automatically by Jules for task [14764933531320714434](https://jules.google.com/task/14764933531320714434) started by @madmax983*