### PR TITLE
🔒 Warden: Fix CSV importer infinite loop DoS

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -194,3 +194,9 @@ The `WalManager` component in `relvar-storage` used `File::read_to_end(&mut buff
 
 **Defense:**
 Added strict file size limits before reading the WAL file. `WalManager` now checks the file metadata length against `MAX_WAL_SIZE` (set to a safe threshold of 2 GB) and returns a standard `std::io::Error::new(std::io::ErrorKind::InvalidData)` wrapped in a `WalError::Io` if the limit is exceeded. This prevents unbounded `Vec` pre-allocations from malicious or overgrown files.
+## 2026-03-07 - CSV Importer Infinite Loop DoS
+**Threat:**
+The CSV importer (`relvar::tools::importer::from_csv`) enforced the `MAX_IMPORT_ROWS` limit by checking `relation.cardinality()`. Since `relation.insert` ignores duplicate tuples, an attacker could supply a massive CSV file containing identical rows. The cardinality would remain 1, bypassing the limit check and causing the server to process the entire file in an unbounded loop, leading to CPU and I/O exhaustion (Denial of Service).
+
+**Defense:**
+Modified `from_csv` to enforce the `MAX_IMPORT_ROWS` limit using `line_idx` (the number of rows read from the source) rather than `relation.cardinality()`. This guarantees the parser will halt after processing `MAX_IMPORT_ROWS` lines, regardless of tuple uniqueness. Added `warden_csv_import_dos.rs` to verify the exploit fails.

--- a/relvar/src/tools/importer.rs
+++ b/relvar/src/tools/importer.rs
@@ -474,7 +474,7 @@ pub fn from_csv<R: std::io::Read>(
     let mut line_buf = String::new();
     let mut line_idx = 0;
     while read_line_safe(&mut reader, &mut line_buf)? > 0 {
-        if relation.cardinality() >= MAX_IMPORT_ROWS {
+        if line_idx >= MAX_IMPORT_ROWS {
             return Err(ImporterError::LimitExceeded(format!(
                 "Size limit exceeded: Max rows: {}",
                 MAX_IMPORT_ROWS

--- a/relvar/tests/warden_csv_import_dos.rs
+++ b/relvar/tests/warden_csv_import_dos.rs
@@ -1,0 +1,62 @@
+use relvar::tools::importer;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
+use std::io::Read;
+
+struct DuplicateReader {
+    line: &'static [u8],
+    count: usize,
+    limit: usize,
+    pos: usize,
+}
+
+impl Read for DuplicateReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.count >= self.limit {
+            return Ok(0);
+        }
+        let mut written = 0;
+        while written < buf.len() && self.count < self.limit {
+            let n = std::cmp::min(buf.len() - written, self.line.len() - self.pos);
+            buf[written..written + n].copy_from_slice(&self.line[self.pos..self.pos + n]);
+            written += n;
+            self.pos += n;
+            if self.pos >= self.line.len() {
+                self.pos = 0;
+                self.count += 1;
+            }
+        }
+        Ok(written)
+    }
+}
+
+#[test]
+fn test_csv_importer_duplicate_row_limit() {
+    let heading = TupleType::new()
+        .with_attribute("id", ScalarType::Int)
+        .with_attribute("name", ScalarType::String);
+    let rel_type = RelationType::new(heading);
+
+    // Header + 100_001 duplicate rows.
+    // MAX_IMPORT_ROWS is 100_000.
+    // If the importer checks cardinality instead of processed rows, it will process all 200,000 without returning LimitExceeded, because cardinality is 1.
+
+    let mut header = std::io::Cursor::new("id,name\n".as_bytes());
+    let duplicates = DuplicateReader {
+        line: b"1,\"Alice\"\n",
+        count: 0,
+        limit: 200_000,
+        pos: 0,
+    };
+
+    let reader = std::io::Read::chain(&mut header, duplicates);
+
+    let result = importer::from_csv(reader, rel_type, ',');
+
+    // It must fail with LimitExceeded
+    match result {
+        Err(importer::ImporterError::LimitExceeded(_)) => {
+            // Expected
+        }
+        res => panic!("Expected LimitExceeded, got: {:?}", res),
+    }
+}


### PR DESCRIPTION
🦠 **Threat:** 
The CSV importer (`relvar::tools::importer::from_csv`) enforced the `MAX_IMPORT_ROWS` limit by checking `relation.cardinality()`. Since `relation.insert` silently ignores duplicate tuples, an attacker could supply a massive CSV file containing identical rows. The cardinality would remain 1, bypassing the limit check and causing the server to process the entire file in an unbounded loop, leading to CPU and I/O exhaustion (Denial of Service).

🛡️ **Defense:** 
Modified `from_csv` to enforce the `MAX_IMPORT_ROWS` limit using `line_idx` (the number of rows read from the source) rather than `relation.cardinality()`. This guarantees the parser will halt after processing `MAX_IMPORT_ROWS` lines, regardless of tuple uniqueness. 

💥 **Severity:** 
High - Could lead to server unresponsiveness and resource exhaustion via a small malicious payload acting like a zip bomb over streamed network connections.

🧪 **Verification:** 
Added `warden_csv_import_dos.rs` to explicitly verify the duplicate row exploit fails with a `LimitExceeded` error instead of hanging. Ran `cargo clippy`, `cargo test`, and `cargo audit`.

---
*PR created automatically by Jules for task [8991353673093085107](https://jules.google.com/task/8991353673093085107) started by @madmax983*