### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -271,12 +271,16 @@ fn compute_grouped_tuples<'a>(
     // Pre-allocate attribute name strings
     let attr_names: Vec<String> = attrs_to_group.iter().map(|a| a.to_string()).collect();
 
+    // PERF: Reusable buffer for the grouping key avoids allocating a new Vec
+    // for every single tuple just to query the HashMap.
+    let mut key_buffer = Vec::with_capacity(grouping_attrs.len());
+
     for tuple in relation.tuples() {
         // Extract grouping key
-        let key: Vec<&ScalarValue> = grouping_attrs
-            .iter()
-            .map(|attr| tuple.get(attr).unwrap())
-            .collect();
+        key_buffer.clear();
+        for attr in grouping_attrs.iter() {
+            key_buffer.push(tuple.get(attr).unwrap());
+        }
 
         // Extract grouped attributes for RVA
         let mut rva_values = std::collections::BTreeMap::new();
@@ -286,7 +290,11 @@ fn compute_grouped_tuples<'a>(
 
         let rva_tuple = Tuple::new_unchecked(rva_heading_arc.clone(), rva_values);
 
-        groups.entry(key).or_default().push(rva_tuple);
+        if let Some(group) = groups.get_mut(key_buffer.as_slice()) {
+            group.push(rva_tuple);
+        } else {
+            groups.insert(key_buffer.clone(), vec![rva_tuple]);
+        }
     }
 
     // Build result tuples

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -561,12 +561,20 @@ impl Relation {
         } else {
             // Group by specified attributes
             let mut groups: HashMap<Vec<&'a ScalarValue>, Vec<&Tuple>> = HashMap::new();
+            // PERF: Reusable buffer for the grouping key avoids allocating a new Vec
+            // for every single tuple just to query the HashMap.
+            let mut key_buffer = Vec::with_capacity(group_by.len());
             for tuple in self.tuples() {
-                let key: Vec<&ScalarValue> = group_by
-                    .iter()
-                    .map(|attr| tuple.get(attr).unwrap())
-                    .collect();
-                groups.entry(key).or_default().push(tuple);
+                key_buffer.clear();
+                for attr in group_by {
+                    key_buffer.push(tuple.get(attr).unwrap());
+                }
+
+                if let Some(group) = groups.get_mut(key_buffer.as_slice()) {
+                    group.push(tuple);
+                } else {
+                    groups.insert(key_buffer.clone(), vec![tuple]);
+                }
             }
             groups
         }


### PR DESCRIPTION
💡 What: Replaced unconditional `Vec` allocation for grouping keys with a reusable `key_buffer` and slice-based lookup (`get_mut`) in `summarize` and `group` operators.
🎯 Why: Previously, grouping operations allocated a new `Vec<&ScalarValue>` for every single tuple to use as an entry key in the `HashMap`, leading to `O(N)` heap allocations where `N` is the cardinality of the relation.
📊 Impact: Eliminates `N - G` heap allocations per query (where `N` is total tuples, `G` is unique groups), reducing memory pressure and improving execution speed.
🔬 Measurement: Run bench tests or observe fewer allocations in profilers when grouping large relations into small numbers of groups.

---
*PR created automatically by Jules for task [16816991854254269611](https://jules.google.com/task/16816991854254269611) started by @madmax983*