### PR TITLE
🪒 Razor: [refactor union_into]

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,8 @@
 **Bloat:** `DepthGuarded<T>` struct wrapper used to prevent recursive serialization/deserialization panics. Added nesting and `.0` boilerplate when unpacking scalars.
 **Cut:** Removed the wrapper struct, replacing it with a custom `deserialize_guarded` function applied via `#[serde(deserialize_with = "...")]` to directly flatten recursive structures.
 **Saved:** Reduced boilerplate wrapper types, streamlined Serde parsing logic, and eliminated intermediate `.0` tuple accesses.
+
+## [Reduction]
+**Bloat:** Redundant per-tuple type validation using `self.insert()` in a loop inside `union_into` when relation headings are already explicitly verified to match.
+**Cut:** Exposed `body` as `pub(crate)` in `Relation` and replaced the loop with `.reserve()` and `.extend()` to directly insert tuples into the underlying `HashSet`.
+**Saved:** Eliminated O(N) redundant validations and reduced overhead in relational algebra merge operations.

--- a/fix_union.py
+++ b/fix_union.py
@@ -1,0 +1,15 @@
+import re
+
+with open("relvar-core/src/algebra/union.rs", "r") as f:
+    content = f.read()
+
+content = content.replace(
+"""        for tuple in other.tuples() {
+            self.insert(tuple.clone()).unwrap();
+        }""",
+"""        self.body.reserve(other.cardinality());
+        self.body.extend(other.tuples().cloned());"""
+)
+
+with open("relvar-core/src/algebra/union.rs", "w") as f:
+    f.write(content)

--- a/relvar-core/src/algebra/union.rs
+++ b/relvar-core/src/algebra/union.rs
@@ -124,9 +124,8 @@ impl Relation {
             return Err(UnionError::TypeMismatch);
         }
 
-        for tuple in other.tuples() {
-            self.insert(tuple.clone()).unwrap();
-        }
+        self.body.reserve(other.cardinality());
+        self.body.extend(other.tuples().cloned());
 
         Ok(self)
     }

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -145,7 +145,7 @@ pub struct Relation {
     /// The relation type (heading) that defines the structure.
     relation_type: RelationType,
     /// The body: a set of tuples conforming to the heading.
-    body: HashSet<Tuple>,
+    pub(crate) body: HashSet<Tuple>,
 }
 
 // Custom Hash implementation for Relation


### PR DESCRIPTION
## [Reduction]
**Bloat:** Redundant per-tuple type validation using `self.insert()` in a loop inside `union_into` when relation headings are already explicitly verified to match.
**Cut:** Exposed `body` as `pub(crate)` in `Relation` and replaced the loop with `.reserve()` and `.extend()` to directly insert tuples into the underlying `HashSet`.
**Saved:** Eliminated O(N) redundant validations and reduced overhead in relational algebra merge operations.

---
*PR created automatically by Jules for task [9120382327576262184](https://jules.google.com/task/9120382327576262184) started by @madmax983*