### PR TITLE
🔒 Warden: [Fix silent failure in Query::Restrict execution]

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -194,3 +194,12 @@ The `WalManager` component in `relvar-storage` used `File::read_to_end(&mut buff
 
 **Defense:**
 Added strict file size limits before reading the WAL file. `WalManager` now checks the file metadata length against `MAX_WAL_SIZE` (set to a safe threshold of 2 GB) and returns a standard `std::io::Error::new(std::io::ErrorKind::InvalidData)` wrapped in a `WalError::Io` if the limit is exceeded. This prevents unbounded `Vec` pre-allocations from malicious or overgrown files.
+
+## 2026-03-08 - Query::Restrict Silent Failure (Logic Bug)
+**Threat:**
+The `Query::execute` implementation for `Query::Restrict` used `unwrap_or_default()` to handle errors from evaluating constraint expressions (`prepared.evaluate(tuple)`).
+If an expression failed to evaluate (e.g., due to a type mismatch or a missing attribute), the error was silently swallowed, and the result was treated as `false` (excluding the tuple). This "fail-open" or silent failure logic could hide critical schema inconsistencies, bypass security checks, or corrupt expected datasets without logging any warnings or raising an error to the caller.
+
+**Defense:**
+Refactored the closure passed to `Relation::restrict_into` to explicitly check the `Result` of `prepared.evaluate(tuple)`. If an error occurs, it captures the first evaluation error into a mutable variable (`eval_error`) in the outer scope, and then propagates that error up the call stack as `QueryError::Constraint` after the iteration completes.
+Added a regression test `warden_query_restrict_error.rs` to verify that both type mismatches and missing attributes correctly halt execution and return an `Err`.

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -172,15 +172,29 @@ impl Query {
             Query::Scan(table_name) => Ok(db.query(table_name)?),
             Query::Restrict { input, predicate } => {
                 let relation = input.execute(db)?;
-                // Note: Relation::restrict takes a closure that returns bool.
-                // We use evaluate() inside, but we must handle errors.
-                // Currently, we treat evaluation errors as false (exclude tuple).
 
                 // Pre-compute optimized structures (HashSet for IN, Vec<char> for LIKE)
                 // This prevents O(N*M) behavior for large IN lists or LIKE patterns
                 let prepared = predicate.prepare();
-                let result = relation
-                    .restrict_into(move |tuple| prepared.evaluate(tuple).unwrap_or_default());
+
+                // Manually restrict the relation to handle and propagate evaluation errors
+                let mut eval_error = None;
+                let result = relation.restrict_into(|tuple| {
+                    match prepared.evaluate(tuple) {
+                        Ok(res) => res,
+                        Err(e) => {
+                            if eval_error.is_none() {
+                                eval_error = Some(e);
+                            }
+                            false // Treat as false to continue, but we'll error out anyway
+                        }
+                    }
+                });
+
+                if let Some(err) = eval_error {
+                    return Err(QueryError::Constraint(err));
+                }
+
                 Ok(result)
             }
             Query::Project { input, attributes } => {

--- a/relvar-core/tests/warden_query_restrict_error.rs
+++ b/relvar-core/tests/warden_query_restrict_error.rs
@@ -1,0 +1,41 @@
+use relvar_core::query::Query;
+use relvar_core::constraints::{ConstraintExpression, CmpOp, ValueOrRef};
+use relvar_core::values::ScalarValue;
+use relvar_core::types::{RelationType, TupleType, ScalarType};
+use relvar_core::database::Database;
+use relvar_core::storage_engine::InMemoryEngine;
+use relvar_core::tuple;
+
+#[test]
+fn test_query_restrict_propagates_errors() {
+    let mut db = Database::new(InMemoryEngine::new());
+
+    let heading = TupleType::new()
+        .with_attribute("id", ScalarType::Int)
+        .with_attribute("name", ScalarType::String);
+
+    db.create_relvar("USERS", RelationType::new(heading)).unwrap();
+    db.insert("USERS", tuple! { id: 1i64, name: "Alice" }).unwrap();
+
+    // Type mismatch error
+    let query = Query::scan("USERS")
+        .restrict(ConstraintExpression::Cmp {
+            left: "name".to_string(),
+            op: CmpOp::Eq,
+            right: ValueOrRef::Value(ScalarValue::Int(1)),
+        });
+
+    let result = query.execute(&db);
+    assert!(result.is_err());
+
+    // Attribute not found error
+    let query_missing = Query::scan("USERS")
+        .restrict(ConstraintExpression::Cmp {
+            left: "missing_attr".to_string(),
+            op: CmpOp::Eq,
+            right: ValueOrRef::Value(ScalarValue::Int(1)),
+        });
+
+    let result_missing = query_missing.execute(&db);
+    assert!(result_missing.is_err());
+}

--- a/relvar-core/tests/warden_query_restrict_error.rs
+++ b/relvar-core/tests/warden_query_restrict_error.rs
@@ -1,10 +1,10 @@
-use relvar_core::query::Query;
-use relvar_core::constraints::{ConstraintExpression, CmpOp, ValueOrRef};
-use relvar_core::values::ScalarValue;
-use relvar_core::types::{RelationType, TupleType, ScalarType};
+use relvar_core::constraints::{CmpOp, ConstraintExpression, ValueOrRef};
 use relvar_core::database::Database;
+use relvar_core::query::Query;
 use relvar_core::storage_engine::InMemoryEngine;
 use relvar_core::tuple;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
+use relvar_core::values::ScalarValue;
 
 #[test]
 fn test_query_restrict_propagates_errors() {
@@ -14,27 +14,27 @@ fn test_query_restrict_propagates_errors() {
         .with_attribute("id", ScalarType::Int)
         .with_attribute("name", ScalarType::String);
 
-    db.create_relvar("USERS", RelationType::new(heading)).unwrap();
-    db.insert("USERS", tuple! { id: 1i64, name: "Alice" }).unwrap();
+    db.create_relvar("USERS", RelationType::new(heading))
+        .unwrap();
+    db.insert("USERS", tuple! { id: 1i64, name: "Alice" })
+        .unwrap();
 
     // Type mismatch error
-    let query = Query::scan("USERS")
-        .restrict(ConstraintExpression::Cmp {
-            left: "name".to_string(),
-            op: CmpOp::Eq,
-            right: ValueOrRef::Value(ScalarValue::Int(1)),
-        });
+    let query = Query::scan("USERS").restrict(ConstraintExpression::Cmp {
+        left: "name".to_string(),
+        op: CmpOp::Eq,
+        right: ValueOrRef::Value(ScalarValue::Int(1)),
+    });
 
     let result = query.execute(&db);
     assert!(result.is_err());
 
     // Attribute not found error
-    let query_missing = Query::scan("USERS")
-        .restrict(ConstraintExpression::Cmp {
-            left: "missing_attr".to_string(),
-            op: CmpOp::Eq,
-            right: ValueOrRef::Value(ScalarValue::Int(1)),
-        });
+    let query_missing = Query::scan("USERS").restrict(ConstraintExpression::Cmp {
+        left: "missing_attr".to_string(),
+        op: CmpOp::Eq,
+        right: ValueOrRef::Value(ScalarValue::Int(1)),
+    });
 
     let result_missing = query_missing.execute(&db);
     assert!(result_missing.is_err());


### PR DESCRIPTION
🌟 Warden: [Query::Restrict Logic Bug]

💡 **Threat**:
The `Query::execute` implementation for `Query::Restrict` used `unwrap_or_default()` to handle errors from evaluating constraint expressions (`prepared.evaluate(tuple)`). 
If an expression failed to evaluate (e.g., due to a type mismatch or a missing attribute), the error was silently swallowed, and the result was treated as `false` (excluding the tuple). This "fail-open" or silent failure logic could hide critical schema inconsistencies, bypass security checks, or corrupt expected datasets without logging any warnings or raising an error to the caller.

🛡️ **Defense**:
Refactored the closure passed to `Relation::restrict_into` to explicitly check the `Result` of `prepared.evaluate(tuple)`. If an error occurs, it captures the first evaluation error into a mutable variable (`eval_error`) in the outer scope, and then propagates that error up the call stack as `QueryError::Constraint` after the iteration completes.

💥 **Severity**: 
High - Could lead to incorrect security checks or silent data corruption.

🧪 **Verification**:
Added a regression test `warden_query_restrict_error.rs` to verify that both type mismatches and missing attributes correctly halt execution and return an `Err`. All tests passed.

---
*PR created automatically by Jules for task [8316951632489114756](https://jules.google.com/task/8316951632489114756) started by @madmax983*