### PR TITLE
⚒️ Forge: [Refactor God Functions in Collaborative Filter]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -537,3 +537,7 @@ Build it right, make it fast, keep it simple.
 ## 2026-03-14 - Extract Complex Type Comparison Logic
 **Learning:** `Ord::cmp` implementations in `relvar-core/src/types/scalar.rs` (`ScalarType`) and `relvar-core/src/values/scalar.rs` (`ScalarValue`) had deeply nested `match` branches (up to 12 levels) for complex variant comparisons like `Relation` and `UserDefined`.
 **Action:** Replace nested `match` inside `Ord::cmp` with a guard clause on discriminant/type mismatch first, and then extract complex variant match arms into private helper functions like `cmp_relation_types` and `cmp_user_defined_types`.
+
+## 2025-06-05 - Collaborative Filtering God Functions
+**Learning:** `relvar/src/experimental/recommend.rs` contained "God Functions" (`compute_user_similarities` and `predict_unseen_items`) that handled multiple complex relational algebra operations in a single block, making them hard to read and test.
+**Action:** Applied the "Three-Phase Operator" pattern to extract logic into private helper methods (`compute_similarity_products`, `summarize_and_calculate_similarity`, `compute_prediction_components`, `summarize_and_calculate_predictions`) to improve clarity and maintainability.

--- a/relvar/src/experimental/recommend.rs
+++ b/relvar/src/experimental/recommend.rs
@@ -94,24 +94,16 @@ impl CollaborativeFilter {
         self.predict_unseen_items(user_similarity, unseen_ratings)
     }
 
-    fn compute_user_similarities(
+    fn compute_similarity_products(
         &self,
         target_user_id: &ScalarValue,
         target_items: &Relation,
     ) -> Result<Relation, DatabaseError> {
-        // Join target_items (item_id, target_score) with all ratings (user_id, item_id, score).
-        // Result: (user_id, item_id, target_score, score)
         let similar_users_items = target_items.join(&self.ratings)?;
-
-        // Exclude the target user themselves from the similar users.
         let similar_users_items =
             similar_users_items.restrict(|t| t.get(&self.user_id_attr) != Some(target_user_id));
 
-        // Compute similarity between target user and other users based on co-rated items.
-        // Sim(U_target, U_other) = SUM(target_score * score) / sqrt(SUM(target_score^2) * SUM(score^2))
-        //
-        // First, extend to compute products
-        let products = similar_users_items
+        similar_users_items
             .extend("products", ScalarType::Float, |t| {
                 let s1 = t.get_typed::<f64>("target_score").unwrap_or(0.0);
                 let s2 = t.get_typed::<f64>(&self.score_attr).unwrap_or(0.0);
@@ -127,9 +119,13 @@ impl CollaborativeFilter {
                 let s = t.get_typed::<f64>(&self.score_attr).unwrap_or(0.0);
                 ScalarValue::Float(s * s)
             })
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
 
-        // Summarize by user_id
+    fn summarize_and_calculate_similarity(
+        &self,
+        products: Relation,
+    ) -> Result<Relation, DatabaseError> {
         let user_similarity_sums = products
             .summarize(
                 &[self.user_id_attr.as_str()],
@@ -141,7 +137,6 @@ impl CollaborativeFilter {
             )
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
-        // Compute final similarity score for each user
         user_similarity_sums
             .extend("similarity", ScalarType::Float, |t| {
                 let sum_prod = t.get_typed::<f64>("sum_products").unwrap_or(0.0);
@@ -154,6 +149,15 @@ impl CollaborativeFilter {
             })
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
             .map(|r| r.project(&[self.user_id_attr.as_str(), "similarity"]))
+    }
+
+    fn compute_user_similarities(
+        &self,
+        target_user_id: &ScalarValue,
+        target_items: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        let products = self.compute_similarity_products(target_user_id, target_items)?;
+        self.summarize_and_calculate_similarity(products)
     }
 
     fn find_unseen_ratings(
@@ -184,19 +188,14 @@ impl CollaborativeFilter {
         other_users_ratings.join(&unseen_item_ids)
     }
 
-    fn predict_unseen_items(
+    fn compute_prediction_components(
         &self,
         user_similarity: Relation,
         unseen_ratings: Relation,
     ) -> Result<Relation, DatabaseError> {
-        // prediction = SUM(similarity * score) / SUM(ABS(similarity))
-        //
-        // Join user_similarity (user_id, similarity) with unseen_ratings (user_id, item_id, score)
-        // Result: (user_id, similarity, item_id, score)
         let similarity_ratings = unseen_ratings.join(&user_similarity)?;
 
-        // Extend: sim_score = similarity * score, abs_sim = abs(similarity)
-        let extended_ratings = similarity_ratings
+        similarity_ratings
             .extend("sim_score", ScalarType::Float, |t| {
                 let sim = t.get_typed::<f64>("similarity").unwrap_or(0.0);
                 let s = t.get_typed::<f64>(&self.score_attr).unwrap_or(0.0);
@@ -207,9 +206,13 @@ impl CollaborativeFilter {
                 let sim = t.get_typed::<f64>("similarity").unwrap_or(0.0);
                 ScalarValue::Float(sim.abs())
             })
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
 
-        // Summarize by item_id
+    fn summarize_and_calculate_predictions(
+        &self,
+        extended_ratings: Relation,
+    ) -> Result<Relation, DatabaseError> {
         let item_predictions = extended_ratings
             .summarize(
                 &[self.item_id_attr.as_str()],
@@ -220,7 +223,6 @@ impl CollaborativeFilter {
             )
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
-        // Final prediction calculation
         item_predictions
             .extend("predicted_score", ScalarType::Float, |t| {
                 let num = t.get_typed::<f64>("sum_sim_score").unwrap_or(0.0);
@@ -231,6 +233,16 @@ impl CollaborativeFilter {
             })
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
             .map(|r| r.project(&[self.item_id_attr.as_str(), "predicted_score"]))
+    }
+
+    fn predict_unseen_items(
+        &self,
+        user_similarity: Relation,
+        unseen_ratings: Relation,
+    ) -> Result<Relation, DatabaseError> {
+        let extended_ratings =
+            self.compute_prediction_components(user_similarity, unseen_ratings)?;
+        self.summarize_and_calculate_predictions(extended_ratings)
     }
 }
 


### PR DESCRIPTION
🚮 **Smell**: `compute_user_similarities` and `predict_unseen_items` were "God Functions", managing multiple phases of complex relational algebra operators in single blocks, hurting readability.
✨ **Solution**: Applied the "Three-Phase Operator" pattern. Extracted core calculation paths into private helper methods (`compute_similarity_products`, `summarize_and_calculate_similarity`, `compute_prediction_components`, `summarize_and_calculate_predictions`).
🧼 **Benefit**: Flattens nested logic, clearly segregating join/extend operations from summarization operations. Eases future unit testing.
🛡️ **Verification**: Tests passed successfully. No logic changed.

---
*PR created automatically by Jules for task [10844505028024838119](https://jules.google.com/task/10844505028024838119) started by @madmax983*