### PR TITLE
⚡ Bolt: Add into methods for union, difference and intersect

### DIFF
--- a/relvar-core/src/algebra/difference.rs
+++ b/relvar-core/src/algebra/difference.rs
@@ -149,6 +149,28 @@ impl Relation {
     pub fn minus(&self, other: &Relation) -> Result<Self, DifferenceError> {
         self.difference(other)
     }
+
+    /// Computes the set difference of this relation with another, consuming this relation.
+    ///
+    /// This is an optimized version of `difference` that avoids O(N) tuple clones for the
+    /// first relation by consuming it.
+    pub fn difference_into(self, other: &Relation) -> Result<Self, DifferenceError> {
+        // Check type compatibility
+        if self.relation_type() != other.relation_type() {
+            return Err(DifferenceError::TypeMismatch);
+        }
+
+        let rel_type = self.relation_type().clone();
+        Ok(Relation::from_tuples_unchecked(
+            rel_type,
+            self.into_iter().filter(|tuple| !other.contains(tuple)),
+        ))
+    }
+
+    /// Alias for [`difference_into`](Self::difference_into) with SQL-style naming.
+    pub fn minus_into(self, other: &Relation) -> Result<Self, DifferenceError> {
+        self.difference_into(other)
+    }
 }
 
 #[cfg(test)]
@@ -262,6 +284,48 @@ mod tests {
         rel2.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
 
         let result = rel1.minus(&rel2).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_difference_into_returns_tuples_in_first_but_not_second() {
+        let heading = emp_type();
+        let rel_type = RelationType::new(heading);
+
+        let mut rel1 = Relation::new(rel_type.clone());
+        rel1.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+        rel1.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+        rel1.insert(tuple! { emp_id: 3i64, name: "Charlie" })
+            .unwrap();
+
+        let mut rel2 = Relation::new(rel_type);
+        rel2.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+        rel2.insert(tuple! { emp_id: 4i64, name: "David" }).unwrap();
+
+        let result = rel1.difference_into(&rel2).unwrap();
+
+        assert_eq!(result.cardinality(), 2); // Alice and Charlie
+
+        let alice = tuple! { emp_id: 1i64, name: "Alice" };
+        let charlie = tuple! { emp_id: 3i64, name: "Charlie" };
+
+        assert!(result.contains(&alice));
+        assert!(result.contains(&charlie));
+        assert!(!result.contains(&tuple! { emp_id: 2i64, name: "Bob" }));
+    }
+
+    #[test]
+    fn test_minus_into_alias() {
+        let heading = emp_type();
+        let rel_type = RelationType::new(heading);
+
+        let mut rel1 = Relation::new(rel_type.clone());
+        rel1.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+
+        let mut rel2 = Relation::new(rel_type);
+        rel2.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+
+        let result = rel1.minus_into(&rel2).unwrap();
         assert!(result.is_empty());
     }
 }

--- a/relvar-core/src/algebra/intersect.rs
+++ b/relvar-core/src/algebra/intersect.rs
@@ -119,6 +119,23 @@ impl Relation {
             self.tuples().filter(|tuple| other.contains(tuple)).cloned(),
         ))
     }
+
+    /// Computes the intersection of this relation with another, consuming this relation.
+    ///
+    /// This is an optimized version of `intersect` that avoids O(N) tuple clones for the
+    /// first relation by consuming it.
+    pub fn intersect_into(self, other: &Relation) -> Result<Self, IntersectError> {
+        // Check type compatibility
+        if self.relation_type() != other.relation_type() {
+            return Err(IntersectError::TypeMismatch);
+        }
+
+        let rel_type = self.relation_type().clone();
+        Ok(Relation::from_tuples_unchecked(
+            rel_type,
+            self.into_iter().filter(|tuple| other.contains(tuple)),
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -220,5 +237,33 @@ mod tests {
 
         let result = rel1.intersect(&rel1).unwrap();
         assert_eq!(result, rel1);
+    }
+
+    #[test]
+    fn test_intersect_into_returns_common_tuples() {
+        let heading = emp_type();
+        let rel_type = RelationType::new(heading);
+
+        let mut rel1 = Relation::new(rel_type.clone());
+        rel1.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+        rel1.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+        rel1.insert(tuple! { emp_id: 3i64, name: "Charlie" })
+            .unwrap();
+
+        let mut rel2 = Relation::new(rel_type);
+        rel2.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+        rel2.insert(tuple! { emp_id: 3i64, name: "Charlie" })
+            .unwrap();
+        rel2.insert(tuple! { emp_id: 4i64, name: "David" }).unwrap();
+
+        let result = rel1.intersect_into(&rel2).unwrap();
+
+        assert_eq!(result.cardinality(), 2); // Bob and Charlie
+
+        let bob = tuple! { emp_id: 2i64, name: "Bob" };
+        let charlie = tuple! { emp_id: 3i64, name: "Charlie" };
+
+        assert!(result.contains(&bob));
+        assert!(result.contains(&charlie));
     }
 }

--- a/relvar-core/src/algebra/restrict.rs
+++ b/relvar-core/src/algebra/restrict.rs
@@ -90,6 +90,7 @@ impl Relation {
             self.tuples().filter(|tuple| predicate(tuple)).cloned(),
         )
     }
+
 }
 
 #[cfg(test)]
@@ -196,4 +197,6 @@ mod tests {
         assert_eq!(result.cardinality(), 2);
         assert_eq!(result, relation);
     }
+
+
 }

--- a/relvar-core/src/algebra/restrict.rs
+++ b/relvar-core/src/algebra/restrict.rs
@@ -90,7 +90,6 @@ impl Relation {
             self.tuples().filter(|tuple| predicate(tuple)).cloned(),
         )
     }
-
 }
 
 #[cfg(test)]
@@ -197,6 +196,4 @@ mod tests {
         assert_eq!(result.cardinality(), 2);
         assert_eq!(result, relation);
     }
-
-
 }

--- a/relvar-core/src/algebra/union.rs
+++ b/relvar-core/src/algebra/union.rs
@@ -113,6 +113,23 @@ impl Relation {
             self.tuples().chain(other.tuples()).cloned(),
         ))
     }
+
+    /// Computes the union of this relation with another, consuming this relation.
+    ///
+    /// This is an optimized version of `union` that avoids O(N) tuple clones for the
+    /// first relation by consuming it.
+    pub fn union_into(mut self, other: &Relation) -> Result<Self, UnionError> {
+        // Check type compatibility
+        if self.relation_type() != other.relation_type() {
+            return Err(UnionError::TypeMismatch);
+        }
+
+        for tuple in other.tuples() {
+            self.insert(tuple.clone()).unwrap();
+        }
+
+        Ok(self)
+    }
 }
 
 #[cfg(test)]
@@ -215,5 +232,32 @@ mod tests {
         let result = rel1.union(&rel1).unwrap();
         assert_eq!(result.cardinality(), 2); // No duplicates
         assert_eq!(result, rel1);
+    }
+
+    #[test]
+    fn test_union_into_removes_duplicates() {
+        let heading = emp_type();
+        let rel_type = RelationType::new(heading);
+
+        let mut rel1 = Relation::new(rel_type.clone());
+        rel1.insert(tuple! { emp_id: 1i64, name: "Alice" }).unwrap();
+        rel1.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
+
+        let mut rel2 = Relation::new(rel_type);
+        rel2.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap(); // Duplicate
+        rel2.insert(tuple! { emp_id: 3i64, name: "Charlie" })
+            .unwrap();
+
+        let result = rel1.union_into(&rel2).unwrap();
+
+        assert_eq!(result.cardinality(), 3); // Alice, Bob, Charlie (Bob not duplicated)
+
+        let alice = tuple! { emp_id: 1i64, name: "Alice" };
+        let bob = tuple! { emp_id: 2i64, name: "Bob" };
+        let charlie = tuple! { emp_id: 3i64, name: "Charlie" };
+
+        assert!(result.contains(&alice));
+        assert!(result.contains(&bob));
+        assert!(result.contains(&charlie));
     }
 }


### PR DESCRIPTION
💡 What: Added `union_into`, `difference_into` and `intersect_into` methods
to `Relation`.
🎯 Why: These relational algebra operators currently take references to
both relations and clone the tuples that end up in the result. In many
contexts like query evaluation, the left-hand relation can be consumed,
allowing us to re-use its allocated structure and avoid `O(N)` `.clone()`
operations.
📊 Impact: Avoids `O(N)` heap allocations and hash map inserts for each of
these operators when chained.
🔬 Measurement: Run `cargo test` and verify that the tests pass.

---
*PR created automatically by Jules for task [15035259593647964372](https://jules.google.com/task/15035259593647964372) started by @madmax983*