### PR TITLE
🪒 Razor: Remove PrimaryKey struct wrapper

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `OperationType` enum with only `Insert` and `Update` variants in `relvar-storage/src/storage/heap.rs`.
 **Cut:** Replaced `OperationType` enum with a simple `bool` flag (`is_update: bool`) since it only had two states.
 **Saved:** Removed enum definition and simplified pattern matching.
+
+## [Reduction]
+**Bloat:** `PrimaryKey` struct that was simply a single-field wrapper around `CandidateKey` with all its methods explicitly passed through to the wrapped type. This was a classic "Layer Lasagna" / redundant type abstraction.
+**Cut:** Removed the `PrimaryKey` struct entirely. Replaced `primary_key: Option<PrimaryKey>` with `primary_key: Option<CandidateKey>` inside `KeyConstraints`. Refactored all usage sites (tests, `visualizer.rs`, etc.) to use `CandidateKey` directly as the primary key.
+**Saved:** ~30 lines of boilerplate code and cognitive load involved in jumping between identical types.

--- a/benches/database.rs
+++ b/benches/database.rs
@@ -3,7 +3,7 @@ use criterion::{
 };
 use relvar::Database;
 use relvar::constraints::{
-    CheckConstraint, CheckConstraints, ConstraintExpression, KeyConstraints, PrimaryKey,
+    CheckConstraint, CheckConstraints, ConstraintExpression, KeyConstraints, CandidateKey,
     ValueOrRef,
 };
 use relvar::tuple;
@@ -115,7 +115,7 @@ fn bench_insert_with_key_constraint(c: &mut Criterion) {
                 || {
                     // Setup: create database, relvar, and add constraint
                     let (_temp_dir, mut db) = create_database_with_relvar();
-                    let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+                    let pk = CandidateKey::new(vec!["emp_id".to_string()]).unwrap();
                     db.set_key_constraints("EMP", KeyConstraints::new().with_primary_key(pk))
                         .unwrap();
                     (_temp_dir, db)

--- a/relvar-core/src/constraints/key.rs
+++ b/relvar-core/src/constraints/key.rs
@@ -17,10 +17,10 @@
 //! # Example
 //!
 //! ```
-//! use relvar_core::constraints::{PrimaryKey, CandidateKey, KeyConstraints};
+//! use relvar_core::constraints::{CandidateKey, KeyConstraints};
 //!
 //! // Single-attribute primary key
-//! let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+//! let pk = CandidateKey::new(vec!["emp_id".to_string()]).unwrap();
 //!
 //! // Composite candidate key (email must also be unique)
 //! let ck = CandidateKey::new(vec!["email".to_string()]).unwrap();
@@ -36,7 +36,7 @@
 //! Key constraints can detect when an insert would create duplicates:
 //!
 //! ```
-//! use relvar_core::constraints::{PrimaryKey, KeyConstraints};
+//! use relvar_core::constraints::{CandidateKey, KeyConstraints};
 //! use relvar_core::types::{TupleType, RelationType, ScalarType};
 //! use relvar_core::values::Relation;
 //! use relvar_core::tuple;
@@ -51,7 +51,7 @@
 //! relation.insert(tuple! { emp_id: 2i64, name: "Bob" }).unwrap();
 //!
 //! // Define primary key on emp_id
-//! let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+//! let pk = CandidateKey::new(vec!["emp_id".to_string()]).unwrap();
 //! let constraints = KeyConstraints::new().with_primary_key(pk);
 //!
 //! // Check if current data satisfies the key constraint
@@ -192,49 +192,10 @@ impl CandidateKey {
     }
 }
 
-/// A primary key is a designated candidate key
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PrimaryKey {
-    key: CandidateKey,
-}
-
-impl PrimaryKey {
-    /// Create a new primary key
-    pub fn new(attributes: Vec<String>) -> Result<Self, KeyConstraintError> {
-        Ok(Self {
-            key: CandidateKey::new(attributes)?,
-        })
-    }
-
-    /// Get the key attributes
-    pub fn attributes(&self) -> &[String] {
-        self.key.attributes()
-    }
-
-    /// Get the underlying candidate key
-    pub fn as_candidate_key(&self) -> &CandidateKey {
-        &self.key
-    }
-
-    /// Check if this key is satisfied by a relation
-    pub fn is_satisfied_by(&self, relation: &Relation) -> Result<bool, KeyConstraintError> {
-        self.key.is_satisfied_by(relation)
-    }
-
-    /// Check if a tuple would violate this key constraint
-    pub fn would_violate(
-        &self,
-        relation: &Relation,
-        new_tuple: &Tuple,
-    ) -> Result<bool, KeyConstraintError> {
-        self.key.would_violate(relation, new_tuple)
-    }
-}
-
 /// Key constraints for a relation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyConstraints {
-    primary_key: Option<PrimaryKey>,
+    primary_key: Option<CandidateKey>,
     candidate_keys: Vec<CandidateKey>,
 }
 
@@ -248,7 +209,7 @@ impl KeyConstraints {
     }
 
     /// Set the primary key
-    pub fn with_primary_key(mut self, key: PrimaryKey) -> Self {
+    pub fn with_primary_key(mut self, key: CandidateKey) -> Self {
         self.primary_key = Some(key);
         self
     }
@@ -260,7 +221,7 @@ impl KeyConstraints {
     }
 
     /// Get the primary key
-    pub fn primary_key(&self) -> Option<&PrimaryKey> {
+    pub fn primary_key(&self) -> Option<&CandidateKey> {
         self.primary_key.as_ref()
     }
 
@@ -406,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_primary_key() {
-        let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+        let pk = CandidateKey::new(vec!["emp_id".to_string()]).unwrap();
         assert_eq!(pk.attributes(), &["emp_id"]);
 
         let mut relation = create_employee_relation();
@@ -422,7 +383,7 @@ mod tests {
 
     #[test]
     fn test_key_constraints_with_primary_key() {
-        let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+        let pk = CandidateKey::new(vec!["emp_id".to_string()]).unwrap();
         let constraints = KeyConstraints::new().with_primary_key(pk);
 
         let mut relation = create_employee_relation();
@@ -438,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_key_constraints_violation_detection() {
-        let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+        let pk = CandidateKey::new(vec!["emp_id".to_string()]).unwrap();
         let constraints = KeyConstraints::new().with_primary_key(pk);
 
         let mut relation = create_employee_relation();
@@ -470,7 +431,7 @@ mod tests {
             .insert(tuple! { emp_id: 2i64, email: "bob@example.com", name: "Bob" })
             .unwrap();
 
-        let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+        let pk = CandidateKey::new(vec!["emp_id".to_string()]).unwrap();
         let ck = CandidateKey::new(vec!["email".to_string()]).unwrap();
 
         let constraints = KeyConstraints::new()

--- a/relvar-core/src/constraints/manager.rs
+++ b/relvar-core/src/constraints/manager.rs
@@ -474,8 +474,7 @@ impl ConstraintManager {
 mod tests {
     use super::*;
     use crate::constraints::{
-        AttributeConstraints, CandidateKey, CheckConstraint, ConstraintExpression, PrimaryKey,
-        TypeConstraint,
+        AttributeConstraints, CandidateKey, CheckConstraint, ConstraintExpression, TypeConstraint,
     };
     use crate::storage_engine::InMemoryEngine;
     use crate::tuple;
@@ -569,7 +568,7 @@ mod tests {
         let mut engine = setup_engine();
         let mut manager = ConstraintManager::new();
 
-        let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+        let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
         let ck = CandidateKey::new(vec!["id".to_string()]).unwrap();
         let keys = KeyConstraints::new()
             .with_primary_key(pk)
@@ -610,7 +609,7 @@ mod tests {
     #[test]
     fn should_return_error_when_bulk_key_constraints_violated() {
         let manager = ConstraintManager::new();
-        let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+        let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
         let ck = CandidateKey::new(vec!["id".to_string()]).unwrap();
         let keys = KeyConstraints::new()
             .with_primary_key(pk)
@@ -637,7 +636,7 @@ mod tests {
         let mut engine = setup_engine();
         let mut manager = ConstraintManager::new();
 
-        let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+        let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
         let ck = CandidateKey::new(vec!["id".to_string()]).unwrap();
         let keys = KeyConstraints::new()
             .with_primary_key(pk)

--- a/relvar-core/src/constraints/mod.rs
+++ b/relvar-core/src/constraints/mod.rs
@@ -17,10 +17,10 @@
 //! # Example
 //!
 //! ```
-//! use relvar_core::constraints::{PrimaryKey, KeyConstraints, ForeignKey};
+//! use relvar_core::constraints::{CandidateKey, KeyConstraints, ForeignKey};
 //!
 //! // Define a primary key on emp_id
-//! let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+//! let pk = CandidateKey::new(vec!["emp_id".to_string()]).unwrap();
 //!
 //! // Create key constraints with the primary key
 //! let key_constraints = KeyConstraints::new()
@@ -46,7 +46,7 @@ pub(crate) mod type_constraint;
 pub use check::{CheckConstraint, CheckConstraintError, CheckConstraints};
 pub use expression::{CmpOp, ConstraintExpression, ExpressionError, ValueOrRef};
 pub use foreign_key::{ForeignKey, ForeignKeyConstraints, ForeignKeyError};
-pub use key::{CandidateKey, KeyConstraintError, KeyConstraints, PrimaryKey};
+pub use key::{CandidateKey, KeyConstraintError, KeyConstraints};
 pub use manager::{ConstraintManager, ConstraintManagerError};
 pub use prepared::PreparedConstraintExpression;
 pub use type_constraint::{AttributeConstraints, TypeConstraint, TypeConstraintError};

--- a/relvar-core/src/database/integrity.rs
+++ b/relvar-core/src/database/integrity.rs
@@ -16,13 +16,13 @@ impl<E: StorageEngine> Database<E> {
     /// use relvar_core::database::Database;
     /// use relvar_core::storage_engine::InMemoryEngine;
     /// use relvar_core::types::{TupleType, RelationType, ScalarType};
-    /// use relvar_core::constraints::{KeyConstraints, PrimaryKey};
+    /// use relvar_core::constraints::{KeyConstraints, CandidateKey};
     ///
     /// let mut db = Database::new(InMemoryEngine::new());
     /// let rel_type = RelationType::new(TupleType::new().with_attribute("id", ScalarType::Int));
     /// db.create_relvar("TEST", rel_type).unwrap();
     ///
-    /// let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    /// let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
     /// let constraints = KeyConstraints::new().with_primary_key(pk);
     /// db.set_key_constraints("TEST", constraints).unwrap();
     /// let current_constraints = db.get_key_constraints("TEST").unwrap();
@@ -34,13 +34,13 @@ impl<E: StorageEngine> Database<E> {
     /// use relvar_core::database::Database;
     /// use relvar_core::storage_engine::InMemoryEngine;
     /// use relvar_core::types::{RelationType, TupleType, ScalarType};
-    /// use relvar_core::constraints::{KeyConstraints, PrimaryKey};
+    /// use relvar_core::constraints::{KeyConstraints, CandidateKey};
     ///
     /// let mut db = Database::new(InMemoryEngine::new());
     /// let heading = TupleType::new().with_attribute("id", ScalarType::Int);
     /// db.create_relvar("USERS", RelationType::new(heading)).unwrap();
     ///
-    /// let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    /// let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
     /// db.set_key_constraints("USERS", KeyConstraints::new().with_primary_key(pk)).unwrap();
     ///
     /// let constraints = db.get_key_constraints("USERS").unwrap();
@@ -96,7 +96,7 @@ impl<E: StorageEngine> Database<E> {
     /// use relvar_core::database::Database;
     /// use relvar_core::storage_engine::InMemoryEngine;
     /// use relvar_core::types::{TupleType, RelationType, ScalarType};
-    /// use relvar_core::constraints::{KeyConstraints, PrimaryKey};
+    /// use relvar_core::constraints::{KeyConstraints, CandidateKey};
     ///
     /// let mut db = Database::new(InMemoryEngine::new());
     /// let rel_type = RelationType::new(
@@ -104,7 +104,7 @@ impl<E: StorageEngine> Database<E> {
     /// );
     /// db.create_relvar("TEST", rel_type).unwrap();
     ///
-    /// let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    /// let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
     /// let constraints = KeyConstraints::new().with_primary_key(pk);
     ///
     /// db.set_key_constraints("TEST", constraints).unwrap();

--- a/relvar-core/src/database/tests.rs
+++ b/relvar-core/src/database/tests.rs
@@ -104,13 +104,13 @@ fn test_transactions() {
 
 #[test]
 fn test_primary_key_constraint() {
-    use crate::constraints::{KeyConstraints, PrimaryKey};
+    use crate::constraints::{CandidateKey, KeyConstraints};
 
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
     db.create_relvar("TEST", test_rel_type()).unwrap();
 
     // Add primary key constraint
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
     let constraints = KeyConstraints::new().with_primary_key(pk);
     db.set_key_constraints("TEST", constraints).unwrap();
 
@@ -158,7 +158,7 @@ fn test_candidate_key_constraint() {
 
 #[test]
 fn test_foreign_key_constraint() {
-    use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+    use crate::constraints::{CandidateKey, ForeignKey, ForeignKeyConstraints, KeyConstraints};
 
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
 
@@ -178,7 +178,7 @@ fn test_foreign_key_constraint() {
     db.create_relvar("EMP", child_type).unwrap();
 
     // Add primary key to parent
-    let pk = PrimaryKey::new(vec!["dept_id".to_string()]).unwrap();
+    let pk = CandidateKey::new(vec!["dept_id".to_string()]).unwrap();
     let dept_constraints = KeyConstraints::new().with_primary_key(pk);
     db.set_key_constraints("DEPT", dept_constraints).unwrap();
 
@@ -314,7 +314,7 @@ fn test_virtual_relvar() {
 
 #[test]
 fn test_delete_with_foreign_key_constraint() {
-    use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+    use crate::constraints::{CandidateKey, ForeignKey, ForeignKeyConstraints, KeyConstraints};
 
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
 
@@ -333,7 +333,7 @@ fn test_delete_with_foreign_key_constraint() {
     db.create_relvar("PARENT", parent_type).unwrap();
     db.create_relvar("CHILD", child_type).unwrap();
 
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
     let parent_constraints = KeyConstraints::new().with_primary_key(pk);
     db.set_key_constraints("PARENT", parent_constraints)
         .unwrap();
@@ -367,12 +367,12 @@ fn test_delete_with_foreign_key_constraint() {
 
 #[test]
 fn test_update_with_primary_key_violation() {
-    use crate::constraints::{KeyConstraints, PrimaryKey};
+    use crate::constraints::{CandidateKey, KeyConstraints};
 
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
     db.create_relvar("TEST", test_rel_type()).unwrap();
 
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
     let constraints = KeyConstraints::new().with_primary_key(pk);
     db.set_key_constraints("TEST", constraints).unwrap();
 
@@ -399,12 +399,12 @@ fn test_update_with_primary_key_violation() {
 
 #[test]
 fn test_transaction_rollback_with_constraints() {
-    use crate::constraints::{KeyConstraints, PrimaryKey};
+    use crate::constraints::{CandidateKey, KeyConstraints};
 
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
     db.create_relvar("TEST", test_rel_type()).unwrap();
 
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
     let constraints = KeyConstraints::new().with_primary_key(pk);
     db.set_key_constraints("TEST", constraints).unwrap();
 
@@ -663,7 +663,7 @@ fn test_virtual_relvar_error_propagation() {
 
 #[test]
 fn test_set_foreign_key_constraints_with_existing_valid_data() {
-    use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+    use crate::constraints::{CandidateKey, ForeignKey, ForeignKeyConstraints, KeyConstraints};
 
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
 
@@ -683,7 +683,7 @@ fn test_set_foreign_key_constraints_with_existing_valid_data() {
     db.create_relvar("CHILD", child_type).unwrap();
 
     // Set PK on parent
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
     db.set_key_constraints("PARENT", KeyConstraints::new().with_primary_key(pk))
         .unwrap();
 
@@ -709,7 +709,7 @@ fn test_set_foreign_key_constraints_with_existing_valid_data() {
 
 #[test]
 fn test_set_foreign_key_constraints_with_existing_invalid_data() {
-    use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+    use crate::constraints::{CandidateKey, ForeignKey, ForeignKeyConstraints, KeyConstraints};
 
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
 
@@ -729,7 +729,7 @@ fn test_set_foreign_key_constraints_with_existing_invalid_data() {
     db.create_relvar("CHILD", child_type).unwrap();
 
     // Set PK on parent
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
     db.set_key_constraints("PARENT", KeyConstraints::new().with_primary_key(pk))
         .unwrap();
 
@@ -762,7 +762,7 @@ fn test_set_foreign_key_constraints_with_existing_invalid_data() {
 
 #[test]
 fn test_delete_referenced_parent_success() {
-    use crate::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+    use crate::constraints::{CandidateKey, ForeignKey, ForeignKeyConstraints, KeyConstraints};
 
     let mut db: Database<InMemoryEngine> = Database::new(InMemoryEngine::new());
 
@@ -780,7 +780,7 @@ fn test_delete_referenced_parent_success() {
     db.create_relvar("PARENT", parent_type).unwrap();
     db.create_relvar("CHILD", child_type).unwrap();
 
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
     db.set_key_constraints("PARENT", KeyConstraints::new().with_primary_key(pk))
         .unwrap();
 

--- a/relvar-core/src/lib.rs
+++ b/relvar-core/src/lib.rs
@@ -117,8 +117,8 @@ pub use values::{Relation, ScalarValue, Tuple};
 pub use constraints::{
     AttributeConstraints, CandidateKey, CheckConstraint, CheckConstraintError, CheckConstraints,
     CmpOp, ConstraintExpression, ConstraintManagerError, ExpressionError, ForeignKey,
-    ForeignKeyConstraints, ForeignKeyError, KeyConstraintError, KeyConstraints, PrimaryKey,
-    TypeConstraint, TypeConstraintError, ValueOrRef,
+    ForeignKeyConstraints, ForeignKeyError, KeyConstraintError, KeyConstraints, TypeConstraint,
+    TypeConstraintError, ValueOrRef,
 };
 
 // Re-export storage engine types

--- a/relvar-core/tests/sentry_database_data_coverage.rs
+++ b/relvar-core/tests/sentry_database_data_coverage.rs
@@ -127,7 +127,7 @@ fn test_database_insert_type_constraint_violation() {
 fn test_database_insert_duplicate_primary_key() {
     let mut db = setup();
 
-    let pk = relvar_core::constraints::PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let pk = relvar_core::constraints::CandidateKey::new(vec!["id".to_string()]).unwrap();
     let key_constraints = relvar_core::constraints::KeyConstraints::new().with_primary_key(pk);
     db.set_key_constraints("TEST", key_constraints).unwrap();
 
@@ -179,7 +179,7 @@ fn test_database_update_referencing_foreign_keys_violation() {
 fn test_database_update_key_constraint_violation() {
     let mut db = setup();
 
-    let pk = relvar_core::constraints::PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let pk = relvar_core::constraints::CandidateKey::new(vec!["id".to_string()]).unwrap();
     let key_constraints = relvar_core::constraints::KeyConstraints::new().with_primary_key(pk);
     db.set_key_constraints("TEST", key_constraints).unwrap();
 

--- a/relvar-core/tests/sentry_database_integrity_coverage.rs
+++ b/relvar-core/tests/sentry_database_integrity_coverage.rs
@@ -24,7 +24,7 @@ fn setup() -> Database<InMemoryEngine> {
 #[test]
 fn test_database_set_key_constraints_fails() {
     let mut db = setup();
-    let pk = relvar_core::constraints::PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let pk = relvar_core::constraints::CandidateKey::new(vec!["id".to_string()]).unwrap();
     let key_constraints = relvar_core::constraints::KeyConstraints::new().with_primary_key(pk);
 
     // Duplicate 1i64 to make it fail

--- a/relvar-core/tests/sentry_database_update_fk_coverage.rs
+++ b/relvar-core/tests/sentry_database_update_fk_coverage.rs
@@ -1,5 +1,5 @@
 use relvar_core::constraints::{
-    ConstraintManagerError, ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey,
+    CandidateKey, ConstraintManagerError, ForeignKey, ForeignKeyConstraints, KeyConstraints,
 };
 use relvar_core::database::Database;
 use relvar_core::error::DatabaseError;
@@ -25,7 +25,7 @@ fn test_update_referenced_parent_fails() {
     db.create_relvar("PARENT", parent_type).unwrap();
     db.create_relvar("CHILD", child_type).unwrap();
 
-    let pk = PrimaryKey::new(vec!["id".to_string()]).unwrap();
+    let pk = CandidateKey::new(vec!["id".to_string()]).unwrap();
     db.set_key_constraints("PARENT", KeyConstraints::new().with_primary_key(pk))
         .unwrap();
 

--- a/relvar/benches/database.rs
+++ b/relvar/benches/database.rs
@@ -1,7 +1,7 @@
 use criterion::{
     BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
 };
-use relvar::constraints::{KeyConstraints, PrimaryKey};
+use relvar::constraints::{CandidateKey, KeyConstraints};
 use relvar::tuple;
 use relvar::{PersistentEngine, RelationType, ScalarType, TupleType};
 use tempfile::TempDir;
@@ -110,7 +110,7 @@ fn bench_insert_with_key_constraint(c: &mut Criterion) {
                 || {
                     // Setup: create database, relvar, and add constraint
                     let (_temp_dir, mut db) = create_database_with_relvar();
-                    let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
+                    let pk = CandidateKey::new(vec!["emp_id".to_string()]).unwrap();
                     db.set_key_constraints("EMP", KeyConstraints::new().with_primary_key(pk))
                         .unwrap();
                     (_temp_dir, db)

--- a/relvar/src/experimental/ecs.rs
+++ b/relvar/src/experimental/ecs.rs
@@ -126,8 +126,8 @@ impl<E: StorageEngine> World<E> {
         self.db.create_relvar(&rel_name, rel_type)?;
 
         // Set Primary Key on entity_id
-        use relvar_core::constraints::{KeyConstraints, PrimaryKey};
-        let pk = PrimaryKey::new(vec![ENTITY_ID_ATTR.to_string()])
+        use relvar_core::constraints::{CandidateKey, KeyConstraints};
+        let pk = CandidateKey::new(vec![ENTITY_ID_ATTR.to_string()])
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
         let constraints = KeyConstraints::new().with_primary_key(pk);
         self.db.set_key_constraints(&rel_name, constraints)?;

--- a/relvar/src/tools/visualizer.rs
+++ b/relvar/src/tools/visualizer.rs
@@ -9,7 +9,7 @@
 //! ```
 //! use relvar::{Database, InMemoryEngine};
 //! use relvar::{TupleType, RelationType, ScalarType};
-//! use relvar::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+//! use relvar::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, CandidateKey};
 //! use relvar::tools::visualizer::SchemaVisualizer;
 //!
 //! let mut db = Database::new(InMemoryEngine::new());
@@ -22,7 +22,7 @@
 //! );
 //! db.create_relvar("DEPT", dept_type).unwrap();
 //!
-//! let pk = PrimaryKey::new(vec!["dept_id".to_string()]).unwrap();
+//! let pk = CandidateKey::new(vec!["dept_id".to_string()]).unwrap();
 //! db.set_key_constraints("DEPT", KeyConstraints::new().with_primary_key(pk)).unwrap();
 //!
 //! // Define Employees
@@ -192,7 +192,9 @@ fn escape_dot_string_content(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use relvar_core::constraints::{ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey};
+    use relvar_core::constraints::{
+        CandidateKey, ForeignKey, ForeignKeyConstraints, KeyConstraints,
+    };
     use relvar_core::storage_engine::InMemoryEngine;
     use relvar_core::types::{RelationType, ScalarType, TupleType};
 
@@ -208,7 +210,7 @@ mod tests {
         );
         db.create_relvar("DEPT", dept_type).unwrap();
 
-        let pk = PrimaryKey::new(vec!["dept_id".to_string()]).unwrap();
+        let pk = CandidateKey::new(vec!["dept_id".to_string()]).unwrap();
         db.set_key_constraints("DEPT", KeyConstraints::new().with_primary_key(pk))
             .unwrap();
 


### PR DESCRIPTION
Removes the redundant `PrimaryKey` struct which was just a 
single-field wrapper around `CandidateKey`. The `KeyConstraints`
now stores the primary key as an `Option<CandidateKey>`, removing
unnecessary boilerplate and simplifying the API.

---
*PR created automatically by Jules for task [6447971080618065372](https://jules.google.com/task/6447971080618065372) started by @madmax983*