### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/relvar-core/tests/sentry_database_update_fk_coverage.rs
+++ b/relvar-core/tests/sentry_database_update_fk_coverage.rs
@@ -1,6 +1,5 @@
-use relvar_core::constraints::{
-    ConstraintManagerError, ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey,
-};
+use relvar_core::constraints::ConstraintManagerError;
+use relvar_core::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
 use relvar_core::database::Database;
 use relvar_core::error::DatabaseError;
 use relvar_core::storage_engine::InMemoryEngine;
@@ -8,27 +7,27 @@ use relvar_core::tuple;
 use relvar_core::types::{RelationType, ScalarType, TupleType};
 
 #[test]
-fn test_update_referenced_parent_fails() {
+fn test_database_update_validates_referencing_foreign_keys() {
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
 
+    // Create PARENT
     let parent_type = RelationType::new(
         TupleType::new()
             .with_attribute("id", ScalarType::Int)
             .with_attribute("name", ScalarType::String),
     );
+    db.create_relvar("PARENT", parent_type).unwrap();
+    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    db.set_key_constraints("PARENT", KeyConstraints::new().with_primary_key(pk))
+        .unwrap();
+
+    // Create CHILD
     let child_type = RelationType::new(
         TupleType::new()
             .with_attribute("child_id", ScalarType::Int)
             .with_attribute("parent_id", ScalarType::Int),
     );
-
-    db.create_relvar("PARENT", parent_type).unwrap();
     db.create_relvar("CHILD", child_type).unwrap();
-
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
-    db.set_key_constraints("PARENT", KeyConstraints::new().with_primary_key(pk))
-        .unwrap();
-
     let fk = ForeignKey::new(
         vec!["parent_id".to_string()],
         "PARENT".to_string(),
@@ -38,26 +37,45 @@ fn test_update_referenced_parent_fails() {
     db.set_foreign_key_constraints("CHILD", ForeignKeyConstraints::new().with_foreign_key(fk))
         .unwrap();
 
-    // Insert parent
-    db.insert("PARENT", tuple! { id: 1i64, name: "Parent1" })
+    // Insert tuples
+    db.insert("PARENT", tuple! { id: 1i64, name: "P1" })
         .unwrap();
-
-    // Insert child referencing Parent1
+    db.insert("PARENT", tuple! { id: 2i64, name: "P2" })
+        .unwrap();
     db.insert("CHILD", tuple! { child_id: 100i64, parent_id: 1i64 })
         .unwrap();
 
-    // Update Parent1's id (referenced by child) - should fail
-    let result = db.update(
+    // Attempt update that violates FK constraint (updating parent being referenced)
+    let err = db.update(
         "PARENT",
         |t| t.get_typed::<i64>("id").unwrap() == 1,
-        |t| tuple! { id: 2i64, name: t.get_typed::<String>("name").unwrap() },
+        |_t| tuple! { id: 99i64, name: "P1_new" },
     );
-
-    assert!(result.is_err());
+    assert!(err.is_err());
     assert!(matches!(
-        result,
+        err,
         Err(DatabaseError::Constraint(
             ConstraintManagerError::ForeignKeyViolation(_)
         ))
     ));
+
+    // Valid update doesn't trigger FK violation
+    let count = db
+        .update(
+            "PARENT",
+            |t| t.get_typed::<i64>("id").unwrap() == 1,
+            |_t| tuple! { id: 1i64, name: "P1_renamed" },
+        )
+        .unwrap();
+    assert_eq!(count, 1);
+
+    // Update on unreferenced parent
+    let count = db
+        .update(
+            "PARENT",
+            |t| t.get_typed::<i64>("id").unwrap() == 2,
+            |_t| tuple! { id: 22i64, name: "P2_new" },
+        )
+        .unwrap();
+    assert_eq!(count, 1);
 }


### PR DESCRIPTION
🎯 Target: `Database::update` and `ConstraintManager::validate_referencing_foreign_keys` interaction.

💣 Risk: Prevents regressions where updating a parent record's primary key might silently orphan child records instead of throwing a `ForeignKeyViolation`.

🧪 Strategy: Added a new integration test `test_database_update_validates_referencing_foreign_keys` that sets up a PARENT and CHILD relation, inserts valid rows, and then attempts an update to the referenced parent's primary key (expecting an error), followed by updates that do not violate the constraint (expecting success).

🔬 Verification: Run the test directly via `cargo test --test sentry_database_update_fk_coverage`.

---
*PR created automatically by Jules for task [1885658448882231888](https://jules.google.com/task/1885658448882231888) started by @madmax983*