### PR TITLE
⚒️ Forge: [Refactor image kernel application]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -561,3 +561,7 @@ Build it right, make it fast, keep it simple.
 ## 2026-04-10 - Extract Complex Physics Calculation Steps
 **Learning:** The `next_step` function in `relvar/src/experimental/physics.rs` contained multiple distinct logical phases (computing forces, handling missing elements and summation, updating kinematics) in a single massive code block, making it hard to follow.
 **Action:** Refactored by extracting these phases into appropriately named private helper methods (`compute_pairwise_forces`, `summarize_net_forces`, `update_kinematics_and_project`), drastically reducing complexity and improving code clarity.
+
+## 2026-04-10 - Refactoring image kernel application into Three-Phase Operator
+**Learning:** `relvar/src/experimental/image.rs` contained a "God Function" `apply_kernel` which combined multiple phases (shifting/scaling, unioning, and summarizing/normalizing), making it overly long (133 lines) and harder to comprehend.
+**Action:** Applied the "Three-Phase Operator" pattern by extracting `compute_kernel_contributions`, `union_contributions`, and `summarize_and_normalize` into separate helper functions to improve readability without changing behavior.

--- a/relvar/src/experimental/image.rs
+++ b/relvar/src/experimental/image.rs
@@ -187,10 +187,14 @@ pub fn apply_kernel(relation: &Relation, kernel: &[KernelTap]) -> Relation {
         return relation.clone(); // Avoid division by zero
     }
 
-    // We accumulate the shifted relations.
-    // Since we can't easily modify Relation in place effectively without potentially
-    // re-allocating, we collect them.
-    let mut contributions = Vec::new();
+    let contributions = compute_kernel_contributions(relation, kernel);
+    let unioned = union_contributions(&contributions);
+
+    summarize_and_normalize(&unioned, total_weight)
+}
+
+fn compute_kernel_contributions(relation: &Relation, kernel: &[KernelTap]) -> Vec<Relation> {
+    let mut contributions = Vec::with_capacity(kernel.len());
 
     for (i, tap) in kernel.iter().enumerate() {
         let dx = tap.dx;
@@ -261,13 +265,20 @@ pub fn apply_kernel(relation: &Relation, kernel: &[KernelTap]) -> Relation {
         contributions.push(renamed);
     }
 
+    contributions
+}
+
+fn union_contributions(contributions: &[Relation]) -> Relation {
     // Step 2: Union
     // Start with the first contribution
     let mut unioned = contributions[0].clone();
     for other in contributions.iter().skip(1) {
         unioned = unioned.union(other).unwrap();
     }
+    unioned
+}
 
+fn summarize_and_normalize(unioned: &Relation, total_weight: i64) -> Relation {
     // Step 3: Summarize
     // Group by (x, y)
     // Sum (r, g, b) -> (sum_r, sum_g, sum_b)


### PR DESCRIPTION
🚮 Smell: `apply_kernel` in `relvar/src/experimental/image.rs` was a 133-line "God Function" that handled multiple phases (shifting/scaling, unioning, summarizing/normalizing), making it hard to read and test.
✨ Solution: Extracted the logical phases into three private helper functions: `compute_kernel_contributions`, `union_contributions`, and `summarize_and_normalize` following the "Three-Phase Operator" pattern.
🧼 Benefit: Significantly reduces cognitive load and flattens the execution flow without altering any runtime behavior.
🛡️ Verification: All tests passed. `cargo clippy` and `cargo fmt` run without issues. No logic was changed.

---
*PR created automatically by Jules for task [4360852398824784204](https://jules.google.com/task/4360852398824784204) started by @madmax983*