### PR TITLE
⚒️ Forge: Replace RwLock unwrap in PersistentEngine

### DIFF
--- a/relvar-storage/src/persistent_engine.rs
+++ b/relvar-storage/src/persistent_engine.rs
@@ -153,7 +153,7 @@ impl PersistentEngine {
         let snapshot = self.get_snapshot_for_current_context()?;
 
         // scan_relation implicitly filters out uncommitted tuples because they are not in committed_txns
-        let relation = self.storage_manager.write().unwrap().scan_relation(
+        let relation = self.storage_manager.write().map_err(|_| StorageError::Other("Lock poisoned".to_string()))?.scan_relation(
             relation_name,
             &snapshot,
             &self.committed_txns,
@@ -180,7 +180,7 @@ impl PersistentEngine {
         self.flush_wal()?;
 
         // Now safe to flush heap files (dirty pages to disk)
-        self.storage_manager.write().unwrap().flush_heap_files()?;
+        self.storage_manager.write().map_err(|_| StorageError::Other("Lock poisoned".to_string()))?.flush_heap_files()?;
 
         // Determine minimum active LSN
         let min_active_lsn = self.get_checkpoint_lsn();
@@ -281,11 +281,11 @@ impl StorageEngine for PersistentEngine {
     }
 
     fn drop_relation(&mut self, name: &str) -> Result<(), StorageError> {
-        self.storage_manager.write().unwrap().drop_relation(name)
+        self.storage_manager.write().map_err(|_| StorageError::Other("Lock poisoned".to_string()))?.drop_relation(name)
     }
 
     fn relation_exists(&self, name: &str) -> bool {
-        self.storage_manager.read().unwrap().relation_exists(name)
+        self.storage_manager.read().unwrap_or_else(|_| panic!("Lock poisoned")).relation_exists(name)
     }
 
     fn get_relation_metadata(&self, name: &str) -> Result<RelationMetadata, StorageError> {
@@ -296,7 +296,7 @@ impl StorageEngine for PersistentEngine {
     }
 
     fn list_relations(&self) -> Vec<String> {
-        self.storage_manager.read().unwrap().list_relations()
+        self.storage_manager.read().unwrap_or_else(|_| panic!("Lock poisoned")).list_relations()
     }
 
     fn load_relation(&self, name: &str) -> Result<Relation, StorageError> {
@@ -378,7 +378,7 @@ impl StorageEngine for PersistentEngine {
             .flush()
             .map_err(|e| StorageError::Other(format!("WAL flush error: {}", e)))?;
 
-        self.storage_manager.write().unwrap().flush_heap_files()?;
+        self.storage_manager.write().map_err(|_| StorageError::Other("Lock poisoned".to_string()))?.flush_heap_files()?;
 
         self.committed_txns.insert(snapshot.txn_id);
         self.active_txns.commit(snapshot.txn_id);


### PR DESCRIPTION
Replaced multiple instances of `unwrap()` on `RwLock` acquisitions within `relvar-storage/src/persistent_engine.rs` to ensure robust error handling. Methods returning a `Result` now propagate an explicit `StorageError::Other("Lock poisoned")` error when a lock is poisoned, instead of panicking. Methods not returning a `Result` were updated to use `.unwrap_or_else(|_| panic!("Lock poisoned"))` to make the panic explicit and idiomatic.

---
*PR created automatically by Jules for task [2494418011069787556](https://jules.google.com/task/2494418011069787556) started by @madmax983*