### PR TITLE
🪒 Razor: Refactor single-variant enums to unit structs

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `OperationType` enum with only `Insert` and `Update` variants in `relvar-storage/src/storage/heap.rs`.
 **Cut:** Replaced `OperationType` enum with a simple `bool` flag (`is_update: bool`) since it only had two states.
 **Saved:** Removed enum definition and simplified pattern matching.
+
+## [Reduction]
+**Bloat:** Single-variant `enum`s for errors (`ScalarValueError`, `UnionError`, `IntersectError`, `DifferenceError`).
+**Cut:** Refactored these `enum`s into simple unit `struct`s (e.g., `pub struct UnionError;`), dropping the unnecessary matching indirection.
+**Saved:** Reduced code complexity and explicit single-variant boilerplate.

--- a/relvar-core/src/algebra/difference.rs
+++ b/relvar-core/src/algebra/difference.rs
@@ -37,15 +37,9 @@ use crate::values::Relation;
 use thiserror::Error;
 
 /// Errors that can occur during difference operations.
-#[derive(Debug, Error)]
-pub enum DifferenceError {
-    /// The two relations have incompatible types (different headings).
-    ///
-    /// Difference requires both relations to have exactly the same heading
-    /// (attribute names and types).
-    #[error("Relations must have the same type (heading) for difference")]
-    TypeMismatch,
-}
+#[derive(Debug, Error, PartialEq, Eq, Clone, Copy)]
+#[error("Relations must have the same type (heading) for difference")]
+pub struct DifferenceError;
 
 impl Relation {
     /// Computes the set difference of this relation with another.
@@ -65,7 +59,7 @@ impl Relation {
     ///
     /// # Errors
     ///
-    /// Returns [`DifferenceError::TypeMismatch`] if the relations have different
+    /// Returns [`DifferenceError`] if the relations have different
     /// headings (different attribute names or types).
     ///
     /// # Behavior
@@ -108,7 +102,7 @@ impl Relation {
     pub fn difference(&self, other: &Relation) -> Result<Self, DifferenceError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
-            return Err(DifferenceError::TypeMismatch);
+            return Err(DifferenceError);
         }
 
         // Filter tuples and create relation without redundant checks
@@ -157,7 +151,7 @@ impl Relation {
     pub fn difference_into(self, other: &Relation) -> Result<Self, DifferenceError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
-            return Err(DifferenceError::TypeMismatch);
+            return Err(DifferenceError);
         }
 
         let rel_type = self.relation_type().clone();
@@ -228,7 +222,7 @@ mod tests {
 
         let result = rel1.difference(&rel2);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), DifferenceError::TypeMismatch));
+        assert_eq!(result.unwrap_err(), DifferenceError);
     }
 
     #[test]

--- a/relvar-core/src/algebra/intersect.rs
+++ b/relvar-core/src/algebra/intersect.rs
@@ -38,15 +38,9 @@ use crate::values::Relation;
 use thiserror::Error;
 
 /// Errors that can occur during intersection operations.
-#[derive(Debug, Error)]
-pub enum IntersectError {
-    /// The two relations have incompatible types (different headings).
-    ///
-    /// Intersection requires both relations to have exactly the same heading
-    /// (attribute names and types).
-    #[error("Relations must have the same type (heading) for intersection")]
-    TypeMismatch,
-}
+#[derive(Debug, Error, PartialEq, Eq, Clone, Copy)]
+#[error("Relations must have the same type (heading) for intersection")]
+pub struct IntersectError;
 
 impl Relation {
     /// Computes the intersection of this relation with another.
@@ -66,7 +60,7 @@ impl Relation {
     ///
     /// # Errors
     ///
-    /// Returns [`IntersectError::TypeMismatch`] if the relations have different
+    /// Returns [`IntersectError`] if the relations have different
     /// headings (different attribute names or types).
     ///
     /// # Behavior
@@ -109,7 +103,7 @@ impl Relation {
     pub fn intersect(&self, other: &Relation) -> Result<Self, IntersectError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
-            return Err(IntersectError::TypeMismatch);
+            return Err(IntersectError);
         }
 
         // Filter tuples and create relation without redundant checks
@@ -127,7 +121,7 @@ impl Relation {
     pub fn intersect_into(self, other: &Relation) -> Result<Self, IntersectError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
-            return Err(IntersectError::TypeMismatch);
+            return Err(IntersectError);
         }
 
         let rel_type = self.relation_type().clone();
@@ -194,7 +188,7 @@ mod tests {
 
         let result = rel1.intersect(&rel2);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), IntersectError::TypeMismatch));
+        assert_eq!(result.unwrap_err(), IntersectError);
     }
 
     #[test]

--- a/relvar-core/src/algebra/union.rs
+++ b/relvar-core/src/algebra/union.rs
@@ -37,15 +37,9 @@ use crate::values::Relation;
 use thiserror::Error;
 
 /// Errors that can occur during union operations.
-#[derive(Debug, Error)]
-pub enum UnionError {
-    /// The two relations have incompatible types (different headings).
-    ///
-    /// Union requires both relations to have exactly the same heading
-    /// (attribute names and types).
-    #[error("Relations must have the same type (heading) for union")]
-    TypeMismatch,
-}
+#[derive(Debug, Error, PartialEq, Eq, Clone, Copy)]
+#[error("Relations must have the same type (heading) for union")]
+pub struct UnionError;
 
 impl Relation {
     /// Computes the union of this relation with another.
@@ -66,7 +60,7 @@ impl Relation {
     ///
     /// # Errors
     ///
-    /// Returns [`UnionError::TypeMismatch`] if the relations have different
+    /// Returns [`UnionError`] if the relations have different
     /// headings (different attribute names or types).
     ///
     /// # Behavior
@@ -103,7 +97,7 @@ impl Relation {
     pub fn union(&self, other: &Relation) -> Result<Self, UnionError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
-            return Err(UnionError::TypeMismatch);
+            return Err(UnionError);
         }
 
         // Chain iterators and create relation without redundant checks
@@ -121,7 +115,7 @@ impl Relation {
     pub fn union_into(mut self, other: &Relation) -> Result<Self, UnionError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
-            return Err(UnionError::TypeMismatch);
+            return Err(UnionError);
         }
 
         for tuple in other.tuples() {
@@ -160,7 +154,7 @@ mod tests {
 
         let result = rel1.union(&rel2);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), UnionError::TypeMismatch));
+        assert_eq!(result.unwrap_err(), UnionError);
     }
 
     #[test]

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -33,16 +33,9 @@ use std::convert::TryFrom;
 use thiserror::Error;
 
 /// Errors that can occur during scalar value operations.
-#[derive(Debug, Error)]
-pub enum ScalarValueError {
-    /// Attempted to use an observer on a built-in type.
-    ///
-    /// The observer operation is only valid for user-defined types (POSSREP pattern).
-    /// Built-in types like `Int`, `String`, etc., do not have observers because
-    /// their representation is their value.
-    #[error("Cannot extract observer from built-in type")]
-    NotUserDefined,
-}
+#[derive(Debug, Error, PartialEq, Eq, Clone, Copy)]
+#[error("Cannot extract observer from built-in type")]
+pub struct ScalarValueError;
 
 /// Represents an atomic (scalar) value at runtime.
 ///
@@ -199,7 +192,7 @@ impl ScalarValue {
     pub fn observer(&self) -> Result<ScalarValue, ScalarValueError> {
         match self {
             ScalarValue::UserDefined { value, .. } => Ok((**value).clone()),
-            _ => Err(ScalarValueError::NotUserDefined),
+            _ => Err(ScalarValueError),
         }
     }
 


### PR DESCRIPTION
🪒 Razor: Refactor single-variant error enums to unit structs

**Reduction:**
- Identified `ScalarValueError`, `UnionError`, `IntersectError`, and `DifferenceError` as single-variant enums.
- According to Razor's guidelines, single-variant enums represent unnecessary "Enterprise FizzBuzz" bloat.
- Refactored these enums to unit structs (e.g., `pub struct UnionError;`), dropping the indirection.
- Replaced pattern-matching usages and updated assertions across their respective domains and tests.

**Verification:**
- Ran `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings`. Code compiles successfully and all tests pass with no regressions.
- Logged changes in `.jules/razor.md`.

---
*PR created automatically by Jules for task [8991314434943953740](https://jules.google.com/task/8991314434943953740) started by @madmax983*