### PR TITLE
⚡ Bolt: [performance improvement] Optimize Tuple::new

### DIFF
--- a/relvar-core/src/values/tuple.rs
+++ b/relvar-core/src/values/tuple.rs
@@ -194,27 +194,30 @@ impl Tuple {
         M: IntoIterator<Item = (String, ScalarValue)>,
     {
         let tuple_type: Arc<TupleType> = tuple_type.into();
-        let values_map: BTreeMap<String, ScalarValue> = values.into_iter().collect();
+        let mut values_map = BTreeMap::new();
 
-        // Verify all attributes have values
-        for attr_name in tuple_type.attribute_names() {
-            if !values_map.contains_key(attr_name) {
-                return Err(TupleError::MissingValue(attr_name.clone()));
-            }
-        }
-
-        // Verify all values match their types
-        for (attr_name, value) in &values_map {
-            if let Some(expected_type) = tuple_type.get_attribute_type(attr_name) {
+        // Validate values during collection to avoid double iteration and allocations on invalid data
+        for (attr_name, value) in values {
+            if let Some(expected_type) = tuple_type.get_attribute_type(&attr_name) {
                 if !value.is_type(expected_type) {
                     return Err(TupleError::TypeMismatch(
-                        attr_name.clone(),
+                        attr_name,
                         expected_type.name().to_string(),
                         value.scalar_type().name().to_string(),
                     ));
                 }
+                values_map.insert(attr_name, value);
             } else {
-                return Err(TupleError::AttributeNotFound(attr_name.clone()));
+                return Err(TupleError::AttributeNotFound(attr_name));
+            }
+        }
+
+        // Verify all attributes have values. Optimize by checking length first.
+        if values_map.len() != tuple_type.degree() {
+            for attr_name in tuple_type.attribute_names() {
+                if !values_map.contains_key(attr_name) {
+                    return Err(TupleError::MissingValue(attr_name.clone()));
+                }
             }
         }
 


### PR DESCRIPTION
💡 What: Optimized `Tuple::new` in `relvar-core` to perform attribute validation (type checking) during the initial consumption of the iterator.
🎯 Why: Previously, `Tuple::new` collected the iterator into a `BTreeMap` and then iterated over it *twice* more to check for missing values and type mismatches. If an error was found, it also cloned the attribute name string to pass into the error enum.
📊 Impact:
- Eliminates collecting invalid data into the `BTreeMap`.
- Eliminates two `.clone()` string allocations on error paths.
- Reduces loop passes over attributes from up to 3 down to 1 (plus an O(1) `.len()` check on the hot path).
- Avoids an additional iteration map lookup overhead.
🔬 Measurement: Verified with `cargo test` and `cargo clippy`.

---
*PR created automatically by Jules for task [13692094994469278151](https://jules.google.com/task/13692094994469278151) started by @madmax983*