### PR TITLE
🪒 Razor: [remove MockRelation builder]

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,8 @@
 **Bloat:** `DepthGuarded<T>` struct wrapper used to prevent recursive serialization/deserialization panics. Added nesting and `.0` boilerplate when unpacking scalars.
 **Cut:** Removed the wrapper struct, replacing it with a custom `deserialize_guarded` function applied via `#[serde(deserialize_with = "...")]` to directly flatten recursive structures.
 **Saved:** Reduced boilerplate wrapper types, streamlined Serde parsing logic, and eliminated intermediate `.0` tuple accesses.
+
+## [Reduction]
+**Bloat:** `MockRelation` builder struct in `relvar/src/experimental/mock.rs` that acted as a "Factory Factory" simply to collect basic arguments (`relation_type`, `count`, `seed`).
+**Cut:** Replaced the struct and its chainable methods with a single public free function `generate_mock_relation`. Internal methods became private module-level free functions.
+**Saved:** Reduced struct definition and builder boilerplate, making the API clearer and simpler to use.

--- a/relvar/src/experimental/mock.rs
+++ b/relvar/src/experimental/mock.rs
@@ -7,7 +7,7 @@
 //! # Example
 //!
 //! ```
-//! use relvar::experimental::mock::MockRelation;
+//! use relvar::experimental::mock::generate_mock_relation;
 //! use relvar_core::types::{RelationType, TupleType, ScalarType};
 //!
 //! // 1. Define schema
@@ -19,10 +19,7 @@
 //! );
 //!
 //! // 2. Generate random data
-//! let relation = MockRelation::new(rel_type)
-//!     .count(100)       // Generate 100 tuples
-//!     .seed(42)         // Use fixed seed for deterministic results
-//!     .generate();
+//! let relation = generate_mock_relation(rel_type, 100, Some(42));
 //!
 //! assert_eq!(relation.cardinality(), 100);
 //! ```
@@ -33,12 +30,16 @@ use relvar_core::types::{RelationType, ScalarType};
 use relvar_core::values::{Relation, ScalarValue, Tuple};
 use std::collections::BTreeMap;
 
-/// A builder for generating mock relations with random data.
+/// Generates a mock relation with random data.
+///
+/// Note: Since relations are sets, duplicate tuples will be ignored.
+/// If the random generation produces duplicates, the final cardinality
+/// might be less than `count`.
 ///
 /// # Example
 ///
 /// ```
-/// use relvar::experimental::mock::MockRelation;
+/// use relvar::experimental::mock::generate_mock_relation;
 /// use relvar_core::types::{RelationType, TupleType, ScalarType};
 ///
 /// let rel_type = RelationType::new(
@@ -47,104 +48,71 @@ use std::collections::BTreeMap;
 ///         .with_attribute("name", ScalarType::String)
 /// );
 ///
-/// let relation = MockRelation::new(rel_type)
-///     .count(10)
-///     .seed(42)
-///     .generate();
+/// let relation = generate_mock_relation(rel_type, 10, Some(42));
 ///
 /// assert_eq!(relation.cardinality(), 10);
 /// ```
-pub struct MockRelation {
+pub fn generate_mock_relation(
     relation_type: RelationType,
     count: usize,
     seed: Option<u64>,
+) -> Relation {
+    let mut relation = Relation::new(relation_type.clone());
+    let mut rng = if let Some(seed) = seed {
+        StdRng::seed_from_u64(seed)
+    } else {
+        StdRng::from_entropy()
+    };
+
+    for _ in 0..count {
+        if let Some(tuple) = generate_tuple(&relation_type, &mut rng) {
+            let _ = relation.insert(tuple);
+        }
+    }
+
+    relation
 }
 
-impl MockRelation {
-    /// Create a new MockRelation builder for the given relation type.
-    pub fn new(relation_type: RelationType) -> Self {
-        Self {
-            relation_type,
-            count: 0,
-            seed: None,
+fn generate_tuple(relation_type: &RelationType, rng: &mut StdRng) -> Option<Tuple> {
+    let mut values = BTreeMap::new();
+
+    for attr_name in relation_type.heading().attribute_names() {
+        let scalar_type = relation_type.heading().get_attribute_type(attr_name)?;
+        let value = generate_value(scalar_type, rng);
+        values.insert(attr_name.clone(), value);
+    }
+
+    Tuple::new(relation_type.heading().clone(), values).ok()
+}
+
+fn generate_value(scalar_type: &ScalarType, rng: &mut StdRng) -> ScalarValue {
+    match scalar_type {
+        ScalarType::Int => ScalarValue::Int(rng.r#gen()),
+        ScalarType::Float => ScalarValue::Float(rng.r#gen()),
+        ScalarType::String => {
+            // Generate a random string of length 5-15
+            let len = rng.gen_range(5..=15);
+            let s: String = (0..len)
+                .map(|_| rng.sample(rand::distributions::Alphanumeric) as char)
+                .collect();
+            ScalarValue::String(s)
         }
-    }
-
-    /// Set the number of tuples to generate.
-    ///
-    /// Note: Since relations are sets, duplicate tuples will be ignored.
-    /// If the random generation produces duplicates, the final cardinality
-    /// might be less than `count`.
-    pub fn count(mut self, count: usize) -> Self {
-        self.count = count;
-        self
-    }
-
-    /// Set the random seed for deterministic generation.
-    pub fn seed(mut self, seed: u64) -> Self {
-        self.seed = Some(seed);
-        self
-    }
-
-    /// Generate the relation.
-    pub fn generate(self) -> Relation {
-        let mut relation = Relation::new(self.relation_type.clone());
-        let mut rng = if let Some(seed) = self.seed {
-            StdRng::seed_from_u64(seed)
-        } else {
-            StdRng::from_entropy()
-        };
-
-        for _ in 0..self.count {
-            if let Some(tuple) = self.generate_tuple(&mut rng) {
-                let _ = relation.insert(tuple);
-            }
+        ScalarType::Bool => ScalarValue::Bool(rng.r#gen()),
+        ScalarType::Bytes => {
+            let len = rng.gen_range(1..=32);
+            let bytes: Vec<u8> = (0..len).map(|_| rng.r#gen()).collect();
+            ScalarValue::Bytes(bytes)
         }
-
-        relation
-    }
-
-    fn generate_tuple(&self, rng: &mut StdRng) -> Option<Tuple> {
-        let mut values = BTreeMap::new();
-
-        for attr_name in self.relation_type.heading().attribute_names() {
-            let scalar_type = self.relation_type.heading().get_attribute_type(attr_name)?;
-            let value = self.generate_value(scalar_type, rng);
-            values.insert(attr_name.clone(), value);
+        ScalarType::Relation(rel_type) => {
+            // Nested relation: return empty for now to avoid infinite recursion
+            ScalarValue::Relation(Relation::new(*rel_type.clone()))
         }
-
-        Tuple::new(self.relation_type.heading().clone(), values).ok()
-    }
-
-    fn generate_value(&self, scalar_type: &ScalarType, rng: &mut StdRng) -> ScalarValue {
-        match scalar_type {
-            ScalarType::Int => ScalarValue::Int(rng.r#gen()),
-            ScalarType::Float => ScalarValue::Float(rng.r#gen()),
-            ScalarType::String => {
-                // Generate a random string of length 5-15
-                let len = rng.gen_range(5..=15);
-                let s: String = (0..len)
-                    .map(|_| rng.sample(rand::distributions::Alphanumeric) as char)
-                    .collect();
-                ScalarValue::String(s)
-            }
-            ScalarType::Bool => ScalarValue::Bool(rng.r#gen()),
-            ScalarType::Bytes => {
-                let len = rng.gen_range(1..=32);
-                let bytes: Vec<u8> = (0..len).map(|_| rng.r#gen()).collect();
-                ScalarValue::Bytes(bytes)
-            }
-            ScalarType::Relation(rel_type) => {
-                // Nested relation: return empty for now to avoid infinite recursion
-                ScalarValue::Relation(Relation::new(*rel_type.clone()))
-            }
-            ScalarType::UserDefined { representation, .. } => {
-                // Recursively generate value for the representation
-                let inner_value = self.generate_value(representation, rng);
-                ScalarValue::UserDefined {
-                    type_def: scalar_type.clone(),
-                    value: Box::new(inner_value),
-                }
+        ScalarType::UserDefined { representation, .. } => {
+            // Recursively generate value for the representation
+            let inner_value = generate_value(representation, rng);
+            ScalarValue::UserDefined {
+                type_def: scalar_type.clone(),
+                value: Box::new(inner_value),
             }
         }
     }
@@ -164,10 +132,7 @@ mod tests {
                 .with_attribute("active", ScalarType::Bool),
         );
 
-        let relation = MockRelation::new(rel_type)
-            .count(50)
-            .seed(12345) // Deterministic
-            .generate();
+        let relation = generate_mock_relation(rel_type, 50, Some(12345));
 
         assert_eq!(relation.cardinality(), 50);
         assert_eq!(relation.degree(), 3);
@@ -194,7 +159,7 @@ mod tests {
                 .with_attribute("user_val", user_defined_type),
         );
 
-        let relation = MockRelation::new(rel_type).count(10).seed(42).generate();
+        let relation = generate_mock_relation(rel_type, 10, Some(42));
 
         assert_eq!(relation.degree(), 7);
         assert_eq!(relation.cardinality(), 10);
@@ -204,12 +169,8 @@ mod tests {
     fn test_determinism() {
         let rel_type = RelationType::new(TupleType::new().with_attribute("val", ScalarType::Float));
 
-        let rel1 = MockRelation::new(rel_type.clone())
-            .count(10)
-            .seed(42)
-            .generate();
-
-        let rel2 = MockRelation::new(rel_type).count(10).seed(42).generate();
+        let rel1 = generate_mock_relation(rel_type.clone(), 10, Some(42));
+        let rel2 = generate_mock_relation(rel_type, 10, Some(42));
 
         assert_eq!(rel1, rel2);
     }


### PR DESCRIPTION
🪒 Razor: Refactored `MockRelation` builder to a free function

**Bloat:** `MockRelation` builder struct in `relvar/src/experimental/mock.rs` that acted as a \"Factory Factory\" simply to collect basic arguments (`relation_type`, `count`, `seed`).
**Cut:** Replaced the struct and its chainable methods with a single public free function `generate_mock_relation`. Internal methods became private module-level free functions.
**Saved:** Reduced struct definition and builder boilerplate, making the API clearer and simpler to use.

---
*PR created automatically by Jules for task [6405936866295668098](https://jules.google.com/task/6405936866295668098) started by @madmax983*