### PR TITLE
🛡️ Sentry: [test coverage improvement] WalRecordIter error paths

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -76,3 +76,6 @@
 ## 2025-05-18 - [ForeignKey Constraint Panic]
 **Learning:** `ForeignKey` constraint validation methods (`is_satisfied_by`, `would_violate_on_insert`, `would_violate_on_delete`) panicked with `.unwrap()` when they were passed a tuple that was missing a required attribute, as dynamic relations might accept partially valid or mismatched inputs.
 **Action:** When validating constraints against tuples, use `.ok_or_else()` to explicitly handle missing attributes by returning an error instead of panicking via `.unwrap()`.
+## 2026-03-31 - WalRecordIter error paths
+**Learning:** `WalRecordIter` implements an iterator over WAL records. It had some `unwrap()`s inside tests but what is really missing from coverage is the error handling paths `WalError::Corrupted` inside the iterator's `read_length` and `next` methods which handle buffer length issues and `offset.checked_add()` overflows, and `record_len` overflows.
+**Action:** When testing iterators reading from byte arrays, verify handling of malformed and corrupted buffers. Added tests explicitly triggering `WalError::Corrupted` by passing exceedingly large `record_len` and truncated buffers.

--- a/relvar-storage/src/wal/iter.rs
+++ b/relvar-storage/src/wal/iter.rs
@@ -87,3 +87,74 @@ impl<'a> Iterator for WalRecordIter<'a> {
         Some(Ok((lsn, record_len_u64, record_bytes)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_buffer() {
+        let buffer = vec![];
+        let mut iter = WalRecordIter::new(&buffer);
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_valid_record() {
+        let mut buffer = vec![];
+        // LSN
+        buffer.extend_from_slice(&1u64.to_le_bytes());
+        // Length
+        buffer.extend_from_slice(&5u64.to_le_bytes());
+        // Data
+        buffer.extend_from_slice(&[1, 2, 3, 4, 5]);
+
+        let mut iter = WalRecordIter::new(&buffer);
+        let item = iter.next().unwrap().unwrap();
+        assert_eq!(item.0.value(), 1);
+        assert_eq!(item.1, 5);
+        assert_eq!(item.2, &[1, 2, 3, 4, 5]);
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_corrupted_length_exceeds_memory() {
+        let mut buffer = vec![];
+        // LSN
+        buffer.extend_from_slice(&1u64.to_le_bytes());
+        // Length - extremely large
+        buffer.extend_from_slice(&u64::MAX.to_le_bytes());
+
+        let mut iter = WalRecordIter::new(&buffer);
+        let err = iter.next().unwrap().unwrap_err();
+        match err {
+            WalError::Corrupted(lsn, msg) => {
+                assert_eq!(lsn.value(), 1);
+                assert!(msg.contains("exceeds memory limits") || msg.contains("offset overflow"));
+            }
+            _ => panic!("Expected Corrupted error"),
+        }
+    }
+
+    #[test]
+    fn test_corrupted_record_extends_beyond_file() {
+        let mut buffer = vec![];
+        // LSN
+        buffer.extend_from_slice(&1u64.to_le_bytes());
+        // Length
+        buffer.extend_from_slice(&100u64.to_le_bytes()); // Expects 100 bytes of data
+        // Data
+        buffer.extend_from_slice(&[1, 2, 3]); // Only 3 bytes available
+
+        let mut iter = WalRecordIter::new(&buffer);
+        let err = iter.next().unwrap().unwrap_err();
+        match err {
+            WalError::Corrupted(lsn, msg) => {
+                assert_eq!(lsn.value(), 1);
+                assert!(msg.contains("Record extends beyond file"));
+            }
+            _ => panic!("Expected Corrupted error"),
+        }
+    }
+}


### PR DESCRIPTION
🎯 Target: `WalRecordIter::read_length` and `WalRecordIter::next` error paths in `relvar-storage/src/wal/iter.rs`.
💣 Risk: Untested error paths when reading corrupted or excessively large buffers, leaving potential panics or unbounded memory limits exposed without test coverage. 
🧪 Strategy: Added specific unit tests passing manually crafted corrupted binary buffers triggering size limits (`exceeds memory limits` / `offset overflow`) and bounds limits (`Record extends beyond file`).
🔬 Verification: Run `cargo test -p relvar-storage`.

---
*PR created automatically by Jules for task [8286846404463758008](https://jules.google.com/task/8286846404463758008) started by @madmax983*