### PR TITLE
🗺️ Atlas: Extract Query AST to Facade Crate

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -1,7 +1,6 @@
-## 2024-03-XX - Module Encapsulation Cleanup
-**Tangle:** Broad visibility (`pub mod`) across many internal modules (`algebra`, `values`, `types`, etc.) leaked implementation details and complicated the dependency graph.
-**Blueprint:** Converted most top-level internal module definitions in `relvar-core`, `relvar-storage`, and `relvar` to `pub(crate) mod`. Re-exported necessary types via their respective `mod.rs` files, ensuring clean, intention-revealing public APIs while maintaining low coupling between internal components.
-
-## 2024-03-XX - The Database Blob
-**Tangle:** The `relvar-core/src/database/mod.rs` module grew into a 1,000-line God Module holding DDL, DML, constraint validation, transaction boundaries, and Virtual Relvars in a single implementation block.
-**Blueprint:** Refactored `Database<E>` into a Facade pattern. The `mod.rs` file now orchestrates the public API while implementation details are cleanly separated into `schema.rs` (DDL), `data.rs` (DML/Querying), `integrity.rs` (Constraints), and `transaction.rs` (TCL) based on domain responsibility.
+## 2025-04-05 - Extracted Query Module to Facade Crate
+**Tangle:** The `query` module (which parses and acts as a generic AST over `relvar-core`) was tightly coupled inside `relvar-core`, expanding the core's surface area.
+**Blueprint:** Moved `relvar-core/src/query/` to `relvar/src/query/` to keep the core crate purely focused on Relational Algebra (Types, Values, Constraints, DB storage) and to make the Query layer part of the external UI facade.
+## 2025-04-05 - Extracted Query Module to Facade Crate
+**Tangle:** The `query` module (which parses and acts as a generic AST over `relvar-core`) was tightly coupled inside `relvar-core`, expanding the core's surface area.
+**Blueprint:** Moved `relvar-core/src/query/` to `relvar/src/query/` to keep the core crate purely focused on Relational Algebra (Types, Values, Constraints, DB storage) and to make the Query layer part of the external UI facade.

--- a/relvar-core/src/lib.rs
+++ b/relvar-core/src/lib.rs
@@ -101,7 +101,6 @@ pub mod algebra;
 pub mod constraints;
 pub mod database;
 pub mod error;
-pub mod query;
 pub mod storage_engine;
 pub mod types;
 pub mod utils;
@@ -109,7 +108,6 @@ pub mod values;
 
 pub use database::Database;
 pub use error::DatabaseError;
-pub use query::{Query, QueryError};
 pub use types::{RelationType, ScalarType, TupleType};
 pub use values::{Relation, ScalarValue, Tuple};
 

--- a/relvar/src/lib.rs
+++ b/relvar/src/lib.rs
@@ -128,9 +128,11 @@ pub mod prelude;
 // Core Components
 pub use relvar_core::DatabaseError;
 pub use relvar_core::database::Database;
-pub use relvar_core::query::{Query, QueryError};
 pub use relvar_core::types::{RelationType, ScalarType, TupleType};
 pub use relvar_core::values::{Relation, ScalarValue, Tuple};
+
+pub mod query;
+pub use query::{Query, QueryError};
 
 // Storage
 pub use relvar_core::storage_engine::{InMemoryEngine, StorageEngine, StorageError};
@@ -139,8 +141,8 @@ pub use relvar_core::storage_engine::{InMemoryEngine, StorageEngine, StorageErro
 pub use relvar_storage::PersistentEngine;
 
 // Modules
-pub use relvar_core::algebra;
-pub use relvar_core::constraints;
+pub use relvar_core::algebra::{self, Aggregation};
+pub use relvar_core::constraints::{self, ConstraintExpression, CmpOp, ValueOrRef};
 
 /// Tuple creation macro.
 pub use relvar_core::tuple;

--- a/relvar/src/prelude.rs
+++ b/relvar/src/prelude.rs
@@ -2,8 +2,8 @@
 //!
 //! Re-exports commonly used types for convenience.
 
+pub use crate::query::Query;
 pub use relvar_core::database::Database;
-pub use relvar_core::query::Query;
 pub use relvar_core::storage_engine::InMemoryEngine;
 pub use relvar_core::types::{RelationType, ScalarType, TupleType};
 pub use relvar_core::values::{Relation, ScalarValue, Tuple};

--- a/relvar/src/query/mod.rs
+++ b/relvar/src/query/mod.rs
@@ -8,7 +8,7 @@
 //! # Example
 //!
 //! ```
-//! use relvar_core::query::Query;
+//! use relvar::query::Query;
 //! use relvar_core::constraints::{ConstraintExpression, CmpOp, ValueOrRef};
 //! use relvar_core::values::ScalarValue;
 //! use relvar_core::types::ScalarType;
@@ -39,12 +39,12 @@
 //! println!("{}", query.explain());
 //! ```
 
-use crate::algebra::Aggregation;
-use crate::constraints::{ConstraintExpression, ExpressionError};
-use crate::database::Database;
-use crate::error::DatabaseError;
-use crate::storage_engine::StorageEngine;
-use crate::values::Relation;
+use relvar_core::algebra::Aggregation;
+use relvar_core::constraints::{ConstraintExpression, ExpressionError};
+use relvar_core::database::Database;
+use relvar_core::error::DatabaseError;
+use relvar_core::storage_engine::StorageEngine;
+use relvar_core::values::Relation;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -58,7 +58,7 @@ use thiserror::Error;
 ///
 /// ```
 ///
-/// use relvar_core::query::Query;
+/// use relvar::query::Query;
 ///
 /// let q = Query::scan("users");
 /// ```
@@ -182,7 +182,7 @@ impl Query {
     /// use relvar_core::database::Database;
     /// use relvar_core::storage_engine::InMemoryEngine;
     /// use relvar_core::types::{RelationType, TupleType, ScalarType};
-    /// use relvar_core::query::Query;
+    /// use relvar::query::Query;
     /// use relvar_core::tuple;
     ///
     /// let mut db = Database::new(InMemoryEngine::new());
@@ -261,7 +261,7 @@ impl Query {
     /// # Examples
     ///
     /// ```
-    /// use relvar_core::query::Query;
+    /// use relvar::query::Query;
     ///
     /// let q = Query::scan("TEST").project(vec!["x"]);
     /// let explanation = q.explain();
@@ -328,7 +328,7 @@ impl Query {
     /// # Examples
     ///
     /// ```
-    /// use relvar_core::query::Query;
+    /// use relvar::query::Query;
     ///
     /// let q = Query::scan("USERS");
     /// ```
@@ -340,7 +340,7 @@ impl Query {
     /// # Examples
     ///
     /// ```
-    /// use relvar_core::query::Query;
+    /// use relvar::query::Query;
     /// use relvar_core::constraints::{ConstraintExpression, CmpOp, ValueOrRef};
     /// use relvar_core::values::ScalarValue;
     ///
@@ -362,7 +362,7 @@ impl Query {
     /// # Examples
     ///
     /// ```
-    /// use relvar_core::query::Query;
+    /// use relvar::query::Query;
     ///
     /// let q = Query::scan("USERS").project(vec!["name", "email"]);
     /// ```
@@ -377,7 +377,7 @@ impl Query {
     /// # Examples
     ///
     /// ```
-    /// use relvar_core::query::Query;
+    /// use relvar::query::Query;
     ///
     /// let q = Query::scan("USERS").rename(vec![("name", "full_name")]);
     /// ```
@@ -395,7 +395,7 @@ impl Query {
     /// # Examples
     ///
     /// ```
-    /// use relvar_core::query::Query;
+    /// use relvar::query::Query;
     ///
     /// let users = Query::scan("USERS");
     /// let orders = Query::scan("ORDERS");
@@ -412,7 +412,7 @@ impl Query {
     /// # Examples
     ///
     /// ```
-    /// use relvar_core::query::Query;
+    /// use relvar::query::Query;
     /// use relvar_core::algebra::Aggregation;
     ///
     /// let q = Query::scan("USERS").summarize(vec!["department"], vec![Aggregation::count("emp_count")]);
@@ -432,12 +432,12 @@ impl Query {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::constraints::CmpOp;
-    use crate::constraints::ValueOrRef;
-    use crate::storage_engine::InMemoryEngine;
-    use crate::tuple;
-    use crate::types::{RelationType, ScalarType, TupleType};
-    use crate::values::ScalarValue;
+    use relvar_core::constraints::CmpOp;
+    use relvar_core::constraints::ValueOrRef;
+    use relvar_core::storage_engine::InMemoryEngine;
+    use relvar_core::tuple;
+    use relvar_core::types::{RelationType, ScalarType, TupleType};
+    use relvar_core::values::ScalarValue;
 
     fn setup_db() -> Database<InMemoryEngine> {
         let mut db = Database::new(InMemoryEngine::new());

--- a/relvar/tests/warden_query_restrict_error.rs
+++ b/relvar/tests/warden_query_restrict_error.rs
@@ -1,6 +1,6 @@
+use relvar::query::Query;
 use relvar_core::constraints::{CmpOp, ConstraintExpression, ValueOrRef};
 use relvar_core::database::Database;
-use relvar_core::query::Query;
 use relvar_core::storage_engine::InMemoryEngine;
 use relvar_core::tuple;
 use relvar_core::types::{RelationType, ScalarType, TupleType};


### PR DESCRIPTION
🕸️ **Tangle**: 
The `query` module (which parses and acts as a generic AST over `relvar-core`) was tightly coupled inside `relvar-core`, expanding the core's surface area.

📏 **Blueprint**: 
Moved `relvar-core/src/query/` to `relvar/src/query/` to keep the core crate purely focused on Relational Algebra (Types, Values, Constraints, DB storage) and to make the Query layer part of the external UI facade. Re-exports correctly point to the updated logic and `warden_query_restrict_error.rs` was appropriately moved to `relvar/tests/`.

🧱 **Stability**: 
Reduced core layer's surface API and prevents business-logic UI dependencies from leaking downwards.

🔬 **Verification**: 
All tests pass. Cargo check and clippy run perfectly. No new dependencies created.

---
*PR created automatically by Jules for task [12058557875089413779](https://jules.google.com/task/12058557875089413779) started by @madmax983*