### PR TITLE
🛡️ Sentry: [test coverage improvement] for PageFile buffer errors

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -82,3 +82,6 @@
 ## 2024-04-10 - Database Facade Constraint Tests
 **Learning:** Many of the Database facade constraint manipulation methods (`get_key_constraints`, `set_key_constraints`, etc) were uncovered because constraints were typically interacted with directly, but the facade handles translating names properly to the underlying engine. Also `drop_relvar` and `drop_virtual_relvar` error conditions were not covered.
 **Action:** Wrote targeted coverage tests for Database methods verifying they behave correctly and emit the right error enumerations (like `TupleMismatch` and constraint errors) directly on `Database<E>`. Always ensure integration-style tests cover the outermost boundary layer.
+## 2024-05-01 - [Coverage Gap in Storage Page Buffer Reading]
+**Learning:** `PageFile::read_page` had uncovered error paths when handling short, malformed, or corrupt file buffers from disk.
+**Action:** Wrote 5 new unit tests mapping specifically to those missing branch coverage blocks (PageError::Serialization mappings).


### PR DESCRIPTION
🎯 Target: `relvar-storage/src/storage/page.rs` (`PageFile::read_page`, `write_page`, `write_page_buffered`).
💣 Risk: These methods handle raw buffers from disk, and previously lacked test coverage for corrupt, truncated, or unparseable length prefixes, as well as `u64` offset overflows during file seeking.
🧪 Strategy: Added 5 distinct integration test cases using `tempfile` to write intentionally corrupt or truncated page buffers to disk, and verified that `PageFile` returns the correct `PageError::Serialization` and `PageError::PageTooLarge` errors.
🔬 Verification: `cargo test --package relvar-storage --test sentry_page_read_corrupted_length --test sentry_page_read_empty_buffer --test sentry_page_read_short_buffer --test sentry_page_read_unparseable_length --test sentry_page_offset_overflow --test sentry_page_read_offset_overflow`

---
*PR created automatically by Jules for task [11401629909779169486](https://jules.google.com/task/11401629909779169486) started by @madmax983*