### PR TITLE
⚡ Bolt: [performance improvement] Optimize constraint validation key extraction buffer allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -48,3 +48,7 @@ Without pre-allocating the vector for `extended_tuples` with `with_capacity()`, 
 ## 2026-03-09 - Group Key and RVA Pre-allocation Optimization
 **Learning:** `compute_grouped_tuples` allocated and cloned heavy `ScalarValue` types repeatedly to build a `HashMap` key for each tuple, causing O(N_tuples) unnecessary allocations. `compute_ungrouped_tuples` lacked result vector pre-allocation based on the RVA cardinality.
 **Action:** Use `Vec<&'a ScalarValue>` as `HashMap` keys during aggregation passes. For collection transformations where sizes are variable but determinable (like ungrouping RVAs), always do an initial size accumulation pass to enable `Vec::with_capacity`.
+
+## 2026-03-27 - Tuple validation key buffer reuse
+**Learning:** Checking Candidate Key and Foreign Key constraints over a `Relation` inside nested loops allocates a `Vec<ScalarValue>` and clones each attribute if we use `.map(|attr| tuple.get(attr).unwrap().clone()).collect()`.
+**Action:** Use a pre-allocated vector inside the loop (e.g. `let mut buffer = Vec::with_capacity(...)`) and extract references via `buffer.push(tuple.get(attr).unwrap())` and `.clear()` it on each iteration to prevent `Vec` reallocations and `ScalarValue` cloning. For `CandidateKey::is_satisfied_by`, `.collect()` into a `HashSet` from the `Vec<&ScalarValue>` instead.

--- a/patch_foreign_key.py
+++ b/patch_foreign_key.py
@@ -1,0 +1,115 @@
+with open("relvar-core/src/constraints/foreign_key.rs", "r") as f:
+    code = f.read()
+
+new_code = code.replace(
+"""    pub fn would_violate_on_insert(
+        &self,
+        new_tuple: &Tuple,
+        referenced_relation: &Relation,
+    ) -> Result<bool, ForeignKeyError> {
+        let foreign_key_values: Vec<_> = self
+            .foreign_key_attributes
+            .iter()
+            .map(|attr| new_tuple.get(attr).unwrap())
+            .collect();
+
+        // Check if any tuple in referenced relation matches
+        for referenced_tuple in referenced_relation.tuples() {
+            let referenced_values: Vec<_> = self
+                .referenced_attributes
+                .iter()
+                .map(|attr| referenced_tuple.get(attr).unwrap())
+                .collect();
+
+            if foreign_key_values == referenced_values {
+                return Ok(false); // Found a match, so no violation
+            }
+        }
+
+        Ok(true) // No match found, violation
+    }""",
+"""    pub fn would_violate_on_insert(
+        &self,
+        new_tuple: &Tuple,
+        referenced_relation: &Relation,
+    ) -> Result<bool, ForeignKeyError> {
+        let mut foreign_key_values = Vec::with_capacity(self.foreign_key_attributes.len());
+        for attr in &self.foreign_key_attributes {
+            foreign_key_values.push(new_tuple.get(attr).unwrap());
+        }
+
+        let mut referenced_values = Vec::with_capacity(self.referenced_attributes.len());
+
+        // Check if any tuple in referenced relation matches
+        for referenced_tuple in referenced_relation.tuples() {
+            referenced_values.clear();
+            for attr in &self.referenced_attributes {
+                referenced_values.push(referenced_tuple.get(attr).unwrap());
+            }
+
+            if foreign_key_values == referenced_values {
+                return Ok(false); // Found a match, so no violation
+            }
+        }
+
+        Ok(true) // No match found, violation
+    }""")
+
+new_code = new_code.replace(
+"""    pub fn would_violate_on_delete(
+        &self,
+        tuple_to_delete: &Tuple,
+        referencing_relation: &Relation,
+    ) -> Result<bool, ForeignKeyError> {
+        let referenced_values: Vec<_> = self
+            .referenced_attributes
+            .iter()
+            .map(|attr| tuple_to_delete.get(attr).unwrap())
+            .collect();
+
+        // Check if any tuple in referencing relation references this tuple
+        for referencing_tuple in referencing_relation.tuples() {
+            let foreign_key_values: Vec<_> = self
+                .foreign_key_attributes
+                .iter()
+                .map(|attr| referencing_tuple.get(attr).unwrap())
+                .collect();
+
+            if foreign_key_values == referenced_values {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }""",
+"""    pub fn would_violate_on_delete(
+        &self,
+        tuple_to_delete: &Tuple,
+        referencing_relation: &Relation,
+    ) -> Result<bool, ForeignKeyError> {
+        let mut referenced_values = Vec::with_capacity(self.referenced_attributes.len());
+        for attr in &self.referenced_attributes {
+            referenced_values.push(tuple_to_delete.get(attr).unwrap());
+        }
+
+        let mut foreign_key_values = Vec::with_capacity(self.foreign_key_attributes.len());
+
+        // Check if any tuple in referencing relation references this tuple
+        for referencing_tuple in referencing_relation.tuples() {
+            foreign_key_values.clear();
+            for attr in &self.foreign_key_attributes {
+                foreign_key_values.push(referencing_tuple.get(attr).unwrap());
+            }
+
+            if foreign_key_values == referenced_values {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }""")
+
+with open("relvar-core/src/constraints/foreign_key.rs", "w") as f:
+    f.write(new_code)
+
+print("patched relvar-core/src/constraints/foreign_key.rs")

--- a/patch_key.py
+++ b/patch_key.py
@@ -1,0 +1,129 @@
+with open("relvar-core/src/constraints/key.rs", "r") as f:
+    code = f.read()
+
+new_code = code.replace(
+"""    /// Extract key value from a tuple
+    fn extract_key_value(
+        &self,
+        tuple: &Tuple,
+    ) -> Result<Vec<crate::values::ScalarValue>, KeyConstraintError> {
+        let mut values = Vec::with_capacity(self.attributes.len());
+        for attr in &self.attributes {
+            if let Some(val) = tuple.get(attr) {
+                values.push(val.clone());
+            } else {
+                return Err(KeyConstraintError::TupleMissingAttribute(attr.clone()));
+            }
+        }
+        Ok(values)
+    }""",
+"""    /// Extract reference to key value from a tuple, avoiding clone
+    fn extract_key_value_ref<'a>(
+        &self,
+        tuple: &'a Tuple,
+        buffer: &mut Vec<&'a crate::values::ScalarValue>,
+    ) -> Result<(), KeyConstraintError> {
+        buffer.clear();
+        for attr in &self.attributes {
+            if let Some(val) = tuple.get(attr) {
+                buffer.push(val);
+            } else {
+                return Err(KeyConstraintError::TupleMissingAttribute(attr.clone()));
+            }
+        }
+        Ok(())
+    }""")
+
+new_code = new_code.replace(
+"""    /// Check if this key is satisfied by a relation (all tuples have unique key values)
+    pub fn is_satisfied_by(&self, relation: &Relation) -> Result<bool, KeyConstraintError> {
+        // Verify all key attributes exist
+        for attr in &self.attributes {
+            if !relation.relation_type().has_attribute(attr) {
+                return Err(KeyConstraintError::InvalidKeyAttributes(
+                    self.attributes.clone(),
+                ));
+            }
+        }
+
+        // Collect all key values
+        let mut key_values = HashSet::new();
+
+        for tuple in relation.tuples() {
+            let key_value = self.extract_key_value(tuple)?;
+            if !key_values.insert(key_value) {
+                // Duplicate found
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }""",
+"""    /// Check if this key is satisfied by a relation (all tuples have unique key values)
+    pub fn is_satisfied_by(&self, relation: &Relation) -> Result<bool, KeyConstraintError> {
+        // Verify all key attributes exist
+        for attr in &self.attributes {
+            if !relation.relation_type().has_attribute(attr) {
+                return Err(KeyConstraintError::InvalidKeyAttributes(
+                    self.attributes.clone(),
+                ));
+            }
+        }
+
+        // Collect all key values
+        let mut key_values = HashSet::new();
+        let mut buffer = Vec::with_capacity(self.attributes.len());
+
+        for tuple in relation.tuples() {
+            self.extract_key_value_ref(tuple, &mut buffer)?;
+            if !key_values.insert(buffer.clone()) {
+                // Duplicate found
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }""")
+
+new_code = new_code.replace(
+"""    /// Check if a tuple would violate this key constraint when inserted into a relation
+    pub fn would_violate(
+        &self,
+        relation: &Relation,
+        new_tuple: &Tuple,
+    ) -> Result<bool, KeyConstraintError> {
+        let new_key_value = self.extract_key_value(new_tuple)?;
+
+        for existing_tuple in relation.tuples() {
+            let existing_key_value = self.extract_key_value(existing_tuple)?;
+            if new_key_value == existing_key_value {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }""",
+"""    /// Check if a tuple would violate this key constraint when inserted into a relation
+    pub fn would_violate(
+        &self,
+        relation: &Relation,
+        new_tuple: &Tuple,
+    ) -> Result<bool, KeyConstraintError> {
+        let mut new_key_value = Vec::with_capacity(self.attributes.len());
+        self.extract_key_value_ref(new_tuple, &mut new_key_value)?;
+
+        let mut existing_key_value = Vec::with_capacity(self.attributes.len());
+        for existing_tuple in relation.tuples() {
+            self.extract_key_value_ref(existing_tuple, &mut existing_key_value)?;
+            if new_key_value == existing_key_value {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }""")
+
+with open("relvar-core/src/constraints/key.rs", "w") as f:
+    f.write(new_code)
+
+print("patched relvar-core/src/constraints/key.rs")

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,16 @@
+1. **Optimize Foreign Key `would_violate_on_insert` and `would_violate_on_delete`**
+   - Replace intermediate `Vec<_>` collections with `Vec<&ScalarValue>` using references to avoid allocating completely new `Vec<ScalarValue>` for every foreign key check.
+   - Refactor `would_violate_on_insert` to use zero-copy checking.
+   - Refactor `would_violate_on_delete` to use zero-copy checking.
+
+2. **Optimize `CandidateKey`'s `is_satisfied_by` and `would_violate`**
+   - Refactor `extract_key_value` to `extract_key_value_ref` returning `Result<Vec<&crate::values::ScalarValue>, KeyConstraintError>` to eliminate `val.clone()` inside the loop for constraint checks.
+   - Update `is_satisfied_by` to collect `Vec<&ScalarValue>` into the `HashSet`.
+   - Update `would_violate` to compare `Vec<&ScalarValue>`.
+   - Keep the original `extract_key_value` or replace it if not used elsewhere.
+
+3. **Complete pre commit steps**
+   - Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
+
+4. **Submit the change**
+   - Once all tests pass, submit the change with a descriptive commit message.

--- a/relvar-core/src/constraints/foreign_key.rs
+++ b/relvar-core/src/constraints/foreign_key.rs
@@ -218,19 +218,19 @@ impl ForeignKey {
         new_tuple: &Tuple,
         referenced_relation: &Relation,
     ) -> Result<bool, ForeignKeyError> {
-        let foreign_key_values: Vec<_> = self
-            .foreign_key_attributes
-            .iter()
-            .map(|attr| new_tuple.get(attr).unwrap())
-            .collect();
+        let mut foreign_key_values = Vec::with_capacity(self.foreign_key_attributes.len());
+        for attr in &self.foreign_key_attributes {
+            foreign_key_values.push(new_tuple.get(attr).unwrap());
+        }
+
+        let mut referenced_values = Vec::with_capacity(self.referenced_attributes.len());
 
         // Check if any tuple in referenced relation matches
         for referenced_tuple in referenced_relation.tuples() {
-            let referenced_values: Vec<_> = self
-                .referenced_attributes
-                .iter()
-                .map(|attr| referenced_tuple.get(attr).unwrap())
-                .collect();
+            referenced_values.clear();
+            for attr in &self.referenced_attributes {
+                referenced_values.push(referenced_tuple.get(attr).unwrap());
+            }
 
             if foreign_key_values == referenced_values {
                 return Ok(false); // Found a match, so no violation
@@ -246,19 +246,19 @@ impl ForeignKey {
         tuple_to_delete: &Tuple,
         referencing_relation: &Relation,
     ) -> Result<bool, ForeignKeyError> {
-        let referenced_values: Vec<_> = self
-            .referenced_attributes
-            .iter()
-            .map(|attr| tuple_to_delete.get(attr).unwrap())
-            .collect();
+        let mut referenced_values = Vec::with_capacity(self.referenced_attributes.len());
+        for attr in &self.referenced_attributes {
+            referenced_values.push(tuple_to_delete.get(attr).unwrap());
+        }
+
+        let mut foreign_key_values = Vec::with_capacity(self.foreign_key_attributes.len());
 
         // Check if any tuple in referencing relation references this tuple
         for referencing_tuple in referencing_relation.tuples() {
-            let foreign_key_values: Vec<_> = self
-                .foreign_key_attributes
-                .iter()
-                .map(|attr| referencing_tuple.get(attr).unwrap())
-                .collect();
+            foreign_key_values.clear();
+            for attr in &self.foreign_key_attributes {
+                foreign_key_values.push(referencing_tuple.get(attr).unwrap());
+            }
 
             if foreign_key_values == referenced_values {
                 return Ok(true);

--- a/relvar-core/src/constraints/key.rs
+++ b/relvar-core/src/constraints/key.rs
@@ -145,10 +145,11 @@ impl CandidateKey {
 
         // Collect all key values
         let mut key_values = HashSet::new();
+        let mut buffer = Vec::with_capacity(self.attributes.len());
 
         for tuple in relation.tuples() {
-            let key_value = self.extract_key_value(tuple)?;
-            if !key_values.insert(key_value) {
+            self.extract_key_value_ref(tuple, &mut buffer)?;
+            if !key_values.insert(buffer.clone()) {
                 // Duplicate found
                 return Ok(false);
             }
@@ -163,10 +164,12 @@ impl CandidateKey {
         relation: &Relation,
         new_tuple: &Tuple,
     ) -> Result<bool, KeyConstraintError> {
-        let new_key_value = self.extract_key_value(new_tuple)?;
+        let mut new_key_value = Vec::with_capacity(self.attributes.len());
+        self.extract_key_value_ref(new_tuple, &mut new_key_value)?;
 
+        let mut existing_key_value = Vec::with_capacity(self.attributes.len());
         for existing_tuple in relation.tuples() {
-            let existing_key_value = self.extract_key_value(existing_tuple)?;
+            self.extract_key_value_ref(existing_tuple, &mut existing_key_value)?;
             if new_key_value == existing_key_value {
                 return Ok(true);
             }
@@ -175,20 +178,21 @@ impl CandidateKey {
         Ok(false)
     }
 
-    /// Extract key value from a tuple
-    fn extract_key_value(
+    /// Extract reference to key value from a tuple, avoiding clone
+    fn extract_key_value_ref<'a>(
         &self,
-        tuple: &Tuple,
-    ) -> Result<Vec<crate::values::ScalarValue>, KeyConstraintError> {
-        let mut values = Vec::with_capacity(self.attributes.len());
+        tuple: &'a Tuple,
+        buffer: &mut Vec<&'a crate::values::ScalarValue>,
+    ) -> Result<(), KeyConstraintError> {
+        buffer.clear();
         for attr in &self.attributes {
             if let Some(val) = tuple.get(attr) {
-                values.push(val.clone());
+                buffer.push(val);
             } else {
                 return Err(KeyConstraintError::TupleMissingAttribute(attr.clone()));
             }
         }
-        Ok(values)
+        Ok(())
     }
 }
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,4 @@
+# find unnecessary Vec allocations when Vec<&ScalarValue> is enough
+
+def search(lines):
+    pass


### PR DESCRIPTION
💡 **What:** Optimized `would_violate` and `is_satisfied_by` in `CandidateKey` to avoid cloning `ScalarValue` by extracting references into a reusable pre-allocated vector. Optimized `would_violate_on_insert` and `would_violate_on_delete` in `ForeignKey` by replacing `.collect::<Vec<_>>()` inside an inner loop with a `Vec::with_capacity()` buffer that is `.clear()`ed on each iteration.
🎯 **Why:** To eliminate `O(N)` `Vec` allocations and `ScalarValue` `.clone()` calls during `Relation` modification when checking Candidate and Foreign Key constraints over existing tuples.
📊 **Impact:** Reduces heap allocations substantially on bulk operations (inserts, updates, or constraint checks). 
🔬 **Measurement:** Running `cargo test constraints` shows that the behavior is completely preserved without any regressions.

---
*PR created automatically by Jules for task [3449226416200621064](https://jules.google.com/task/3449226416200621064) started by @madmax983*