### PR TITLE
⚒️ Forge: Refactor ScalarValue eq and hash nesting

### DIFF
--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -238,6 +238,10 @@ impl Drop for ScalarValue {
 // the same representation value. This ensures type safety.
 impl PartialEq for ScalarValue {
     fn eq(&self, other: &Self) -> bool {
+        if std::mem::discriminant(self) != std::mem::discriminant(other) {
+            return false;
+        }
+
         match (self, other) {
             (ScalarValue::Int(a), ScalarValue::Int(b)) => a == b,
             (ScalarValue::Float(a), ScalarValue::Float(b)) => {
@@ -260,36 +264,8 @@ impl PartialEq for ScalarValue {
                     type_def: type_b,
                     value: val_b,
                 },
-            ) => {
-                if type_a != type_b {
-                    return false;
-                }
-                // Iterative comparison to prevent stack overflow
-                let mut cur_a = val_a;
-                let mut cur_b = val_b;
-                loop {
-                    match (&**cur_a, &**cur_b) {
-                        (
-                            ScalarValue::UserDefined {
-                                type_def: ta,
-                                value: va,
-                            },
-                            ScalarValue::UserDefined {
-                                type_def: tb,
-                                value: vb,
-                            },
-                        ) => {
-                            if ta != tb {
-                                return false;
-                            }
-                            cur_a = va;
-                            cur_b = vb;
-                        }
-                        (a, b) => return a == b,
-                    }
-                }
-            }
-            _ => false,
+            ) => ScalarValue::eq_user_defined_values(type_a, val_a, type_b, val_b),
+            _ => unreachable!("Discriminant check should have caught mismatched types"),
         }
     }
 }
@@ -331,26 +307,7 @@ impl std::hash::Hash for ScalarValue {
                 v.hash(state);
             }
             ScalarValue::UserDefined { type_def, value } => {
-                6u8.hash(state);
-                type_def.hash(state);
-                // Iterative hash to prevent stack overflow
-                let mut cur = value;
-                loop {
-                    match &**cur {
-                        ScalarValue::UserDefined {
-                            type_def: t,
-                            value: v,
-                        } => {
-                            6u8.hash(state);
-                            t.hash(state);
-                            cur = v;
-                        }
-                        other => {
-                            other.hash(state);
-                            break;
-                        }
-                    }
-                }
+                ScalarValue::hash_user_defined_value(type_def, value, state);
             }
         }
     }
@@ -458,6 +415,69 @@ impl ScalarValue {
         match a.cardinality().cmp(&b.cardinality()) {
             Ordering::Equal => a.degree().cmp(&b.degree()),
             other => other,
+        }
+    }
+
+    fn eq_user_defined_values(
+        type_a: &ScalarType,
+        val_a: &ScalarValue,
+        type_b: &ScalarType,
+        val_b: &ScalarValue,
+    ) -> bool {
+        if type_a != type_b {
+            return false;
+        }
+        // Iterative comparison to prevent stack overflow
+        let mut cur_a = val_a;
+        let mut cur_b = val_b;
+        loop {
+            match (cur_a, cur_b) {
+                (
+                    ScalarValue::UserDefined {
+                        type_def: ta,
+                        value: va,
+                    },
+                    ScalarValue::UserDefined {
+                        type_def: tb,
+                        value: vb,
+                    },
+                ) => {
+                    if ta != tb {
+                        return false;
+                    }
+                    cur_a = va.as_ref();
+                    cur_b = vb.as_ref();
+                }
+                (a, b) => return a == b,
+            }
+        }
+    }
+
+    fn hash_user_defined_value<H: std::hash::Hasher>(
+        type_def: &ScalarType,
+        value: &ScalarValue,
+        state: &mut H,
+    ) {
+        use std::hash::Hash;
+        6u8.hash(state);
+        type_def.hash(state);
+        // Iterative hash to prevent stack overflow
+        let mut cur = value;
+        loop {
+            match cur {
+                ScalarValue::UserDefined {
+                    type_def: t,
+                    value: v,
+                } => {
+                    6u8.hash(state);
+                    t.hash(state);
+                    cur = v.as_ref();
+                }
+                other => {
+                    other.hash(state);
+                    break;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
🚮 Smell: The `PartialEq::eq` and `Hash::hash` implementations for `ScalarValue` in `relvar-core/src/values/scalar.rs` contained deeply nested "Pyramid of Doom" structures for the recursive `UserDefined` variant, making the code hard to read and increasing cognitive load.

✨ Solution: Extracted the recursive logic into private helper functions `eq_user_defined_values` and `hash_user_defined_value`. Additionally, added a guard clause using `std::mem::discriminant` at the beginning of `PartialEq::eq` to return early if the types don't match, allowing for a cleaner `match` block.

🧼 Benefit: Dramatically improves readability by flattening the structure, adhering to the "nesting is the mind-killer" philosophy. The code is strictly a refactor with zero behavior changes, providing a cleaner foundation.

🛡️ Verification: Tests passed. No logic changed. Compiled with `cargo clippy --all-targets --all-features -- -D warnings` and verified with `cargo test`.

---
*PR created automatically by Jules for task [7849799654715400733](https://jules.google.com/task/7849799654715400733) started by @madmax983*