### PR TITLE
⚒️ Forge: [refactor test setup logic and add guard clause to rename]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -544,3 +544,7 @@ Build it right, make it fast, keep it simple.
 ## 2026-03-14 - Extract Complex PartialEq and Hash Logic
 **Learning:** `PartialEq::eq` and `Hash::hash` implementations in `relvar-core/src/values/scalar.rs` (`ScalarValue`) had deeply nested `match` branches for complex variants like `UserDefined`.
 **Action:** Replaced nested `match` inside `PartialEq::eq` with an upfront `std::mem::discriminant` guard clause for type mismatch, and extracted the complex variant match arms into private helper functions like `eq_user_defined_values` and `hash_user_defined_value`. Ensure `&Box<T>` references are explicitly mapped to `&T` using `.as_ref()` in loops.
+
+## 2026-03-14 - Extract Database Test Setup Logic
+**Learning:** `relvar-core/src/database/tests.rs` contained significant duplicate test setup logic for creating `PARENT` and `CHILD` relation types and setting up their tables, making the tests noisy and harder to read.
+**Action:** Extract duplicate test setup into a helper function `setup_parent_child_db` inside the test module. This removes repetitive boilerplate across testing functions and simplifies test logic.

--- a/relvar-core/src/algebra/rename.rs
+++ b/relvar-core/src/algebra/rename.rs
@@ -151,6 +151,10 @@ impl Relation {
     /// from the old names to the new names while consuming the source relation.
     /// This reduces heap allocations and `.clone()` overhead.
     pub fn rename_into(self, mappings: &[(&str, &str)]) -> Self {
+        if mappings.is_empty() {
+            return self;
+        }
+
         // Build new heading with renamed attributes
         let mut new_heading = TupleType::new();
 

--- a/relvar-core/src/database/tests.rs
+++ b/relvar-core/src/database/tests.rs
@@ -18,6 +18,32 @@ fn test_rel_type() -> RelationType {
     )
 }
 
+fn setup_parent_child_db() -> Database<InMemoryEngine> {
+    use crate::constraints::{KeyConstraints, PrimaryKey};
+    let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
+
+    let parent_type = RelationType::new(
+        TupleType::new()
+            .with_attribute("id", ScalarType::Int)
+            .with_attribute("name", ScalarType::String),
+    );
+    let child_type = RelationType::new(
+        TupleType::new()
+            .with_attribute("child_id", ScalarType::Int)
+            .with_attribute("parent_id", ScalarType::Int),
+    );
+
+    db.create_relvar("PARENT", parent_type).unwrap();
+    db.create_relvar("CHILD", child_type).unwrap();
+
+    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let parent_constraints = KeyConstraints::new().with_primary_key(pk);
+    db.set_key_constraints("PARENT", parent_constraints)
+        .unwrap();
+
+    db
+}
+
 #[test]
 fn test_create_and_query_relvar() {
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
@@ -314,29 +340,9 @@ fn test_virtual_relvar() {
 
 #[test]
 fn test_delete_with_foreign_key_constraint() {
-    use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+    use crate::constraints::{ForeignKey, ForeignKeyConstraints};
 
-    let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
-
-    // Create parent and child
-    let parent_type = RelationType::new(
-        TupleType::new()
-            .with_attribute("id", ScalarType::Int)
-            .with_attribute("name", ScalarType::String),
-    );
-    let child_type = RelationType::new(
-        TupleType::new()
-            .with_attribute("child_id", ScalarType::Int)
-            .with_attribute("parent_id", ScalarType::Int),
-    );
-
-    db.create_relvar("PARENT", parent_type).unwrap();
-    db.create_relvar("CHILD", child_type).unwrap();
-
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
-    let parent_constraints = KeyConstraints::new().with_primary_key(pk);
-    db.set_key_constraints("PARENT", parent_constraints)
-        .unwrap();
+    let mut db = setup_parent_child_db();
 
     let fk = ForeignKey::new(
         vec!["parent_id".to_string()],
@@ -663,29 +669,9 @@ fn test_virtual_relvar_error_propagation() {
 
 #[test]
 fn test_set_foreign_key_constraints_with_existing_valid_data() {
-    use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+    use crate::constraints::{ForeignKey, ForeignKeyConstraints};
 
-    let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
-
-    // Create parent and child relvars
-    let parent_type = RelationType::new(
-        TupleType::new()
-            .with_attribute("id", ScalarType::Int)
-            .with_attribute("name", ScalarType::String),
-    );
-    let child_type = RelationType::new(
-        TupleType::new()
-            .with_attribute("child_id", ScalarType::Int)
-            .with_attribute("parent_id", ScalarType::Int),
-    );
-
-    db.create_relvar("PARENT", parent_type).unwrap();
-    db.create_relvar("CHILD", child_type).unwrap();
-
-    // Set PK on parent
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
-    db.set_key_constraints("PARENT", KeyConstraints::new().with_primary_key(pk))
-        .unwrap();
+    let mut db = setup_parent_child_db();
 
     // Insert data BEFORE setting FK
     db.insert("PARENT", tuple! { id: 1i64, name: "Parent1" })
@@ -709,29 +695,9 @@ fn test_set_foreign_key_constraints_with_existing_valid_data() {
 
 #[test]
 fn test_set_foreign_key_constraints_with_existing_invalid_data() {
-    use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+    use crate::constraints::{ForeignKey, ForeignKeyConstraints};
 
-    let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
-
-    // Create parent and child relvars
-    let parent_type = RelationType::new(
-        TupleType::new()
-            .with_attribute("id", ScalarType::Int)
-            .with_attribute("name", ScalarType::String),
-    );
-    let child_type = RelationType::new(
-        TupleType::new()
-            .with_attribute("child_id", ScalarType::Int)
-            .with_attribute("parent_id", ScalarType::Int),
-    );
-
-    db.create_relvar("PARENT", parent_type).unwrap();
-    db.create_relvar("CHILD", child_type).unwrap();
-
-    // Set PK on parent
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
-    db.set_key_constraints("PARENT", KeyConstraints::new().with_primary_key(pk))
-        .unwrap();
+    let mut db = setup_parent_child_db();
 
     // Insert data BEFORE setting FK
     db.insert("PARENT", tuple! { id: 1i64, name: "Parent1" })
@@ -762,27 +728,9 @@ fn test_set_foreign_key_constraints_with_existing_invalid_data() {
 
 #[test]
 fn test_delete_referenced_parent_success() {
-    use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+    use crate::constraints::{ForeignKey, ForeignKeyConstraints};
 
-    let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
-
-    let parent_type = RelationType::new(
-        TupleType::new()
-            .with_attribute("id", ScalarType::Int)
-            .with_attribute("name", ScalarType::String),
-    );
-    let child_type = RelationType::new(
-        TupleType::new()
-            .with_attribute("child_id", ScalarType::Int)
-            .with_attribute("parent_id", ScalarType::Int),
-    );
-
-    db.create_relvar("PARENT", parent_type).unwrap();
-    db.create_relvar("CHILD", child_type).unwrap();
-
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
-    db.set_key_constraints("PARENT", KeyConstraints::new().with_primary_key(pk))
-        .unwrap();
+    let mut db = setup_parent_child_db();
 
     let fk = ForeignKey::new(
         vec!["parent_id".to_string()],


### PR DESCRIPTION
🚮 **Smell:** `relvar-core/src/database/tests.rs` contained significant duplicate test setup logic for creating `PARENT` and `CHILD` relations. Additionally, `relvar-core/src/algebra/rename.rs` executed `rename_into` allocations even when `mappings` was empty.

✨ **Solution:** Extracted duplicate test setup into a helper function `setup_parent_child_db`. Added an early return guard clause `if mappings.is_empty() { return self; }` to `rename_into`. Updated `.jules/forge.md` to document the learning.

🧼 **Benefit:** Removes repetitive boilerplate across testing functions and simplifies test logic. Prevents unnecessary allocation overhead and execution if there's no rename mapping.

🛡️ **Verification:** Tests passed. No logic changed. `cargo clippy` and `cargo fmt` executed successfully.

---
*PR created automatically by Jules for task [5812154703614183626](https://jules.google.com/task/5812154703614183626) started by @madmax983*