### PR TITLE
⚒️ Forge: Extract raytracer render phases

### DIFF
--- a/relvar/src/experimental/raytracer.rs
+++ b/relvar/src/experimental/raytracer.rs
@@ -109,11 +109,7 @@ impl Scene {
         Ok(())
     }
 
-    /// Renders the scene to a relation of pixels.
-    ///
-    /// Yields a relation with heading `(x, y, r, g, b)`.
-    pub fn render(&self, width: i64, height: i64) -> Result<Relation, DatabaseError> {
-        // 1. Generate Rays Relation: (x, y, ox, oy, oz, dx, dy, dz, dummy_join)
+    fn generate_rays(&self, width: i64, height: i64) -> Result<Relation, DatabaseError> {
         let ray_heading = TupleType::new()
             .with_attribute("x", ScalarType::Int)
             .with_attribute("y", ScalarType::Int)
@@ -169,6 +165,10 @@ impl Scene {
             }
         }
 
+        Ok(rays)
+    }
+
+    fn compute_intersections(&self, rays: &Relation) -> Result<Relation, DatabaseError> {
         // 2. Prepare Spheres for Cross Join
         // We use extend to add `dummy_join: 1` so natural join acts as a cross join.
         let spheres_prepared = self
@@ -233,6 +233,14 @@ impl Scene {
             })
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
+        Ok(intersections)
+    }
+
+    fn calculate_visible_pixels(
+        &self,
+        rays: &Relation,
+        intersections: &Relation,
+    ) -> Result<Relation, DatabaseError> {
         // 5. Filter Hits
         let hits = intersections.restrict(|t| {
             let dist = t.get_typed::<f64>("t").unwrap_or(-1.0);
@@ -295,6 +303,15 @@ impl Scene {
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
         Ok(final_image)
+    }
+
+    /// Renders the scene to a relation of pixels.
+    ///
+    /// Yields a relation with heading `(x, y, r, g, b)`.
+    pub fn render(&self, width: i64, height: i64) -> Result<Relation, DatabaseError> {
+        let rays = self.generate_rays(width, height)?;
+        let intersections = self.compute_intersections(&rays)?;
+        self.calculate_visible_pixels(&rays, &intersections)
     }
 }
 


### PR DESCRIPTION
🚮 Smell: `render` in `relvar/src/experimental/raytracer.rs` was a 119-line "God Function" handling ray generation, intersection calculation, and pixel mapping, causing a `clippy::too_many_lines` warning.
✨ Solution: Extracted the logic into three distinct helper methods: `generate_rays`, `compute_intersections`, and `calculate_visible_pixels`. The `render` method now clearly coordinates these three phases.
🧼 Benefit: Significantly reduces cognitive load and allows reading the core algorithm at a high level without being bogged down by the math. Follows the "Three-Phase Operator" pattern from Forge's journal.
🛡️ Verification: Tests passed. No logic changed. All output relation structures remain identical.

---
*PR created automatically by Jules for task [11350718667168000908](https://jules.google.com/task/11350718667168000908) started by @madmax983*