### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/relvar-core/src/algebra/difference.rs
+++ b/relvar-core/src/algebra/difference.rs
@@ -154,17 +154,14 @@ impl Relation {
     ///
     /// This is an optimized version of `difference` that avoids O(N) tuple clones for the
     /// first relation by consuming it.
-    pub fn difference_into(self, other: &Relation) -> Result<Self, DifferenceError> {
+    pub fn difference_into(mut self, other: &Relation) -> Result<Self, DifferenceError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
             return Err(DifferenceError::TypeMismatch);
         }
 
-        let rel_type = self.relation_type().clone();
-        Ok(Relation::from_tuples_unchecked(
-            rel_type,
-            self.into_iter().filter(|tuple| !other.contains(tuple)),
-        ))
+        self.body.retain(|tuple| !other.body.contains(tuple));
+        Ok(self)
     }
 
     /// Alias for [`difference_into`](Self::difference_into) with SQL-style naming.

--- a/relvar-core/src/algebra/intersect.rs
+++ b/relvar-core/src/algebra/intersect.rs
@@ -124,17 +124,14 @@ impl Relation {
     ///
     /// This is an optimized version of `intersect` that avoids O(N) tuple clones for the
     /// first relation by consuming it.
-    pub fn intersect_into(self, other: &Relation) -> Result<Self, IntersectError> {
+    pub fn intersect_into(mut self, other: &Relation) -> Result<Self, IntersectError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
             return Err(IntersectError::TypeMismatch);
         }
 
-        let rel_type = self.relation_type().clone();
-        Ok(Relation::from_tuples_unchecked(
-            rel_type,
-            self.into_iter().filter(|tuple| other.contains(tuple)),
-        ))
+        self.body.retain(|tuple| other.body.contains(tuple));
+        Ok(self)
     }
 }
 

--- a/relvar-core/src/algebra/union.rs
+++ b/relvar-core/src/algebra/union.rs
@@ -124,9 +124,8 @@ impl Relation {
             return Err(UnionError::TypeMismatch);
         }
 
-        for tuple in other.tuples() {
-            self.insert(tuple.clone()).unwrap();
-        }
+        self.body.reserve(other.body.len());
+        self.body.extend(other.body.iter().cloned());
 
         Ok(self)
     }

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -145,7 +145,7 @@ pub struct Relation {
     /// The relation type (heading) that defines the structure.
     relation_type: RelationType,
     /// The body: a set of tuples conforming to the heading.
-    body: HashSet<Tuple>,
+    pub(crate) body: HashSet<Tuple>,
 }
 
 // Custom Hash implementation for Relation


### PR DESCRIPTION
💡 What: Optimized in-place relational set operations (`union_into`, `intersect_into`, `difference_into`) by making `Relation::body` a `pub(crate)` field and using standard `HashSet` mutations (`reserve`/`extend`/`retain`) instead of iterators and `.insert()` loops.

🎯 Why: The original implementations were unnecessarily creating new HashSets or performing redundant schema validation per element despite type compatibility already being verified. This saves significant re-allocation and hashing overhead for these operations.

📊 Impact: Reduces heap allocations by modifying the existing relation in-place and bypasses repeated validation, resulting in faster and less memory-intensive union/intersect/difference operations.

🔬 Measurement: Run `cargo test` and verify that no regressions have been introduced, and `cargo check` to ensure lifetimes are intact and clippy throws no new errors.

---
*PR created automatically by Jules for task [3923560947046953590](https://jules.google.com/task/3923560947046953590) started by @madmax983*