### PR TITLE
🔒 Warden: Fix Image Processing Bounds CPU/Memory DoS

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -225,3 +225,11 @@ The CSV importer in `relvar/src/tools/importer.rs` enforced its `MAX_IMPORT_ROWS
 
 **Defense:**
 Modified the limit check in the CSV row iteration loop to validate against the processed row count (`line_idx >= MAX_IMPORT_ROWS`) rather than the deduplicated relation cardinality. This ensures the parsing engine stops strictly after evaluating 100,000 incoming lines, regardless of their content.
+## 2026-04-05 - Image Processing Memory Exhaustion DoS and Integer Overflow Panic
+**Threat:**
+The image processing module (`relvar::experimental::image::save`, `load` and `apply_kernel`) relied on unchecked arithmetic and dynamic collections `vec![0u8; width * height * 3]` when transforming between Relations and raw RGB image bytes. An attacker could construct a malicious Relation with just two tuples containing extreme spatial coordinate values (e.g. `x = -9223372036854775808i64` and `x = 9223372036854775807i64`). When calculating image bounding boxes, this resulted in integer subtraction panics or out-of-memory panics (DoS) due to unbounded `vec!` allocation sizes.
+
+**Defense:**
+1. Replaced unchecked arithmetic with safe `checked_sub`, `checked_add`, `saturating_add`, and `saturating_mul`.
+2. Fallback coordinates safely map out-of-bounds calculations using `unwrap_or(usize::MAX)` and standard size checks to gracefully skip invalid points.
+3. Implemented a strict `width.saturating_mul(height) > 10_000_000` bounds check, preventing any allocation over ~30MB memory and safely returning an empty image or relation `(0, 0, Vec::new())` if coordinates exceed this threshold.

--- a/relvar/src/experimental/image.rs
+++ b/relvar/src/experimental/image.rs
@@ -45,10 +45,15 @@ pub fn load(width: usize, height: usize, data: &[u8]) -> Relation {
     let rel_type = RelationType::new(heading);
     let mut relation = Relation::new(rel_type);
 
+    // Enforce size caps for imported images to prevent CPU DoS
+    if width.saturating_mul(height) > 10_000_000 {
+        return relation;
+    }
+
     for y in 0..height {
         for x in 0..width {
-            let idx = (y * width + x) * 3;
-            if idx + 2 < data.len() {
+            let idx = y.saturating_mul(width).saturating_add(x).saturating_mul(3);
+            if idx.saturating_add(2) < data.len() {
                 let r = data[idx] as i64;
                 let g = data[idx + 1] as i64;
                 let b = data[idx + 2] as i64;
@@ -104,9 +109,24 @@ pub fn save(relation: &Relation) -> (usize, usize, Vec<u8>) {
         }
     }
 
-    let width = (max_x - min_x + 1) as usize;
-    let height = (max_y - min_y + 1) as usize;
-    let mut data = vec![0u8; width * height * 3];
+    let width = max_x
+        .checked_sub(min_x)
+        .and_then(|w| w.checked_add(1))
+        .and_then(|w| usize::try_from(w).ok())
+        .unwrap_or(0);
+
+    let height = max_y
+        .checked_sub(min_y)
+        .and_then(|h| h.checked_add(1))
+        .and_then(|h| usize::try_from(h).ok())
+        .unwrap_or(0);
+
+    // Limit image resolution to prevent memory exhaustion DoS (e.g. 10 million pixels)
+    if width.saturating_mul(height) > 10_000_000 {
+        return (0, 0, Vec::new());
+    }
+
+    let mut data = vec![0u8; width.saturating_mul(height).saturating_mul(3)];
 
     for tuple in relation.tuples() {
         let x = tuple.get_typed::<i64>("x").unwrap_or(0);
@@ -115,14 +135,25 @@ pub fn save(relation: &Relation) -> (usize, usize, Vec<u8>) {
         let g = tuple.get_typed::<i64>("g").unwrap_or(0).clamp(0, 255) as u8;
         let b = tuple.get_typed::<i64>("b").unwrap_or(0).clamp(0, 255) as u8;
 
-        let img_x = (x - min_x) as usize;
-        let img_y = (y - min_y) as usize;
+        let img_x = x
+            .checked_sub(min_x)
+            .and_then(|v| usize::try_from(v).ok())
+            .unwrap_or(usize::MAX);
+        let img_y = y
+            .checked_sub(min_y)
+            .and_then(|v| usize::try_from(v).ok())
+            .unwrap_or(usize::MAX);
 
         if img_x < width && img_y < height {
-            let idx = (img_y * width + img_x) * 3;
-            data[idx] = r;
-            data[idx + 1] = g;
-            data[idx + 2] = b;
+            let idx = img_y
+                .saturating_mul(width)
+                .saturating_add(img_x)
+                .saturating_mul(3);
+            if idx.saturating_add(2) < data.len() {
+                data[idx] = r;
+                data[idx + 1] = g;
+                data[idx + 2] = b;
+            }
         }
     }
 
@@ -177,31 +208,31 @@ pub fn apply_kernel(relation: &Relation, kernel: &[KernelTap]) -> Relation {
         // Extend 1: Calculate target coordinates
         let with_coords = relation
             .extend("tx", ScalarType::Int, move |t| {
-                let x = t.get_typed::<i64>("x").unwrap();
-                ScalarValue::Int(x + dx)
+                let x = t.get_typed::<i64>("x").unwrap_or(0);
+                ScalarValue::Int(x.saturating_add(dx))
             })
             .unwrap()
             .extend("ty", ScalarType::Int, move |t| {
-                let y = t.get_typed::<i64>("y").unwrap();
-                ScalarValue::Int(y + dy)
+                let y = t.get_typed::<i64>("y").unwrap_or(0);
+                ScalarValue::Int(y.saturating_add(dy))
             })
             .unwrap();
 
         // Extend 2: Calculate weighted color components
         let with_weights = with_coords
             .extend("wr", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("r").unwrap();
-                ScalarValue::Int(v * weight)
+                let v = t.get_typed::<i64>("r").unwrap_or(0);
+                ScalarValue::Int(v.saturating_mul(weight))
             })
             .unwrap()
             .extend("wg", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("g").unwrap();
-                ScalarValue::Int(v * weight)
+                let v = t.get_typed::<i64>("g").unwrap_or(0);
+                ScalarValue::Int(v.saturating_mul(weight))
             })
             .unwrap()
             .extend("wb", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("b").unwrap();
-                ScalarValue::Int(v * weight)
+                let v = t.get_typed::<i64>("b").unwrap_or(0);
+                ScalarValue::Int(v.saturating_mul(weight))
             })
             .unwrap();
 
@@ -253,17 +284,17 @@ pub fn apply_kernel(relation: &Relation, kernel: &[KernelTap]) -> Relation {
     // Extend with final values: sum / total_weight
     let normalized = summarized
         .extend("final_r", ScalarType::Int, move |t| {
-            let s = t.get_typed::<i64>("sum_r").unwrap();
+            let s = t.get_typed::<i64>("sum_r").unwrap_or(0);
             ScalarValue::Int(s / total_weight)
         })
         .unwrap()
         .extend("final_g", ScalarType::Int, move |t| {
-            let s = t.get_typed::<i64>("sum_g").unwrap();
+            let s = t.get_typed::<i64>("sum_g").unwrap_or(0);
             ScalarValue::Int(s / total_weight)
         })
         .unwrap()
         .extend("final_b", ScalarType::Int, move |t| {
-            let s = t.get_typed::<i64>("sum_b").unwrap();
+            let s = t.get_typed::<i64>("sum_b").unwrap_or(0);
             ScalarValue::Int(s / total_weight)
         })
         .unwrap();

--- a/relvar/tests/warden_exploit_image_dos.rs
+++ b/relvar/tests/warden_exploit_image_dos.rs
@@ -1,0 +1,31 @@
+use relvar::experimental::image::save;
+use relvar_core::tuple;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
+use relvar_core::values::Relation;
+
+#[test]
+fn test_image_dos() {
+    let heading = TupleType::new()
+        .with_attribute("x".to_string(), ScalarType::Int)
+        .with_attribute("y".to_string(), ScalarType::Int)
+        .with_attribute("r".to_string(), ScalarType::Int)
+        .with_attribute("g".to_string(), ScalarType::Int)
+        .with_attribute("b".to_string(), ScalarType::Int);
+    let rel_type = RelationType::new(heading);
+
+    let mut relation = Relation::new(rel_type);
+    // Two points very far apart
+    relation
+        .insert(tuple! { x: 0i64, y: 0i64, r: 0i64, g: 0i64, b: 0i64 })
+        .unwrap();
+    relation
+        .insert(tuple! { x: 100000i64, y: 100000i64, r: 0i64, g: 0i64, b: 0i64 })
+        .unwrap();
+
+    let (w, h, data) = save(&relation);
+
+    // The patched version should return empty image due to safety limits.
+    assert_eq!(data.len(), 0);
+    assert_eq!(w, 0);
+    assert_eq!(h, 0);
+}

--- a/relvar/tests/warden_exploit_image_dos_2.rs
+++ b/relvar/tests/warden_exploit_image_dos_2.rs
@@ -1,0 +1,33 @@
+use relvar::experimental::image::save;
+use relvar_core::tuple;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
+use relvar_core::values::Relation;
+
+#[test]
+fn test_image_dos_overflow() {
+    let heading = TupleType::new()
+        .with_attribute("x".to_string(), ScalarType::Int)
+        .with_attribute("y".to_string(), ScalarType::Int)
+        .with_attribute("r".to_string(), ScalarType::Int)
+        .with_attribute("g".to_string(), ScalarType::Int)
+        .with_attribute("b".to_string(), ScalarType::Int);
+    let rel_type = RelationType::new(heading);
+
+    let mut relation = Relation::new(rel_type);
+
+    // Two points causing i64 overflow or usize overflow.
+    relation
+        .insert(tuple! { x: -9223372036854775808i64, y: 0i64, r: 0i64, g: 0i64, b: 0i64 })
+        .unwrap();
+    relation
+        .insert(tuple! { x: 9223372036854775807i64, y: 0i64, r: 0i64, g: 0i64, b: 0i64 })
+        .unwrap();
+
+    let (w, h, data) = save(&relation);
+
+    // The patched version should return empty image due to safety limits or safe math.
+    // If width falls back to 0 due to overflow, the total size is 0 and it returns successfully with empty vec.
+    // That means `w` might be 0, and `h` might be 1 (because max_y - min_y is 0 - 0 = 0, +1 = 1).
+    assert_eq!(data.len(), 0);
+    assert_eq!(w * h, 0);
+}


### PR DESCRIPTION
🦠 Threat
The image processing module (`relvar::experimental::image::save`, `load` and `apply_kernel`) relied on unchecked arithmetic and dynamic collections `vec![0u8; width * height * 3]` when transforming between Relations and raw RGB image bytes. An attacker could construct a malicious Relation with just two tuples containing extreme spatial coordinate values (e.g. `x = -9223372036854775808i64` and `x = 9223372036854775807i64`). When calculating image bounding boxes, this resulted in integer subtraction panics or out-of-memory panics (DoS) due to unbounded `vec!` allocation sizes.

🛡️ Defense
1. Replaced unchecked arithmetic with safe `checked_sub`, `checked_add`, `saturating_add`, and `saturating_mul`.
2. Fallback coordinates safely map out-of-bounds calculations using `unwrap_or(usize::MAX)` and standard size checks to gracefully skip invalid points.
3. Implemented a strict `width.saturating_mul(height) > 10_000_000` bounds check, preventing any allocation over ~30MB memory and safely returning an empty image or relation `(0, 0, Vec::new())` if coordinates exceed this threshold.

💥 Severity
Critical. Allowed trivial CPU and Memory Denial of Service and node crash (via panic) simply by ingesting a crafted dataset and attempting to export or view it.

🧪 Verification
Added two test suites demonstrating the bounds mitigations and the `10,000,000` cap handling in `relvar/tests/warden_exploit_image_dos.rs` and `relvar/tests/warden_exploit_image_dos_2.rs`. Verified complete pass with `cargo clippy`, `cargo test`, and recorded learnings.

---
*PR created automatically by Jules for task [3236696344076091736](https://jules.google.com/task/3236696344076091736) started by @madmax983*