### PR TITLE
🗺️ Atlas: Encapsulate algebra::delta module

### DIFF
--- a/relvar-core/src/algebra/delta.rs
+++ b/relvar-core/src/algebra/delta.rs
@@ -13,7 +13,7 @@
 //! use relvar_core::values::Relation;
 //! use relvar_core::types::{RelationType, TupleType, ScalarType};
 //! use relvar_core::tuple;
-//! use relvar_core::algebra::delta::Delta;
+//! use relvar_core::algebra::Delta;
 //!
 //! let heading = TupleType::new().with_attribute("x", ScalarType::Int);
 //! let rel_type = RelationType::new(heading);
@@ -64,7 +64,7 @@ impl Delta {
     /// ```
     /// use relvar_core::values::Relation;
     /// use relvar_core::types::{RelationType, TupleType, ScalarType};
-    /// use relvar_core::algebra::delta::Delta;
+    /// use relvar_core::algebra::Delta;
     ///
     /// let heading = TupleType::new().with_attribute("x", ScalarType::Int);
     /// let rel_type = RelationType::new(heading);
@@ -96,7 +96,7 @@ impl Delta {
     /// ```
     /// use relvar_core::values::Relation;
     /// use relvar_core::types::{RelationType, TupleType, ScalarType};
-    /// use relvar_core::algebra::delta::Delta;
+    /// use relvar_core::algebra::Delta;
     ///
     /// let heading = TupleType::new().with_attribute("x", ScalarType::Int);
     /// let rel_type = RelationType::new(heading);
@@ -138,7 +138,7 @@ impl Delta {
     /// ```
     /// use relvar_core::values::Relation;
     /// use relvar_core::types::{RelationType, TupleType, ScalarType};
-    /// use relvar_core::algebra::delta::Delta;
+    /// use relvar_core::algebra::Delta;
     ///
     /// let heading = TupleType::new().with_attribute("x", ScalarType::Int);
     /// let rel_type = RelationType::new(heading);
@@ -178,7 +178,7 @@ impl Delta {
     /// ```
     /// use relvar_core::values::Relation;
     /// use relvar_core::types::{RelationType, TupleType, ScalarType};
-    /// use relvar_core::algebra::delta::Delta;
+    /// use relvar_core::algebra::Delta;
     ///
     /// let heading = TupleType::new().with_attribute("x", ScalarType::Int);
     /// let rel_type = RelationType::new(heading);
@@ -212,7 +212,7 @@ impl Delta {
     /// ```
     /// use relvar_core::values::Relation;
     /// use relvar_core::types::{RelationType, TupleType, ScalarType};
-    /// use relvar_core::algebra::delta::Delta;
+    /// use relvar_core::algebra::Delta;
     ///
     /// let heading = TupleType::new().with_attribute("x", ScalarType::Int);
     /// let rel_type = RelationType::new(heading);

--- a/relvar-core/src/algebra/mod.rs
+++ b/relvar-core/src/algebra/mod.rs
@@ -88,7 +88,8 @@
 //! - Results are always valid relations
 
 /// Relational Delta operator.
-pub mod delta;
+pub(crate) mod delta;
+pub use delta::Delta;
 
 /// Set difference operator (A MINUS B).
 pub(crate) mod difference;

--- a/relvar-core/tests/sentry_delta_error_paths.rs
+++ b/relvar-core/tests/sentry_delta_error_paths.rs
@@ -1,4 +1,4 @@
-use relvar_core::algebra::delta::Delta;
+use relvar_core::algebra::Delta;
 use relvar_core::error::DatabaseError;
 use relvar_core::types::{RelationType, ScalarType, TupleType};
 use relvar_core::values::Relation;


### PR DESCRIPTION
🕸️ Tangle: The `delta` module inside `relvar-core/src/algebra/mod.rs` was exposed as fully public (`pub mod delta;`), which leaked internal module structure and violated the desired Facade pattern.

📐 Blueprint: Changed the module visibility to `pub(crate) mod delta;` and re-exported the `Delta` struct using `pub use delta::Delta;`. This provides a clean, flat public API for users of the algebra module. Updated integration tests to import `Delta` directly from `relvar_core::algebra::Delta`.

🧱 Stability: Improves encapsulation and lowers coupling without altering any existing runtime logic. The public interface is cleaner and internal module paths are protected from external reliance.

🔬 Verification: Ran `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all`. All tests (including `sentry_delta_error_paths.rs` and doc tests) pass with zero warnings.

---
*PR created automatically by Jules for task [10319911845358437096](https://jules.google.com/task/10319911845358437096) started by @madmax983*