### PR TITLE
🪒 Razor: [Refactor error types]

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -1,19 +1,9 @@
 ## [Reduction]
-**Bloat:** Empty `ImageProcessor` and `Tokenizer` structs acting purely as namespaces for static methods (Enterprise FizzBuzz "God Struct" style).
-**Cut:** Removed the empty structs and `impl` blocks, changing the static methods into module-level free functions. Updated usage sites.
-**Saved:** Reduced boilerplate, improved clarity, explicit module-level function calls instead of Object-Oriented faux namespaces.
+**Bloat:** Single-variant enums `UnionError`, `IntersectError`, and `DifferenceError` in `relvar-core/src/algebra/` acting as unit structs but declared as enums.
+**Cut:** Converted them to unit structs (`pub struct UnionError;`, etc.) to simplify error handling and reduce boilerplate, aligning with the KISS principle.
+**Saved:** Unnecessary enum matching and boilerplate code.
 
 ## [Reduction]
-**Bloat:** `OperationType` enum with only `Insert` and `Update` variants in `relvar-storage/src/storage/heap.rs`.
-**Cut:** Replaced `OperationType` enum with a simple `bool` flag (`is_update: bool`) since it only had two states.
-**Saved:** Removed enum definition and simplified pattern matching.
-
-## [Reduction]
-**Bloat:** `DepthGuarded<T>` struct wrapper used to prevent recursive serialization/deserialization panics. Added nesting and `.0` boilerplate when unpacking scalars.
-**Cut:** Removed the wrapper struct, replacing it with a custom `deserialize_guarded` function applied via `#[serde(deserialize_with = "...")]` to directly flatten recursive structures.
-**Saved:** Reduced boilerplate wrapper types, streamlined Serde parsing logic, and eliminated intermediate `.0` tuple accesses.
-
-## [Reduction]
-**Bloat:** Redundant per-tuple type validation using `self.insert()` in a loop inside `union_into` when relation headings are already explicitly verified to match.
-**Cut:** Exposed `body` as `pub(crate)` in `Relation` and replaced the loop with `.reserve()` and `.extend()` to directly insert tuples into the underlying `HashSet`.
-**Saved:** Eliminated O(N) redundant validations and reduced overhead in relational algebra merge operations.
+**Bloat:** Single-variant enums `UnionError`, `IntersectError`, and `DifferenceError` in `relvar-core/src/algebra/` acting as unit structs but declared as enums.
+**Cut:** Converted them to unit structs (`pub struct UnionError;`, etc.) to simplify error handling and reduce boilerplate, aligning with the KISS principle.
+**Saved:** Unnecessary enum matching and boilerplate code.

--- a/relvar-core/src/algebra/difference.rs
+++ b/relvar-core/src/algebra/difference.rs
@@ -38,14 +38,8 @@ use thiserror::Error;
 
 /// Errors that can occur during difference operations.
 #[derive(Debug, Error)]
-pub enum DifferenceError {
-    /// The two relations have incompatible types (different headings).
-    ///
-    /// Difference requires both relations to have exactly the same heading
-    /// (attribute names and types).
-    #[error("Relations must have the same type (heading) for difference")]
-    TypeMismatch,
-}
+#[error("Relations must have the same type (heading) for difference")]
+pub struct DifferenceError;
 
 impl Relation {
     /// Computes the set difference of this relation with another.
@@ -65,7 +59,7 @@ impl Relation {
     ///
     /// # Errors
     ///
-    /// Returns [`DifferenceError::TypeMismatch`] if the relations have different
+    /// Returns [`DifferenceError`] if the relations have different
     /// headings (different attribute names or types).
     ///
     /// # Behavior
@@ -108,7 +102,7 @@ impl Relation {
     pub fn difference(&self, other: &Relation) -> Result<Self, DifferenceError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
-            return Err(DifferenceError::TypeMismatch);
+            return Err(DifferenceError);
         }
 
         // Filter tuples and create relation without redundant checks
@@ -163,7 +157,7 @@ impl Relation {
     pub fn difference_into(mut self, other: &Relation) -> Result<Self, DifferenceError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
-            return Err(DifferenceError::TypeMismatch);
+            return Err(DifferenceError);
         }
 
         self.body.retain(|tuple| !other.contains(tuple));
@@ -237,7 +231,7 @@ mod tests {
 
         let result = rel1.difference(&rel2);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), DifferenceError::TypeMismatch));
+        assert!(matches!(result.unwrap_err(), DifferenceError));
     }
 
     #[test]

--- a/relvar-core/src/algebra/intersect.rs
+++ b/relvar-core/src/algebra/intersect.rs
@@ -39,14 +39,8 @@ use thiserror::Error;
 
 /// Errors that can occur during intersection operations.
 #[derive(Debug, Error)]
-pub enum IntersectError {
-    /// The two relations have incompatible types (different headings).
-    ///
-    /// Intersection requires both relations to have exactly the same heading
-    /// (attribute names and types).
-    #[error("Relations must have the same type (heading) for intersection")]
-    TypeMismatch,
-}
+#[error("Relations must have the same type (heading) for intersection")]
+pub struct IntersectError;
 
 impl Relation {
     /// Computes the intersection of this relation with another.
@@ -66,7 +60,7 @@ impl Relation {
     ///
     /// # Errors
     ///
-    /// Returns [`IntersectError::TypeMismatch`] if the relations have different
+    /// Returns [`IntersectError`] if the relations have different
     /// headings (different attribute names or types).
     ///
     /// # Behavior
@@ -109,7 +103,7 @@ impl Relation {
     pub fn intersect(&self, other: &Relation) -> Result<Self, IntersectError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
-            return Err(IntersectError::TypeMismatch);
+            return Err(IntersectError);
         }
 
         // Filter tuples and create relation without redundant checks
@@ -127,7 +121,7 @@ impl Relation {
     pub fn intersect_into(mut self, other: &Relation) -> Result<Self, IntersectError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
-            return Err(IntersectError::TypeMismatch);
+            return Err(IntersectError);
         }
 
         self.body.retain(|tuple| other.contains(tuple));
@@ -191,7 +185,7 @@ mod tests {
 
         let result = rel1.intersect(&rel2);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), IntersectError::TypeMismatch));
+        assert!(matches!(result.unwrap_err(), IntersectError));
     }
 
     #[test]

--- a/relvar-core/src/algebra/union.rs
+++ b/relvar-core/src/algebra/union.rs
@@ -38,14 +38,8 @@ use thiserror::Error;
 
 /// Errors that can occur during union operations.
 #[derive(Debug, Error)]
-pub enum UnionError {
-    /// The two relations have incompatible types (different headings).
-    ///
-    /// Union requires both relations to have exactly the same heading
-    /// (attribute names and types).
-    #[error("Relations must have the same type (heading) for union")]
-    TypeMismatch,
-}
+#[error("Relations must have the same type (heading) for union")]
+pub struct UnionError;
 
 impl Relation {
     /// Computes the union of this relation with another.
@@ -66,7 +60,7 @@ impl Relation {
     ///
     /// # Errors
     ///
-    /// Returns [`UnionError::TypeMismatch`] if the relations have different
+    /// Returns [`UnionError`] if the relations have different
     /// headings (different attribute names or types).
     ///
     /// # Behavior
@@ -103,7 +97,7 @@ impl Relation {
     pub fn union(&self, other: &Relation) -> Result<Self, UnionError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
-            return Err(UnionError::TypeMismatch);
+            return Err(UnionError);
         }
 
         // Chain iterators and create relation without redundant checks
@@ -121,7 +115,7 @@ impl Relation {
     pub fn union_into(mut self, other: &Relation) -> Result<Self, UnionError> {
         // Check type compatibility
         if self.relation_type() != other.relation_type() {
-            return Err(UnionError::TypeMismatch);
+            return Err(UnionError);
         }
 
         self.body.reserve(other.cardinality());
@@ -159,7 +153,7 @@ mod tests {
 
         let result = rel1.union(&rel2);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), UnionError::TypeMismatch));
+        assert!(matches!(result.unwrap_err(), UnionError));
     }
 
     #[test]


### PR DESCRIPTION
## [Reduction] \n **Bloat:** Single-variant enums `UnionError`, `IntersectError`, and `DifferenceError` in `relvar-core/src/algebra/` acting as unit structs but declared as enums.\n **Cut:** Converted them to unit structs (`pub struct UnionError;`, etc.) to simplify error handling and reduce boilerplate, aligning with the KISS principle.\n **Saved:** Unnecessary enum matching and boilerplate code.

---
*PR created automatically by Jules for task [13450489849250681619](https://jules.google.com/task/13450489849250681619) started by @madmax983*