### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -66,3 +66,6 @@
 ## 2025-03-20 - Unvalidated Referencing Foreign Keys on Update
 **Learning:** `Database::update` in `relvar-core/src/database/data.rs` applies updates and validates the updated relation against its own constraints, but crucially forgets to validate referencing foreign keys (i.e. if this relation is a parent to another relation, and a primary key was updated, the child relation's foreign keys might be violated). The `delete` method correctly calls `self.constraints.validate_referencing_foreign_keys`, but `update` does not.
 **Action:** Always validate `validate_referencing_foreign_keys` in both `delete` and `update` logic paths for relational systems.
+## 2025-03-28 - Database Schema Error Paths and Virtual Relvars
+**Learning:** Found several untested code paths regarding schema operations on `virtual_relvars`, specifically defining a virtual relvar when a base or virtual relvar already exists, and requesting types/dropping nonexistent relvars, mapping to `DatabaseError::RelationAlreadyExists` and `DatabaseError::Storage(StorageEngineError::RelationNotFound)`.
+**Action:** When implementing database schemas, explicitly test the boundary conditions between base relvars and virtual relvars, as virtual relvars share the namespace. Ensure `get_relvar_type` and existence tests adequately cover both.

--- a/relvar-core/tests/sentry_database_dml_coverage.rs
+++ b/relvar-core/tests/sentry_database_dml_coverage.rs
@@ -1,0 +1,27 @@
+use relvar_core::database::Database;
+use relvar_core::error::DatabaseError;
+use relvar_core::storage_engine::InMemoryEngine;
+use relvar_core::tuple;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
+
+#[test]
+fn test_database_update_tuple_mismatch() {
+    let mut db = Database::new(InMemoryEngine::new());
+    let rel_type = RelationType::new(
+        TupleType::new()
+            .with_attribute("id", ScalarType::Int)
+            .with_attribute("val", ScalarType::Int),
+    );
+    db.create_relvar("TEST", rel_type).unwrap();
+    db.insert("TEST", tuple! { id: 1i64, val: 10i64 }).unwrap();
+
+    // Update should fail due to returning a tuple of wrong type
+    let result = db.update(
+        "TEST",
+        |t: &relvar_core::values::Tuple| t.get_typed::<i64>("id").unwrap() == 1,
+        |_t: &relvar_core::values::Tuple| tuple! { id: 1i64, wrong_attr: 10i64 }, // Invalid tuple type
+    );
+
+    assert!(result.is_err());
+    assert!(matches!(result, Err(DatabaseError::TupleMismatch)));
+}

--- a/relvar-core/tests/sentry_database_integrity_coverage.rs
+++ b/relvar-core/tests/sentry_database_integrity_coverage.rs
@@ -72,8 +72,8 @@ fn test_database_set_type_constraints_fails() {
         max: relvar_core::values::ScalarValue::Int(15),
     };
 
-    let constraints = AttributeConstraints::new("val".to_string(), ScalarType::Int)
-        .with_constraint(type_cons);
+    let constraints =
+        AttributeConstraints::new("val".to_string(), ScalarType::Int).with_constraint(type_cons);
 
     // Should fail because one of the tuples has val=20
     let result = db.set_type_constraints("TEST", "val", constraints);
@@ -88,18 +88,17 @@ fn test_database_set_check_constraints_fails() {
     let check_expr = relvar_core::constraints::ConstraintExpression::Cmp {
         left: "val".to_string(),
         op: relvar_core::constraints::CmpOp::Lt,
-        right: relvar_core::constraints::ValueOrRef::Value(
-            relvar_core::values::ScalarValue::Int(15),
-        ),
+        right: relvar_core::constraints::ValueOrRef::Value(relvar_core::values::ScalarValue::Int(
+            15,
+        )),
     };
 
-    let constraints = CheckConstraints::new().with_constraint(
-        relvar_core::constraints::CheckConstraint::new(
+    let constraints =
+        CheckConstraints::new().with_constraint(relvar_core::constraints::CheckConstraint::new(
             "val_lt_15".to_string(),
             "must be less than 15".to_string(),
             check_expr,
-        ),
-    );
+        ));
 
     // Should fail because one tuple has val=20
     let result = db.set_check_constraints("TEST", constraints);
@@ -113,7 +112,12 @@ fn test_database_set_key_constraints_nonexistent_fails() {
     let constraints = KeyConstraints::new();
     let result = db.set_key_constraints("NONEXISTENT", constraints);
     assert!(result.is_err());
-    assert!(matches!(result, Err(DatabaseError::Constraint(relvar_core::constraints::ConstraintManagerError::RelationNotFound(_)))));
+    assert!(matches!(
+        result,
+        Err(DatabaseError::Constraint(
+            relvar_core::constraints::ConstraintManagerError::RelationNotFound(_)
+        ))
+    ));
 }
 
 #[test]
@@ -122,7 +126,12 @@ fn test_database_set_foreign_key_constraints_nonexistent_fails() {
     let constraints = ForeignKeyConstraints::new();
     let result = db.set_foreign_key_constraints("NONEXISTENT", constraints);
     assert!(result.is_err());
-    assert!(matches!(result, Err(DatabaseError::Constraint(relvar_core::constraints::ConstraintManagerError::RelationNotFound(_)))));
+    assert!(matches!(
+        result,
+        Err(DatabaseError::Constraint(
+            relvar_core::constraints::ConstraintManagerError::RelationNotFound(_)
+        ))
+    ));
 }
 
 #[test]
@@ -141,5 +150,10 @@ fn test_database_set_check_constraints_nonexistent_fails() {
     let constraints = CheckConstraints::new();
     let result = db.set_check_constraints("NONEXISTENT", constraints);
     assert!(result.is_err());
-    assert!(matches!(result, Err(DatabaseError::Constraint(relvar_core::constraints::ConstraintManagerError::RelationNotFound(_)))));
+    assert!(matches!(
+        result,
+        Err(DatabaseError::Constraint(
+            relvar_core::constraints::ConstraintManagerError::RelationNotFound(_)
+        ))
+    ));
 }

--- a/relvar-core/tests/sentry_database_integrity_coverage.rs
+++ b/relvar-core/tests/sentry_database_integrity_coverage.rs
@@ -1,13 +1,11 @@
 use relvar_core::constraints::{
-    AttributeConstraints, CheckConstraint, CheckConstraints, CmpOp, ConstraintExpression,
-    ForeignKeyConstraints, TypeConstraint, ValueOrRef,
+    AttributeConstraints, CheckConstraints, ForeignKeyConstraints, KeyConstraints,
 };
 use relvar_core::database::Database;
 use relvar_core::error::DatabaseError;
 use relvar_core::storage_engine::InMemoryEngine;
 use relvar_core::tuple;
 use relvar_core::types::{RelationType, ScalarType, TupleType};
-use relvar_core::values::ScalarValue;
 
 fn setup() -> Database<InMemoryEngine> {
     let mut db = Database::new(InMemoryEngine::new());
@@ -18,19 +16,21 @@ fn setup() -> Database<InMemoryEngine> {
     );
     db.create_relvar("TEST", rel_type).unwrap();
     db.insert("TEST", tuple! { id: 1i64, val: 10i64 }).unwrap();
+    db.insert("TEST", tuple! { id: 2i64, val: 20i64 }).unwrap();
     db
 }
 
 #[test]
 fn test_database_set_key_constraints_fails() {
     let mut db = setup();
-    let pk = relvar_core::constraints::PrimaryKey::new(vec!["id".to_string()]).unwrap();
-    let key_constraints = relvar_core::constraints::KeyConstraints::new().with_primary_key(pk);
 
-    // Duplicate 1i64 to make it fail
-    db.insert("TEST", tuple! { id: 1i64, val: 20i64 }).unwrap();
+    db.insert("TEST", tuple! { id: 3i64, val: 10i64 }).unwrap();
 
-    let result = db.set_key_constraints("TEST", key_constraints);
+    // Try to set primary key on val, which has duplicates (10i64)
+    let pk = relvar_core::constraints::PrimaryKey::new(vec!["val".to_string()]).unwrap();
+    let constraints = KeyConstraints::new().with_primary_key(pk);
+
+    let result = db.set_key_constraints("TEST", constraints);
     assert!(result.is_err());
     assert!(matches!(result, Err(DatabaseError::Constraint(_))));
 }
@@ -46,6 +46,7 @@ fn test_database_set_foreign_key_constraints_fails() {
     );
     db.create_relvar("CHILD", child_type).unwrap();
 
+    // Insert an orphan record
     db.insert("CHILD", tuple! { child_id: 100i64, test_id: 999i64 })
         .unwrap();
 
@@ -55,9 +56,9 @@ fn test_database_set_foreign_key_constraints_fails() {
         vec!["id".to_string()],
     )
     .unwrap();
-    let fk_constraints = ForeignKeyConstraints::new().with_foreign_key(fk);
+    let constraints = ForeignKeyConstraints::new().with_foreign_key(fk);
 
-    let result = db.set_foreign_key_constraints("CHILD", fk_constraints);
+    let result = db.set_foreign_key_constraints("CHILD", constraints);
     assert!(result.is_err());
     assert!(matches!(result, Err(DatabaseError::Constraint(_))));
 }
@@ -66,17 +67,16 @@ fn test_database_set_foreign_key_constraints_fails() {
 fn test_database_set_type_constraints_fails() {
     let mut db = setup();
 
-    let type_cons = TypeConstraint::Range {
-        min: ScalarValue::Int(100), // value 10 is in DB, so this fails
-        max: ScalarValue::Int(200),
+    let type_cons = relvar_core::constraints::TypeConstraint::Range {
+        min: relvar_core::values::ScalarValue::Int(0),
+        max: relvar_core::values::ScalarValue::Int(15),
     };
 
-    let result = db.set_type_constraints(
-        "TEST",
-        "val",
-        AttributeConstraints::new("val".to_string(), ScalarType::Int).with_constraint(type_cons),
-    );
+    let constraints = AttributeConstraints::new("val".to_string(), ScalarType::Int)
+        .with_constraint(type_cons);
 
+    // Should fail because one of the tuples has val=20
+    let result = db.set_type_constraints("TEST", "val", constraints);
     assert!(result.is_err());
     assert!(matches!(result, Err(DatabaseError::Constraint(_))));
 }
@@ -85,18 +85,61 @@ fn test_database_set_type_constraints_fails() {
 fn test_database_set_check_constraints_fails() {
     let mut db = setup();
 
-    let check_expr = ConstraintExpression::Cmp {
+    let check_expr = relvar_core::constraints::ConstraintExpression::Cmp {
         left: "val".to_string(),
-        op: CmpOp::Gt,
-        right: ValueOrRef::Value(ScalarValue::Int(100)), // 10 is in DB
+        op: relvar_core::constraints::CmpOp::Lt,
+        right: relvar_core::constraints::ValueOrRef::Value(
+            relvar_core::values::ScalarValue::Int(15),
+        ),
     };
-    let checks = CheckConstraints::new().with_constraint(CheckConstraint::new(
-        "val_large",
-        "must be > 100",
-        check_expr,
-    ));
 
-    let result = db.set_check_constraints("TEST", checks);
+    let constraints = CheckConstraints::new().with_constraint(
+        relvar_core::constraints::CheckConstraint::new(
+            "val_lt_15".to_string(),
+            "must be less than 15".to_string(),
+            check_expr,
+        ),
+    );
+
+    // Should fail because one tuple has val=20
+    let result = db.set_check_constraints("TEST", constraints);
     assert!(result.is_err());
     assert!(matches!(result, Err(DatabaseError::Constraint(_))));
+}
+
+#[test]
+fn test_database_set_key_constraints_nonexistent_fails() {
+    let mut db = setup();
+    let constraints = KeyConstraints::new();
+    let result = db.set_key_constraints("NONEXISTENT", constraints);
+    assert!(result.is_err());
+    assert!(matches!(result, Err(DatabaseError::Constraint(relvar_core::constraints::ConstraintManagerError::RelationNotFound(_)))));
+}
+
+#[test]
+fn test_database_set_foreign_key_constraints_nonexistent_fails() {
+    let mut db = setup();
+    let constraints = ForeignKeyConstraints::new();
+    let result = db.set_foreign_key_constraints("NONEXISTENT", constraints);
+    assert!(result.is_err());
+    assert!(matches!(result, Err(DatabaseError::Constraint(relvar_core::constraints::ConstraintManagerError::RelationNotFound(_)))));
+}
+
+#[test]
+fn test_database_set_type_constraints_nonexistent_fails() {
+    let mut db = setup();
+    let constraints = AttributeConstraints::new("val".to_string(), ScalarType::Int);
+    let result = db.set_type_constraints("NONEXISTENT", "val", constraints);
+    assert!(result.is_err());
+    // The type constraint internally triggers a fetch which eventually resolves through map_err returning just Constraint(_)
+    assert!(matches!(result, Err(DatabaseError::Constraint(_))));
+}
+
+#[test]
+fn test_database_set_check_constraints_nonexistent_fails() {
+    let mut db = setup();
+    let constraints = CheckConstraints::new();
+    let result = db.set_check_constraints("NONEXISTENT", constraints);
+    assert!(result.is_err());
+    assert!(matches!(result, Err(DatabaseError::Constraint(relvar_core::constraints::ConstraintManagerError::RelationNotFound(_)))));
 }

--- a/relvar-core/tests/sentry_database_schema_coverage.rs
+++ b/relvar-core/tests/sentry_database_schema_coverage.rs
@@ -1,10 +1,99 @@
 use relvar_core::database::Database;
+use relvar_core::error::DatabaseError;
 use relvar_core::storage_engine::InMemoryEngine;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
 
 #[test]
 fn test_drop_relvar_not_found() {
     let mut db = Database::new(InMemoryEngine::new());
-
     let result = db.drop_relvar("NONEXISTENT");
     assert!(result.is_err());
+    assert!(matches!(result, Err(DatabaseError::Storage(_))));
+}
+
+#[test]
+fn test_get_relvar_type_not_found() {
+    let db = Database::new(InMemoryEngine::new());
+    let result = db.get_relvar_type("NONEXISTENT");
+    assert!(result.is_err());
+    assert!(matches!(result, Err(DatabaseError::Storage(_))));
+}
+
+#[test]
+fn test_get_relvar_type_virtual() {
+    let mut db = Database::new(InMemoryEngine::new());
+    let rel_type = RelationType::new(TupleType::new().with_attribute("id", ScalarType::Int));
+    db.define_virtual_relvar("VIRT_TEST", rel_type.clone(), |_| {
+        Ok(relvar_core::values::Relation::new(
+            relvar_core::types::RelationType::new(relvar_core::types::TupleType::new()),
+        ))
+    })
+    .unwrap();
+
+    let result = db.get_relvar_type("VIRT_TEST");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), rel_type);
+}
+
+#[test]
+fn test_create_relvar_already_exists() {
+    let mut db = Database::new(InMemoryEngine::new());
+    let rel_type = RelationType::new(TupleType::new().with_attribute("id", ScalarType::Int));
+
+    // Create first time
+    db.create_relvar("TEST", rel_type.clone()).unwrap();
+
+    // Create second time should fail
+    let result = db.create_relvar("TEST", rel_type);
+    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(DatabaseError::RelationAlreadyExists(_))
+    ));
+}
+
+#[test]
+fn test_define_virtual_relvar_already_exists_base() {
+    let mut db = Database::new(InMemoryEngine::new());
+    let rel_type = RelationType::new(TupleType::new().with_attribute("id", ScalarType::Int));
+
+    // Create base relvar
+    db.create_relvar("TEST", rel_type.clone()).unwrap();
+
+    // Define virtual relvar with same name should fail
+    let result = db.define_virtual_relvar("TEST", rel_type, |_| {
+        Ok(relvar_core::values::Relation::new(
+            relvar_core::types::RelationType::new(relvar_core::types::TupleType::new()),
+        ))
+    });
+    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(DatabaseError::RelationAlreadyExists(_))
+    ));
+}
+
+#[test]
+fn test_define_virtual_relvar_already_exists_virtual() {
+    let mut db = Database::new(InMemoryEngine::new());
+    let rel_type = RelationType::new(TupleType::new().with_attribute("id", ScalarType::Int));
+
+    db.define_virtual_relvar("VIRT_TEST", rel_type.clone(), |_| {
+        Ok(relvar_core::values::Relation::new(
+            relvar_core::types::RelationType::new(relvar_core::types::TupleType::new()),
+        ))
+    })
+    .unwrap();
+
+    // Define virtual relvar with same name should fail
+    let result = db.define_virtual_relvar("VIRT_TEST", rel_type, |_| {
+        Ok(relvar_core::values::Relation::new(
+            relvar_core::types::RelationType::new(relvar_core::types::TupleType::new()),
+        ))
+    });
+    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(DatabaseError::RelationAlreadyExists(_))
+    ));
 }


### PR DESCRIPTION
🎯 Target: Database schema operations (`define_virtual_relvar`, `drop_relvar`, `get_relvar_type`), DML operations (`update`), and integrity constraint handling (`set_type_constraints` etc.).

💣 Risk: Error paths and boundary conditions were previously untested. This means that if logic regarding name collisions between base and virtual relvars, type mismatches in updates, or fetching information from nonexistent relvars were accidentally broken, no test would fail, potentially leading to panics or incorrect behavior down the line.

🧪 Strategy: Added multiple integration test files (`sentry_database_schema_coverage.rs`, `sentry_database_dml_coverage.rs`, `sentry_database_integrity_coverage.rs`) that explicitly trigger these error paths using `assert!(matches!(...))` to verify the correct `DatabaseError` variants are returned. Tested defining virtual relvars over existing base relvars, fetching nonexistent relation types, failing updates due to tuple mismatch, and correctly testing constraint assignment failure paths for nonexistent relvars.

🔬 Verification: Run `cargo test --test sentry_database_schema_coverage --test sentry_database_dml_coverage --test sentry_database_integrity_coverage`

---
*PR created automatically by Jules for task [1308201798178970173](https://jules.google.com/task/1308201798178970173) started by @madmax983*