### PR TITLE
⚒️ Forge: Refactor PhysicsEngine next_step

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -558,3 +558,6 @@ Build it right, make it fast, keep it simple.
 ## 2024-04-09 - Long Functions Refactor
 **Learning:** Found several "God Functions" in `relvar-storage` related to WAL parsing, Page loading, and MVCC visibility that exceeded 50 lines.
 **Action:** Refactored into smaller helper functions (e.g. `WalRecordIter`, `parse_page_data`, `is_created_visible`, `is_deletion_invisible`, `prepare_insert`) to flatten structure, reduce variables in scope, and improve readability without altering logic.
+## 2026-04-10 - Extract Complex Physics Calculation Steps
+**Learning:** The `next_step` function in `relvar/src/experimental/physics.rs` contained multiple distinct logical phases (computing forces, handling missing elements and summation, updating kinematics) in a single massive code block, making it hard to follow.
+**Action:** Refactored by extracting these phases into appropriately named private helper methods (`compute_pairwise_forces`, `summarize_net_forces`, `update_kinematics_and_project`), drastically reducing complexity and improving code clarity.

--- a/find_long_functions.py
+++ b/find_long_functions.py
@@ -6,7 +6,7 @@ def find_functions():
 
     results = []
 
-    for root, dirs, files in os.walk('relvar-core/src'):
+    for root, dirs, files in os.walk('.'):
         for file in files:
             if not file.endswith('.rs'):
                 continue

--- a/relvar/src/experimental/physics.rs
+++ b/relvar/src/experimental/physics.rs
@@ -53,6 +53,12 @@ impl PhysicsEngine {
     /// // Note: This is a placeholder example
     /// ```
     pub fn next_step(&self) -> Result<Relation, DatabaseError> {
+        let with_forces = self.compute_pairwise_forces()?;
+        let all_particles_with_forces = self.summarize_net_forces(&with_forces)?;
+        self.update_kinematics_and_project(&all_particles_with_forces)
+    }
+
+    fn compute_pairwise_forces(&self) -> Result<Relation, DatabaseError> {
         // 1. Cross join particles with themselves to compute pairwise forces.
         // Rename attributes to distinguish particle 1 and particle 2.
         let p1 = self.particles.rename(&[
@@ -84,7 +90,7 @@ impl PhysicsEngine {
 
         // 3. Compute forces for each pair
         let g = self.g;
-        let with_forces = interactions
+        interactions
             .extend("fx", ScalarType::Float, move |t| {
                 let x1 = t.get_typed::<f64>("x1").unwrap();
                 let y1 = t.get_typed::<f64>("y1").unwrap();
@@ -131,8 +137,10 @@ impl PhysicsEngine {
 
                 ScalarValue::Float(fy)
             })
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
 
+    fn summarize_net_forces(&self, with_forces: &Relation) -> Result<Relation, DatabaseError> {
         // 4. Summarize to get net forces for each particle
         let net_forces = with_forces
             .summarize(
@@ -168,10 +176,15 @@ impl PhysicsEngine {
             .extend("net_fy", ScalarType::Float, |_| ScalarValue::Float(0.0))
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
-        let all_particles_with_forces = particles_with_forces
+        particles_with_forces
             .union(&missing_with_zero_forces)
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
 
+    fn update_kinematics_and_project(
+        &self,
+        all_particles_with_forces: &Relation,
+    ) -> Result<Relation, DatabaseError> {
         // 6. Update kinematics: v = v + a*dt, p = p + v*dt
         let dt = self.dt;
         let updated = all_particles_with_forces


### PR DESCRIPTION
🚮 Smell: The `next_step` function in `relvar/src/experimental/physics.rs` was a massive 165-line "God Function" that mixed multiple distinct logic phases (pairwise force computation, summarization and zero-force handling, and kinematics update) making it very difficult to read.
✨ Solution: Extracted the logical phases into three private, clear helper methods: `compute_pairwise_forces`, `summarize_net_forces`, and `update_kinematics_and_project`.
🧼 Benefit: Greatly reduces cognitive load by flattening structure and giving semantic names to calculation steps.
🛡️ Verification: Tests passed. No logic changed. Code cleanly separated without behavior side-effects.

---
*PR created automatically by Jules for task [16355239988901082173](https://jules.google.com/task/16355239988901082173) started by @madmax983*