### PR TITLE
⚡ Bolt: Pre-allocate vectors in heap tuple extraction

### DIFF
--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -387,7 +387,9 @@ impl HeapFile {
     where
         I: Iterator<Item = &'a SlotEntry>,
     {
-        let mut results = Vec::new();
+        let (lower, _) = slots.size_hint();
+        // pre-allocate to avoid repeated allocations
+        let mut results = Vec::with_capacity(lower);
         for slot in slots {
             let tuple = self.extract_tuple_from_page(page, slot.offset(), slot.length())?;
             results.push(tuple);
@@ -404,7 +406,9 @@ impl HeapFile {
     where
         I: Iterator<Item = &'a VersionedSlotEntry>,
     {
-        let mut results = Vec::new();
+        let (lower, _) = slots.size_hint();
+        // pre-allocate to avoid repeated allocations
+        let mut results = Vec::with_capacity(lower);
         for slot in slots {
             let tuple = self.extract_tuple_from_page(page, slot.offset(), slot.length())?;
             results.push(tuple);


### PR DESCRIPTION
⚡ Bolt: Pre-allocate vectors in heap tuple extraction

💡 What: Changed `Vec::new()` to `Vec::with_capacity(lower)` using `slots.size_hint()` in `extract_tuples_from_slots` and `extract_tuples_from_versioned_slots` in `relvar-storage/src/storage/heap.rs`.
🎯 Why: Avoids repeated dynamic reallocations of the underlying buffer when extracting multiple tuples from a page.
📊 Impact: Reduces heap allocations per page read operation, especially when a page contains many slots.
🔬 Measurement: Run `cargo clippy`, `cargo test`, and `cargo fmt`.

---
*PR created automatically by Jules for task [5047385403904288458](https://jules.google.com/task/5047385403904288458) started by @madmax983*