### PR TITLE
🔒 Warden: [security fix] Fix CSV Importer CPU Exhaustion DoS

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -219,3 +219,9 @@ In `relvar-storage/src/storage/page.rs` (reading page metadata length) and `relv
 **Defense:**
 1. Replaced `.try_into().unwrap()` with `.try_into().map_err(|_| ...)` in both `page.rs` and `heap.rs`.
 2. Mapped failures explicitly to domain-specific serialization errors (`PageError::Serialization` and `postcard::Error::DeserializeUnexpectedEnd`), ensuring any future slice bounds mismatch fails gracefully instead of crashing the server.
+## 2026-04-02 - CSV Duplicate Row CPU Exhaustion DoS
+**Threat:**
+The CSV importer in `relvar/src/tools/importer.rs` enforced its `MAX_IMPORT_ROWS` limit against the resulting `relation.cardinality()`. Because relational attributes are sets and silently deduplicate matching tuples, an attacker could supply an endless stream of duplicate rows. The relation's cardinality would never grow, bypassing the limit check and causing the parsing loop to run indefinitely, leading to CPU exhaustion (Denial of Service).
+
+**Defense:**
+Modified the limit check in the CSV row iteration loop to validate against the processed row count (`line_idx >= MAX_IMPORT_ROWS`) rather than the deduplicated relation cardinality. This ensures the parsing engine stops strictly after evaluating 100,000 incoming lines, regardless of their content.

--- a/relvar/src/tools/importer.rs
+++ b/relvar/src/tools/importer.rs
@@ -474,7 +474,7 @@ pub fn from_csv<R: std::io::Read>(
     let mut line_buf = String::new();
     let mut line_idx = 0;
     while read_line_safe(&mut reader, &mut line_buf)? > 0 {
-        if relation.cardinality() >= MAX_IMPORT_ROWS {
+        if line_idx >= MAX_IMPORT_ROWS {
             return Err(ImporterError::LimitExceeded(format!(
                 "Size limit exceeded: Max rows: {}",
                 MAX_IMPORT_ROWS

--- a/relvar/tests/warden_exploit_csv_dos.rs
+++ b/relvar/tests/warden_exploit_csv_dos.rs
@@ -1,0 +1,42 @@
+use relvar::tools::importer;
+use relvar::{RelationType, ScalarType, TupleType};
+
+#[test]
+fn test_exploit_csv_duplicate_row_limit() {
+    // 1. Define a schema
+    let heading = TupleType::new()
+        .with_attribute("id", ScalarType::Int)
+        .with_attribute("name", ScalarType::String);
+    let rel_type = RelationType::new(heading);
+
+    // 2. Construct a CSV payload with > MAX_IMPORT_ROWS (100,000) duplicate rows
+    let max_rows = 100_001;
+    let mut csv = String::new();
+    csv.push_str("id,name\n");
+    for _ in 0..max_rows {
+        csv.push_str("1,\"Alice\"\n");
+    }
+
+    // 3. Attempt import
+    // This should fail if we are enforcing limits on the number of processed records.
+    // If it succeeds, we have a DoS vector (unbounded CPU consumption).
+    let result = importer::from_csv(csv.as_bytes(), rel_type, ',');
+
+    match result {
+        Ok(rel) => {
+            // If we get here, the exploit worked (bad!)
+            println!(
+                "Exploit successful: Processed {} duplicate rows, resulting relation cardinality: {}",
+                max_rows,
+                rel.cardinality()
+            );
+            panic!(
+                "Security limits bypassed! Processed {} duplicate rows",
+                max_rows
+            );
+        }
+        Err(e) => {
+            println!("Exploit failed (good): {}", e);
+        }
+    }
+}


### PR DESCRIPTION
* 🦠 Threat: The CSV importer in `relvar/src/tools/importer.rs` checked the `MAX_IMPORT_ROWS` limit against the deduplicated relation's `cardinality()`. Because identical tuples are deduplicated in a relational set, an attacker could supply an endless stream of identical rows, completely bypassing the limit and forcing the importer into an infinite loop, resulting in a CPU exhaustion Denial of Service (DoS).
* 🛡️ Defense: Modified the limit enforcement check to strictly track the number of lines parsed (`line_idx >= MAX_IMPORT_ROWS`) instead of relying on the final deduplicated cardinality count.
* 💥 Severity: High - A simple CSV file with endless duplicates could permanently lock up server threads, causing system-wide degradation.
* 🧪 Verification: Added `relvar/tests/warden_exploit_csv_dos.rs` to verify that injecting > 100,000 duplicate rows safely terminates the import with a `LimitExceeded` error instead of succeeding or hanging. Ran `cargo audit`, `cargo clippy`, `cargo test`, and `cargo fmt`.

---
*PR created automatically by Jules for task [2839337086734113165](https://jules.google.com/task/2839337086734113165) started by @madmax983*