### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/relvar-core/src/algebra/semijoin.rs
+++ b/relvar-core/src/algebra/semijoin.rs
@@ -789,4 +789,39 @@ mod tests {
 
         assert_eq!(direct, via_diff);
     }
+
+    #[test]
+    fn test_semijoin_key_missing_attributes() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::Hash;
+
+        let t1 = tuple! { a: 1i64 };
+        let attributes = vec!["a".to_string(), "b".to_string()];
+
+        let key1 = super::SemijoinKey {
+            tuple: &t1,
+            attributes: &attributes,
+        };
+
+        // Should not panic on missing attribute "b", and hashing should complete
+        let mut hasher = DefaultHasher::new();
+        key1.hash(&mut hasher);
+
+        let t2 = tuple! { a: 1i64, c: "test" };
+        let key2 = super::SemijoinKey {
+            tuple: &t2,
+            attributes: &attributes,
+        };
+
+        // Ensure missing attributes don't cause panics during partial eq comparison
+        assert_eq!(key1, key2);
+
+        let t3 = tuple! { a: 1i64, b: 2i64 };
+        let key3 = super::SemijoinKey {
+            tuple: &t3,
+            attributes: &attributes,
+        };
+
+        assert_ne!(key1, key3);
+    }
 }

--- a/relvar-core/tests/sentry_delta_coverage.rs
+++ b/relvar-core/tests/sentry_delta_coverage.rs
@@ -1,4 +1,4 @@
-use relvar_core::algebra::delta::Delta;
+use relvar_core::algebra::Delta;
 use relvar_core::error::DatabaseError;
 use relvar_core::types::{RelationType, ScalarType, TupleType};
 use relvar_core::values::Relation;


### PR DESCRIPTION
🎯 Target: `SemijoinKey`'s `Hash` trait implementation in `relvar-core/src/algebra/semijoin.rs`.
💣 Risk: Missing coverage for missing attribute branch inside internal helper.
🧪 Strategy: Write a test that manually instantiates a `SemijoinKey` passing an attribute missing from the tuple to test the internal error/none handling.
🔬 Verification: Run `cargo test -p relvar-core`.

---
*PR created automatically by Jules for task [2499561745348120839](https://jules.google.com/task/2499561745348120839) started by @madmax983*