### PR TITLE
⚒️ Forge: [Refactor test_foreign_key_constraint]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -548,3 +548,9 @@ Build it right, make it fast, keep it simple.
 ## 2026-03-14 - Extract Database Test Setup Logic
 **Learning:** `relvar-core/src/database/tests.rs` contained significant duplicate test setup logic for creating `PARENT` and `CHILD` relation types and setting up their tables, making the tests noisy and harder to read.
 **Action:** Extract duplicate test setup into a helper function `setup_parent_child_db` inside the test module. This removes repetitive boilerplate across testing functions and simplifies test logic.
+## 2026-04-04 - [Refactor test_foreign_key_constraint]
+**Learning:** The test setup code for parent/child tables (like DEPT and EMP) was largely redundant with an existing  helper in . Extracting such manual setups into the helper function greatly improves the readability of constraint tests.
+**Action:** When adding new constraint tests or encountering long test setups, prefer using or adapting existing helper functions to keep the tests concise and focused on the behavior being tested.
+## 2026-04-04 - [Refactor test_foreign_key_constraint]
+**Learning:** The test setup code for parent/child tables (like DEPT and EMP) was largely redundant with an existing `setup_parent_child_db()` helper in `relvar-core/src/database/tests.rs`. Extracting such manual setups into the helper function greatly improves the readability of constraint tests.
+**Action:** When adding new constraint tests or encountering long test setups, prefer using or adapting existing helper functions to keep the tests concise and focused on the behavior being tested.

--- a/relvar-core/src/database/tests.rs
+++ b/relvar-core/src/database/tests.rs
@@ -184,51 +184,31 @@ fn test_candidate_key_constraint() {
 
 #[test]
 fn test_foreign_key_constraint() {
-    use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+    use crate::constraints::{ForeignKey, ForeignKeyConstraints};
 
-    let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
-
-    // Create parent and child relvars
-    let parent_type = RelationType::new(
-        TupleType::new()
-            .with_attribute("dept_id", ScalarType::Int)
-            .with_attribute("dept_name", ScalarType::String),
-    );
-    let child_type = RelationType::new(
-        TupleType::new()
-            .with_attribute("emp_id", ScalarType::Int)
-            .with_attribute("dept_id", ScalarType::Int),
-    );
-
-    db.create_relvar("DEPT", parent_type).unwrap();
-    db.create_relvar("EMP", child_type).unwrap();
-
-    // Add primary key to parent
-    let pk = PrimaryKey::new(vec!["dept_id".to_string()]).unwrap();
-    let dept_constraints = KeyConstraints::new().with_primary_key(pk);
-    db.set_key_constraints("DEPT", dept_constraints).unwrap();
+    let mut db = setup_parent_child_db();
 
     // Insert parent record
-    db.insert("DEPT", tuple! { dept_id: 10i64, dept_name: "Engineering" })
+    db.insert("PARENT", tuple! { id: 10i64, name: "Engineering" })
         .unwrap();
 
     // Add foreign key constraint
     let fk = ForeignKey::new(
-        vec!["dept_id".to_string()],
-        "DEPT".to_string(),
-        vec!["dept_id".to_string()],
+        vec!["parent_id".to_string()],
+        "PARENT".to_string(),
+        vec!["id".to_string()],
     )
     .unwrap();
     let fk_constraints = ForeignKeyConstraints::new().with_foreign_key(fk);
-    db.set_foreign_key_constraints("EMP", fk_constraints)
+    db.set_foreign_key_constraints("CHILD", fk_constraints)
         .unwrap();
 
     // Insert with valid foreign key should succeed
-    db.insert("EMP", tuple! { emp_id: 1i64, dept_id: 10i64 })
+    db.insert("CHILD", tuple! { child_id: 1i64, parent_id: 10i64 })
         .unwrap();
 
     // Insert with invalid foreign key should fail
-    let result = db.insert("EMP", tuple! { emp_id: 2i64, dept_id: 99i64 });
+    let result = db.insert("CHILD", tuple! { child_id: 2i64, parent_id: 99i64 });
     assert!(result.is_err());
     assert!(matches!(
         result,


### PR DESCRIPTION
🚮 Smell: The `test_foreign_key_constraint` function was identified as a "God Function" by the `find_long_functions.py` script because it manually set up two relation variables (`DEPT` and `EMP`) and configured keys. This setup boilerplate distracted from the actual constraint logic being tested.

✨ Solution: Replaced the manual setup with a call to the existing `setup_parent_child_db()` helper function, which sets up `PARENT` and `CHILD` base relvars with primary and candidate keys. Updated the rest of the test to use `PARENT`/`CHILD` instead of `DEPT`/`EMP`.

🧼 Benefit: Dramatically reduces cognitive load and boilerplate in the test, making the actual foreign key violation logic much clearer to read.

🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [4320694725514530618](https://jules.google.com/task/4320694725514530618) started by @madmax983*