### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -62,3 +62,6 @@ This ensures the map matches the territory.
 ## 2024-06-03 - Cargo Doc Warnings Fixed
 **Confusion:** Rustdoc was emitting warnings because of redundant explicit link targets and an empty rust code block.
 **Clarification:** I updated `relvar-core/src/query/mod.rs` to remove redundant explicit links, letting rustdoc infer the link from the label name (`[`Database`]`). In `relvar-core/src/utils/recursion.rs`, I added the `text` modifier to a non-rust code block (conceptual example) so that it isn't parsed as valid Rust.
+## 2024-06-03 - Replaced "Returns the" noise with descriptive verbs
+**Confusion:** Some simple getter functions in `relvar-storage` (`storage/page.rs`, `storage/catalog.rs`) had auto-generated boilerplate `/// Returns the...` or `/// Returns a...` comments, providing zero semantic value.
+**Clarification:** I updated these getters (`data` and `list_relations`) with precise verbs and context, explaining what information is retrieved or exposed, fully eradicating this boilerplate pattern.

--- a/relvar-storage/src/storage/catalog.rs
+++ b/relvar-storage/src/storage/catalog.rs
@@ -269,7 +269,7 @@ impl Catalog {
             .ok_or_else(|| CatalogError::RelationNotFound(name.to_string()))
     }
 
-    /// Returns a list of all relation names in the catalog.
+    /// Retrieves a list of all relation names currently tracked by the catalog.
     ///
     /// The order of names is not guaranteed (hash map iteration order).
     pub fn list_relations(&self) -> Vec<String> {

--- a/relvar-storage/src/storage/page.rs
+++ b/relvar-storage/src/storage/page.rs
@@ -173,7 +173,7 @@ impl Page {
         self.id
     }
 
-    /// Returns a reference to the page's data.
+    /// Exposes the underlying byte array of the page for reading.
     pub fn data(&self) -> &[u8] {
         &self.data
     }


### PR DESCRIPTION
📖 **Chapter**: `relvar-storage` (Catalog and Page modules)
🔦 **Insight**: Boilerplate documentation like "Returns the x" provides zero semantic value and violates the Bard persona's rule against noisy getters. These have been eradicated in favor of descriptive context ("Retrieves a list of...", "Exposes the underlying byte array...").
🧪 **Example**: `Catalog::list_relations` and `Page::data` documentation updated.
🖼️ **Preview**: Verified locally with `cargo doc --no-deps`.

---
*PR created automatically by Jules for task [850678430296392099](https://jules.google.com/task/850678430296392099) started by @madmax983*