### PR TITLE
🪒 Razor: Replace OperationType enum with simple bool

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -2,3 +2,8 @@
 **Bloat:** Empty `ImageProcessor` and `Tokenizer` structs acting purely as namespaces for static methods (Enterprise FizzBuzz "God Struct" style).
 **Cut:** Removed the empty structs and `impl` blocks, changing the static methods into module-level free functions. Updated usage sites.
 **Saved:** Reduced boilerplate, improved clarity, explicit module-level function calls instead of Object-Oriented faux namespaces.
+
+## [Reduction]
+**Bloat:** `OperationType` enum with only `Insert` and `Update` variants in `relvar-storage/src/storage/heap.rs`.
+**Cut:** Replaced `OperationType` enum with a simple `bool` flag (`is_update: bool`) since it only had two states.
+**Saved:** Removed enum definition and simplified pattern matching.

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -56,13 +56,6 @@ pub(crate) struct TupleId {
     pub(crate) slot: u32,
 }
 
-/// Operation type for size checking (Insert vs Update)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OperationType {
-    Insert,
-    Update,
-}
-
 /// Errors that can occur during heap file operations.
 #[derive(Debug, Error)]
 pub enum HeapError {
@@ -766,7 +759,7 @@ impl HeapFile {
 
         // Check if tuple is too large to ever fit
         // New inserts have no previous version (prev_version = None)
-        self.check_versioned_tuple_size_limit(tuple_data.len(), OperationType::Insert)?;
+        self.check_versioned_tuple_size_limit(tuple_data.len(), false)?;
 
         // Find a page with enough space, or create a new one
         self.find_page_for_insertion(|heap, page_id| {
@@ -779,7 +772,7 @@ impl HeapFile {
     fn check_versioned_tuple_size_limit(
         &self,
         tuple_data_len: usize,
-        op_type: OperationType,
+        is_update: bool,
     ) -> Result<(), HeapError> {
         // Create a dummy versioned page with one slot
         let dummy_page = VersionedSlottedPage {
@@ -790,12 +783,13 @@ impl HeapFile {
                 length: tuple_data_len as u32,
                 xmin: crate::wal::TransactionId::new(0),
                 xmax: None,
-                prev_version: match op_type {
-                    OperationType::Update => Some(TupleId {
+                prev_version: if is_update {
+                    Some(TupleId {
                         page_id: 0,
                         slot: 0,
-                    }),
-                    OperationType::Insert => None,
+                    })
+                } else {
+                    None
                 },
             })],
         };
@@ -1134,7 +1128,7 @@ impl HeapFile {
 
         // Check if new tuple is too large
         // Updates link to previous version (prev_version = Some(...))
-        self.check_versioned_tuple_size_limit(new_tuple_data.len(), OperationType::Update)?;
+        self.check_versioned_tuple_size_limit(new_tuple_data.len(), true)?;
 
         // Find a page with space for new version
         self.find_page_for_insertion(|heap, page_id| {
@@ -3620,12 +3614,12 @@ mod security_tests {
 
             // Check if it fits with None (insert)
             let fits_insert = heap
-                .check_versioned_tuple_size_limit(tuple_data_len, OperationType::Insert)
+                .check_versioned_tuple_size_limit(tuple_data_len, false)
                 .is_ok();
 
             // Check if it fits with Some (update)
             let fits_update = heap
-                .check_versioned_tuple_size_limit(tuple_data_len, OperationType::Update)
+                .check_versioned_tuple_size_limit(tuple_data_len, true)
                 .is_ok();
 
             if fits_insert && !fits_update {


### PR DESCRIPTION
Replaced enum `OperationType` with simple `bool` to enforce KISS.

---
*PR created automatically by Jules for task [7381694288254415913](https://jules.google.com/task/7381694288254415913) started by @madmax983*