### PR TITLE
⚡ Bolt: [performance improvement] Optimize intersect_into and difference_into

### DIFF
--- a/relvar-core/src/algebra/difference.rs
+++ b/relvar-core/src/algebra/difference.rs
@@ -153,18 +153,15 @@ impl Relation {
     /// Computes the set difference of this relation with another, consuming this relation.
     ///
     /// This is an optimized version of `difference` that avoids O(N) tuple clones for the
-    /// first relation by consuming it.
-    pub fn difference_into(self, other: &Relation) -> Result<Self, DifferenceError> {
+    /// first relation by consuming it and mutates the inner body in place.
+    pub fn difference_into(mut self, other: &Relation) -> Result<Self, DifferenceError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
             return Err(DifferenceError::TypeMismatch);
         }
 
-        let rel_type = self.relation_type().clone();
-        Ok(Relation::from_tuples_unchecked(
-            rel_type,
-            self.into_iter().filter(|tuple| !other.contains(tuple)),
-        ))
+        self.body.retain(|tuple| !other.contains(tuple));
+        Ok(self)
     }
 
     /// Alias for [`difference_into`](Self::difference_into) with SQL-style naming.

--- a/relvar-core/src/algebra/intersect.rs
+++ b/relvar-core/src/algebra/intersect.rs
@@ -123,18 +123,15 @@ impl Relation {
     /// Computes the intersection of this relation with another, consuming this relation.
     ///
     /// This is an optimized version of `intersect` that avoids O(N) tuple clones for the
-    /// first relation by consuming it.
-    pub fn intersect_into(self, other: &Relation) -> Result<Self, IntersectError> {
+    /// first relation by consuming it and mutates the inner body in place.
+    pub fn intersect_into(mut self, other: &Relation) -> Result<Self, IntersectError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
             return Err(IntersectError::TypeMismatch);
         }
 
-        let rel_type = self.relation_type().clone();
-        Ok(Relation::from_tuples_unchecked(
-            rel_type,
-            self.into_iter().filter(|tuple| other.contains(tuple)),
-        ))
+        self.body.retain(|tuple| other.contains(tuple));
+        Ok(self)
     }
 }
 

--- a/relvar-core/tests/sentry_delta_coverage.rs
+++ b/relvar-core/tests/sentry_delta_coverage.rs
@@ -1,4 +1,4 @@
-use relvar_core::algebra::delta::Delta;
+use relvar_core::algebra::Delta;
 use relvar_core::error::DatabaseError;
 use relvar_core::types::{RelationType, ScalarType, TupleType};
 use relvar_core::values::Relation;


### PR DESCRIPTION
💡 What: The optimization implemented. Switched `Relation::intersect_into` and `Relation::difference_into` to mutate the underlying `body` (a `HashSet`) using `retain()` instead of rebuilding the relation using `from_tuples_unchecked`.
🎯 Why: The previous implementation required cloning the `RelationType`, spawning iterators, and rebuilding the internal `HashSet` (which entails re-evaluating the hash for every tuple) during `into_iter().filter(...)`. Mutating the `HashSet` in-place drops invalid elements faster and skips redundant hashing and memory allocation.
📊 Impact: Expected gain. Eliminates dynamic allocation of the `HashSet` during in-place set reduction and eliminates redundant internal duplicate checks and type-safety overhead since the consumed relation is strictly valid by definition.
🔬 Measurement: Run bench `process_data` or standard cargo benchmarks over large relation datasets.

---
*PR created automatically by Jules for task [15471985538015692933](https://jules.google.com/task/15471985538015692933) started by @madmax983*