### PR TITLE
🪒 Razor: Remove DepthGuarded wrapper and OperationType enum

### DIFF
--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -28,7 +28,6 @@
 //! assert_ne!(widget_id, supplier_id);
 //! ```
 
-use crate::utils::recursion::DepthGuarded;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use thiserror::Error;
@@ -789,10 +788,14 @@ enum ScalarTypeUnchecked {
     String,
     Bool,
     Bytes,
-    Relation(DepthGuarded<Box<crate::types::RelationType>>),
+    Relation(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<crate::types::RelationType>,
+    ),
     UserDefined {
         name: String,
-        representation: Box<DepthGuarded<ScalarTypeUnchecked>>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        representation: Box<ScalarTypeUnchecked>,
     },
 }
 
@@ -800,19 +803,21 @@ impl TryFrom<ScalarTypeUnchecked> for ScalarType {
     type Error = String;
 
     fn try_from(unchecked: ScalarTypeUnchecked) -> Result<Self, Self::Error> {
+        let _guard = crate::utils::recursion::RecursionGuard::new()
+            .map_err(|e| e.to_string())?;
+
         let ty = match unchecked {
             ScalarTypeUnchecked::Int => ScalarType::Int,
             ScalarTypeUnchecked::Float => ScalarType::Float,
             ScalarTypeUnchecked::String => ScalarType::String,
             ScalarTypeUnchecked::Bool => ScalarType::Bool,
             ScalarTypeUnchecked::Bytes => ScalarType::Bytes,
-            ScalarTypeUnchecked::Relation(rel) => ScalarType::Relation(rel.0),
+            ScalarTypeUnchecked::Relation(rel) => ScalarType::Relation(rel),
             ScalarTypeUnchecked::UserDefined {
                 name,
                 representation,
             } => {
-                // Explicitly dereference the Box to access the inner DepthGuarded value
-                let inner = ScalarType::try_from((*representation).0)?;
+                let inner = ScalarType::try_from(*representation)?;
                 ScalarType::UserDefined {
                     name,
                     representation: Box::new(inner),

--- a/relvar-core/src/utils/recursion.rs
+++ b/relvar-core/src/utils/recursion.rs
@@ -1,9 +1,9 @@
 //! Bounded Recursion Safety.
 //!
-//! This module provides a simple `DepthGuarded` wrapper to enforce maximum recursion
+//! This module provides a simple `deserialize_guarded` function to enforce maximum recursion
 //! limits (`MAX_TYPE_DEPTH`) on nested tree structures (like ASTs or nested Types).
 //! This prevents stack overflows, particularly against deeply nested payload attacks.
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::cell::Cell;
 
 thread_local! {
@@ -73,17 +73,15 @@ impl Drop for RecursionGuard {
     }
 }
 
-/// A wrapper that enforces recursion limits during Serde deserialization.
-#[derive(Debug)]
-pub struct DepthGuarded<T>(pub T);
-
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for DepthGuarded<T> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let _guard = RecursionGuard::new().map_err(serde::de::Error::custom)?;
-        let value = T::deserialize(deserializer)?;
-        Ok(DepthGuarded(value))
-    }
+/// A custom deserialization function that enforces recursion limits.
+///
+/// Use this with `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]`
+/// on recursive fields to protect against stack overflows during deserialization.
+pub fn deserialize_guarded<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    let _guard = RecursionGuard::new().map_err(serde::de::Error::custom)?;
+    T::deserialize(deserializer)
 }

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -27,7 +27,6 @@
 //! ```
 
 use crate::types::ScalarType;
-use crate::utils::recursion::DepthGuarded;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use thiserror::Error;
@@ -510,10 +509,14 @@ enum ScalarValueUnchecked {
     String(String),
     Bool(bool),
     Bytes(Vec<u8>),
-    Relation(DepthGuarded<crate::values::Relation>),
+    Relation(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        crate::values::Relation,
+    ),
     UserDefined {
         type_def: ScalarType,
-        value: Box<DepthGuarded<ScalarValueUnchecked>>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        value: Box<ScalarValueUnchecked>,
     },
 }
 
@@ -521,13 +524,16 @@ impl TryFrom<ScalarValueUnchecked> for ScalarValue {
     type Error = String;
 
     fn try_from(unchecked: ScalarValueUnchecked) -> Result<Self, Self::Error> {
+        let _guard = crate::utils::recursion::RecursionGuard::new()
+            .map_err(|e| e.to_string())?;
+
         match unchecked {
             ScalarValueUnchecked::Int(v) => Ok(ScalarValue::Int(v)),
             ScalarValueUnchecked::Float(v) => Ok(ScalarValue::Float(v)),
             ScalarValueUnchecked::String(v) => Ok(ScalarValue::String(v)),
             ScalarValueUnchecked::Bool(v) => Ok(ScalarValue::Bool(v)),
             ScalarValueUnchecked::Bytes(v) => Ok(ScalarValue::Bytes(v)),
-            ScalarValueUnchecked::Relation(v) => Ok(ScalarValue::Relation(v.0)),
+            ScalarValueUnchecked::Relation(v) => Ok(ScalarValue::Relation(v)),
             ScalarValueUnchecked::UserDefined { type_def, value } => {
                 // First, ensure the type definition itself is a UserDefined type.
                 // A ScalarValue::UserDefined variant must have a ScalarType::UserDefined type definition.
@@ -543,8 +549,7 @@ impl TryFrom<ScalarValueUnchecked> for ScalarValue {
                 };
 
                 // Recursively convert and validate the inner value
-                // Unwrap the DepthGuarded wrapper
-                let inner_value = ScalarValue::try_from((*value).0)?;
+                let inner_value = ScalarValue::try_from(*value)?;
 
                 // Enforce type consistency: inner value MUST match the representation type
                 if !inner_value.is_type(representation) {

--- a/relvar-storage/src/storage/heap.rs
+++ b/relvar-storage/src/storage/heap.rs
@@ -56,13 +56,6 @@ pub(crate) struct TupleId {
     pub(crate) slot: u32,
 }
 
-/// Operation type for size checking (Insert vs Update)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OperationType {
-    Insert,
-    Update,
-}
-
 /// Errors that can occur during heap file operations.
 #[derive(Debug, Error)]
 pub enum HeapError {
@@ -766,7 +759,7 @@ impl HeapFile {
 
         // Check if tuple is too large to ever fit
         // New inserts have no previous version (prev_version = None)
-        self.check_versioned_tuple_size_limit(tuple_data.len(), OperationType::Insert)?;
+        self.check_versioned_tuple_size_limit(tuple_data.len(), None)?;
 
         // Find a page with enough space, or create a new one
         self.find_page_for_insertion(|heap, page_id| {
@@ -779,7 +772,7 @@ impl HeapFile {
     fn check_versioned_tuple_size_limit(
         &self,
         tuple_data_len: usize,
-        op_type: OperationType,
+        prev_version: Option<TupleId>,
     ) -> Result<(), HeapError> {
         // Create a dummy versioned page with one slot
         let dummy_page = VersionedSlottedPage {
@@ -790,13 +783,7 @@ impl HeapFile {
                 length: tuple_data_len as u32,
                 xmin: crate::wal::TransactionId::new(0),
                 xmax: None,
-                prev_version: match op_type {
-                    OperationType::Update => Some(TupleId {
-                        page_id: 0,
-                        slot: 0,
-                    }),
-                    OperationType::Insert => None,
-                },
+                prev_version,
             })],
         };
 
@@ -1134,7 +1121,7 @@ impl HeapFile {
 
         // Check if new tuple is too large
         // Updates link to previous version (prev_version = Some(...))
-        self.check_versioned_tuple_size_limit(new_tuple_data.len(), OperationType::Update)?;
+        self.check_versioned_tuple_size_limit(new_tuple_data.len(), Some(TupleId { page_id: 0, slot: 0 }))?;
 
         // Find a page with space for new version
         self.find_page_for_insertion(|heap, page_id| {
@@ -3620,12 +3607,12 @@ mod security_tests {
 
             // Check if it fits with None (insert)
             let fits_insert = heap
-                .check_versioned_tuple_size_limit(tuple_data_len, OperationType::Insert)
+                .check_versioned_tuple_size_limit(tuple_data_len, None)
                 .is_ok();
 
             // Check if it fits with Some (update)
             let fits_update = heap
-                .check_versioned_tuple_size_limit(tuple_data_len, OperationType::Update)
+                .check_versioned_tuple_size_limit(tuple_data_len, Some(TupleId { page_id: 0, slot: 0 }))
                 .is_ok();
 
             if fits_insert && !fits_update {


### PR DESCRIPTION
🪒 Razor: Flattening unnecessary abstractions and removing bloat

**Bloat:** 
- The `DepthGuarded` wrapper struct in `utils/recursion.rs` was adding unnecessary indirection and boilerplate just to enforce a recursion limit during deserialization.
- The `OperationType` enum in `storage/heap.rs` was a redundant two-variant enum (`Insert`, `Update`) that was just being matched to create an `Option<TupleId>`.

**Cut:** 
- Removed `DepthGuarded` entirely. Replaced it with a module-level `deserialize_guarded` function in `utils/recursion.rs` that applies `RecursionGuard`. Used the `#[serde(deserialize_with = "...")]` attribute to directly apply this guard to recursive fields on `ScalarTypeUnchecked` and `ScalarValueUnchecked`.
- Removed `OperationType` enum. Simplified `check_versioned_tuple_size_limit` to accept an `Option<TupleId>` for the previous version directly.

**Saved:** 
- Eliminated 2 structs/enums and flattened the type hierarchy.
- Improved code clarity and reduced boilerplate pattern matching.

---
*PR created automatically by Jules for task [12381609034651380406](https://jules.google.com/task/12381609034651380406) started by @madmax983*