### PR TITLE
🪒 Razor: Flatten `DepthGuarded` structure in scalar types

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `OperationType` enum with only `Insert` and `Update` variants in `relvar-storage/src/storage/heap.rs`.
 **Cut:** Replaced `OperationType` enum with a simple `bool` flag (`is_update: bool`) since it only had two states.
 **Saved:** Removed enum definition and simplified pattern matching.
+
+## [Reduction]
+**Bloat:** `DepthGuarded<T>` struct wrapper used to prevent recursive serialization/deserialization panics. Added nesting and `.0` boilerplate when unpacking scalars.
+**Cut:** Removed the wrapper struct, replacing it with a custom `deserialize_guarded` function applied via `#[serde(deserialize_with = "...")]` to directly flatten recursive structures.
+**Saved:** Reduced boilerplate wrapper types, streamlined Serde parsing logic, and eliminated intermediate `.0` tuple accesses.

--- a/plan.md
+++ b/plan.md
@@ -1,21 +1,4 @@
-1. **Refactor `ScalarValue::eq` and `Hash` in `relvar-core/src/values/scalar.rs`**
-   - The `eq` method in `PartialEq` implementation is a nested `match` block.
-   - We have viewed the full `eq` and `hash` implementations. The `UserDefined` loop logic in `eq` spans lines 267-291, and the `UserDefined` loop logic in `hash` spans lines 336-353.
-   - We will extract `eq_user_defined_values` into `impl ScalarValue` to match the `cmp_user_defined_values` pattern that was confirmed to exist (lines 464-502).
-   - We will extract `eq_floats` into `impl ScalarValue` to match the `cmp_floats` pattern that was confirmed to exist (lines 415-450).
-   - We will refactor `eq` to use an early return: `if std::mem::discriminant(self) != std::mem::discriminant(other) { return false; }`. This flattens the match arms, replacing the nested `match (self, other)` logic.
-   - For `Hash`, we will extract a `hash_user_defined_values` helper method inside `impl ScalarValue` and call it from the `Hash` implementation to flatten the function.
-   - I will use `replace_with_git_merge_diff` to make these changes.
-
-2. **Run tests & clippy**
-   - Run `cargo clippy --all-targets --all-features -- -D warnings` using `run_in_bash_session`.
-   - Run `cargo test` using `run_in_bash_session` to ensure these refactors do not break behavior.
-   - Run `cargo fmt --all` using `run_in_bash_session`.
-
-3. **Complete pre-commit steps**
-   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done using `pre_commit_instructions`.
-
-4. **Submit PR**
-   - Use `submit` with branch `forge/refactor-scalar-eq`
-   - Title: `⚒️ Forge: refactor ScalarValue eq and hash methods`
-   - Describe Smell, Solution, Benefit, and Verification according to Forge's process.
+1. **Remove `DepthGuarded` wrapper struct** in `relvar-core/src/utils/recursion.rs`. Add a generic helper function `deserialize_with_guard` instead.
+2. **Update `ScalarType` and `ScalarValue`** to use `#[serde(deserialize_with = "...")]` instead of the `DepthGuarded` wrapper type. Remove the intermediate `ScalarTypeUnchecked` and `ScalarValueUnchecked` enums, which adds unnecessary complexity. We can enforce `MAX_TYPE_DEPTH` invariant directly in the `TryFrom` or using standard serde validations. Wait, if we use `deserialize_with`, we might not need the unchecked enums at all, as we can check the limits natively.
+Let's see the memory constraint:
+"When enforcing recursion limits during Serde deserialization, avoid wrapping types in custom guard structs (like `DepthGuarded`). Instead, use `#[serde(deserialize_with = "...")]` to call a custom deserialization function that encapsulates the guard logic, keeping the type hierarchy flat."

--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -28,7 +28,6 @@
 //! assert_ne!(widget_id, supplier_id);
 //! ```
 
-use crate::utils::recursion::DepthGuarded;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use thiserror::Error;
@@ -806,10 +805,14 @@ enum ScalarTypeUnchecked {
     String,
     Bool,
     Bytes,
-    Relation(DepthGuarded<Box<crate::types::RelationType>>),
+    Relation(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<crate::types::RelationType>,
+    ),
     UserDefined {
         name: String,
-        representation: Box<DepthGuarded<ScalarTypeUnchecked>>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        representation: Box<ScalarTypeUnchecked>,
     },
 }
 
@@ -823,13 +826,13 @@ impl TryFrom<ScalarTypeUnchecked> for ScalarType {
             ScalarTypeUnchecked::String => ScalarType::String,
             ScalarTypeUnchecked::Bool => ScalarType::Bool,
             ScalarTypeUnchecked::Bytes => ScalarType::Bytes,
-            ScalarTypeUnchecked::Relation(rel) => ScalarType::Relation(rel.0),
+            ScalarTypeUnchecked::Relation(rel) => ScalarType::Relation(rel),
             ScalarTypeUnchecked::UserDefined {
                 name,
                 representation,
             } => {
-                // Explicitly dereference the Box to access the inner DepthGuarded value
-                let inner = ScalarType::try_from((*representation).0)?;
+                // Explicitly dereference the Box to access the inner value
+                let inner = ScalarType::try_from(*representation)?;
                 ScalarType::UserDefined {
                     name,
                     representation: Box::new(inner),

--- a/relvar-core/src/utils/recursion.rs
+++ b/relvar-core/src/utils/recursion.rs
@@ -73,17 +73,15 @@ impl Drop for RecursionGuard {
     }
 }
 
-/// A wrapper that enforces recursion limits during Serde deserialization.
-#[derive(Debug)]
-pub struct DepthGuarded<T>(pub T);
-
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for DepthGuarded<T> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let _guard = RecursionGuard::new().map_err(serde::de::Error::custom)?;
-        let value = T::deserialize(deserializer)?;
-        Ok(DepthGuarded(value))
-    }
+/// A custom deserialization function that encapsulates the recursion guard logic.
+///
+/// It should be used with `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]`
+/// to enforce recursion limits during Serde deserialization without wrapping types in custom guard structs.
+pub fn deserialize_guarded<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    let _guard = RecursionGuard::new().map_err(serde::de::Error::custom)?;
+    T::deserialize(deserializer)
 }

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -27,7 +27,6 @@
 //! ```
 
 use crate::types::ScalarType;
-use crate::utils::recursion::DepthGuarded;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use thiserror::Error;
@@ -510,10 +509,14 @@ enum ScalarValueUnchecked {
     String(String),
     Bool(bool),
     Bytes(Vec<u8>),
-    Relation(DepthGuarded<crate::values::Relation>),
+    Relation(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        crate::values::Relation,
+    ),
     UserDefined {
         type_def: ScalarType,
-        value: Box<DepthGuarded<ScalarValueUnchecked>>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        value: Box<ScalarValueUnchecked>,
     },
 }
 
@@ -527,7 +530,7 @@ impl TryFrom<ScalarValueUnchecked> for ScalarValue {
             ScalarValueUnchecked::String(v) => Ok(ScalarValue::String(v)),
             ScalarValueUnchecked::Bool(v) => Ok(ScalarValue::Bool(v)),
             ScalarValueUnchecked::Bytes(v) => Ok(ScalarValue::Bytes(v)),
-            ScalarValueUnchecked::Relation(v) => Ok(ScalarValue::Relation(v.0)),
+            ScalarValueUnchecked::Relation(v) => Ok(ScalarValue::Relation(v)),
             ScalarValueUnchecked::UserDefined { type_def, value } => {
                 // First, ensure the type definition itself is a UserDefined type.
                 // A ScalarValue::UserDefined variant must have a ScalarType::UserDefined type definition.
@@ -543,8 +546,7 @@ impl TryFrom<ScalarValueUnchecked> for ScalarValue {
                 };
 
                 // Recursively convert and validate the inner value
-                // Unwrap the DepthGuarded wrapper
-                let inner_value = ScalarValue::try_from((*value).0)?;
+                let inner_value = ScalarValue::try_from(*value)?;
 
                 // Enforce type consistency: inner value MUST match the representation type
                 if !inner_value.is_type(representation) {


### PR DESCRIPTION
Replaces the `DepthGuarded` struct wrapper with a targeted `deserialize_guarded` function applied directly via `#[serde(deserialize_with = "...")]`. This eliminates unnecessary `.0` tuple accesses and flat type nesting in AST definitions, satisfying the YAGNI and KISS principles. Updated Razor journal.

---
*PR created automatically by Jules for task [2086395530189430792](https://jules.google.com/task/2086395530189430792) started by @madmax983*