### PR TITLE
🔒 Warden: [security fix] Fix heap offset integer overflow and unchecked slice conversion

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -194,3 +194,10 @@ The `WalManager` component in `relvar-storage` used `File::read_to_end(&mut buff
 
 **Defense:**
 Added strict file size limits before reading the WAL file. `WalManager` now checks the file metadata length against `MAX_WAL_SIZE` (set to a safe threshold of 2 GB) and returns a standard `std::io::Error::new(std::io::ErrorKind::InvalidData)` wrapped in a `WalError::Io` if the limit is exceeded. This prevents unbounded `Vec` pre-allocations from malicious or overgrown files.
+## 2026-03-30 - Storage Arithmetic & Unchecked Conversion Panics
+**Threat:**
+In `relvar-storage`, several mathematical operations involving slice lengths and offsets (e.g., `start + slot_entry.length as usize`) used standard `+` operators without checking for overflow. Additionally, byte-slice parsing in `page.rs` used `.try_into().unwrap()`. Maliciously crafted storage files could trigger integer overflows or `try_into` panics, leading to Denial of Service (DoS).
+
+**Defense:**
+1. Replaced unbounded `+` operations in `heap.rs` with `.checked_add(...).ok_or(...)`, mapping overflows explicitly to `HeapError::TupleNotFound` or `HeapError::PageFull`.
+2. Replaced the `.unwrap()` on `.try_into()` inside `page.rs` with `.map_err(...)?` returning `PageError::Serialization` to ensure memory-safe error handling.

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -519,7 +519,9 @@ impl HeapFile {
 
         // Calculate total size correctly
         let total_tuple_data_size: usize = existing_tuples.iter().map(|t| t.len()).sum::<usize>();
-        let required_space = header_size + total_tuple_data_size;
+        let required_space = header_size
+            .checked_add(total_tuple_data_size)
+            .ok_or(HeapError::PageFull)?;
 
         if required_space > USABLE_PAGE_SIZE_V1 {
             return Err(HeapError::PageFull);
@@ -592,7 +594,9 @@ impl HeapFile {
 
         // Extract tuple data from page
         let start = slot_entry.offset as usize;
-        let end = start + slot_entry.length as usize;
+        let end = start
+            .checked_add(slot_entry.length as usize)
+            .ok_or(HeapError::TupleNotFound)?;
 
         if end > page.data().len() {
             return Err(HeapError::TupleNotFound);
@@ -627,7 +631,9 @@ impl HeapFile {
 
         // Extract tuple data from page
         let start = slot_entry.offset as usize;
-        let end = start + slot_entry.length as usize;
+        let end = start
+            .checked_add(slot_entry.length as usize)
+            .ok_or(HeapError::TupleNotFound)?;
 
         if end > page.data().len() {
             return Err(HeapError::TupleNotFound);
@@ -862,11 +868,15 @@ impl HeapFile {
         // Calculate required space using ACTUAL serialized size
         // CRITICAL: Must use bincode size, not sizeof, as they differ!
         let slot_dir = serialize_compat(&versioned_page)?;
-        let header_size = V2_HEADER_SIZE + slot_dir.len();
+        let header_size = V2_HEADER_SIZE
+            .checked_add(slot_dir.len())
+            .ok_or(HeapError::PageFull)?;
 
         // existing_tuples already includes tuple_data, so we just sum existing_tuples
         let total_tuple_data_size: usize = existing_tuples.iter().map(|t| t.len()).sum::<usize>();
-        let required_space = header_size + total_tuple_data_size;
+        let required_space = header_size
+            .checked_add(total_tuple_data_size)
+            .ok_or(HeapError::PageFull)?;
 
         if required_space > USABLE_PAGE_SIZE_V2 {
             return Err(HeapError::PageFull);
@@ -1353,7 +1363,11 @@ impl HeapFile {
                 if crate::mvcc::visibility::is_visible(&version_metadata, snapshot, committed) {
                     // Extract tuple data from page
                     let start = slot_entry.offset as usize;
-                    let end = start + slot_entry.length as usize;
+                    let end = start
+                        .checked_add(slot_entry.length as usize)
+                        .ok_or_else(|| {
+                            HeapError::Serialization("Tuple offset overflow".to_string())
+                        })?;
 
                     if end <= page.data().len() {
                         let tuple_data = &page.data()[start..end];

--- a/relvar-storage/src/storage/page.rs
+++ b/relvar-storage/src/storage/page.rs
@@ -336,7 +336,9 @@ impl PageFile {
             )));
         }
 
-        let data_len_u64 = u64::from_le_bytes(buffer[0..8].try_into().unwrap());
+        let data_len_u64 = u64::from_le_bytes(buffer[0..8].try_into().map_err(|_| {
+            PageError::Serialization("Failed to read data length prefix".to_string())
+        })?);
 
         // Check if data length exceeds PAGE_SIZE - 8 (maximum possible data)
         // We check this using u64 arithmetic BEFORE casting to usize to prevent


### PR DESCRIPTION
🔒 Warden: [security fix] Fix heap offset integer overflow and unchecked slice conversion

🦠 Threat: In `relvar-storage`, several mathematical operations involving slice lengths and offsets (e.g., `start + slot_entry.length as usize`) used standard `+` operators without checking for overflow. Additionally, byte-slice parsing in `page.rs` used `.try_into().unwrap()`. Maliciously crafted storage files could trigger integer overflows or `try_into` panics, leading to Denial of Service (DoS) and memory exhaustion.

🛡️ Defense:
1. Replaced unbounded `+` operations in `heap.rs` with `.checked_add(...).ok_or(...)`, mapping overflows explicitly to `HeapError::TupleNotFound` or `HeapError::PageFull`.
2. Replaced the `.unwrap()` on `.try_into()` inside `page.rs` with `.map_err(...)?` returning `PageError::Serialization` to ensure memory-safe error handling.

💥 Severity: Medium to High - could lead to Denial of Service via application panic from malicious storage files or corrupted disk state.

🧪 Verification: Compiled, ran `cargo clippy` and `cargo test` locally. Passed all existing storage tests without introducing regressions.

---
*PR created automatically by Jules for task [12252270850590886985](https://jules.google.com/task/12252270850590886985) started by @madmax983*