### PR TITLE
⚒️ Forge: refactor graph algorithms

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -570,3 +570,4 @@ Build it right, make it fast, keep it simple.
 ## 2024-05-30 - Extract God Function in Enigma
 **Learning:** Enigma machine's `encrypt` function was over 120 lines long because of large inline closures and duplicated mapping logic.
 **Action:** Refactored by extracting the forward/backward rotor passes and the static mapping into private associated functions. The main `encrypt` function is now much cleaner and easier to read.
+## 2026-04-14 - Refactored God Functions in Graph algorithms\n**Learning:** The `bfs` and `pagerank` functions in `relvar/src/experimental/graph.rs` were extremely large and deeply nested, making the relational algebra logic hard to follow.\n**Action:** Extracted the core loop bodies and initialization steps into private helper functions. This flattens the main functions into readable iterations and clarifies the boundaries of the relational operations.

--- a/relvar/src/experimental/graph.rs
+++ b/relvar/src/experimental/graph.rs
@@ -111,7 +111,33 @@ impl Graph {
     /// // Note: This is a placeholder example
     /// ```
     pub fn bfs(&self, start_node_id: ScalarValue) -> Result<Relation, DatabaseError> {
-        // 1. Initialize result schema: (node_id, distance)
+        let mut visited = self.initialize_bfs_visited(start_node_id)?;
+        let mut frontier = visited.clone();
+
+        loop {
+            if frontier.is_empty() {
+                break;
+            }
+
+            let new_frontier = self.compute_next_frontier(&visited, &frontier)?;
+
+            if new_frontier.is_empty() {
+                break;
+            }
+
+            visited = visited
+                .union(&new_frontier)
+                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+            frontier = new_frontier;
+        }
+
+        Ok(visited)
+    }
+
+    fn initialize_bfs_visited(
+        &self,
+        start_node_id: ScalarValue,
+    ) -> Result<Relation, DatabaseError> {
         let result_heading = TupleType::new()
             .with_attribute(
                 self.node_id_attr.clone(),
@@ -125,8 +151,6 @@ impl Graph {
             .with_attribute("distance", ScalarType::Int);
 
         let result_type = RelationType::new(result_heading.clone());
-
-        // 2. Create initial visited set (just the start node at distance 0)
         let mut visited = Relation::new(result_type.clone());
         let mut start_tuple_map = std::collections::BTreeMap::new();
         start_tuple_map.insert(self.node_id_attr.clone(), start_node_id);
@@ -137,96 +161,40 @@ impl Graph {
                 .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?,
         )?;
 
-        // 3. Frontier is the set of newly visited nodes to expand
-        let mut frontier = visited.clone();
-
-        // 4. Loop until frontier is empty
-        loop {
-            if frontier.is_empty() {
-                break;
-            }
-
-            // JOIN frontier with edges
-            // frontier: (node_id, distance)
-            // edges: (from, to)
-            // Join condition: frontier.node_id = edges.from
-
-            // Rename frontier.node_id -> from_attr to enable natural join
-            let rename_map = vec![(self.node_id_attr.as_str(), self.from_attr.as_str())];
-            let frontier_renamed = frontier.rename(&rename_map);
-
-            // Join: (from, distance, to)
-            let joined = frontier_renamed.join(&self.edges)?;
-
-            // Project: (to, distance)
-            let projected = joined.project(&[self.to_attr.as_str(), "distance"]);
-
-            // Rename: to -> node_id
-            let rename_back_map = vec![(self.to_attr.as_str(), self.node_id_attr.as_str())];
-            let next_nodes = projected.rename(&rename_back_map);
-
-            // Extend: distance = distance + 1
-            let next_nodes_inc = next_nodes
-                .extend("new_distance", ScalarType::Int, |t| {
-                    let d = t.get_typed::<i64>("distance").unwrap();
-                    ScalarValue::Int(d + 1)
-                })
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            // Project out old distance and rename new_distance -> distance
-            let next_frontier_candidates = next_nodes_inc
-                .project(&[self.node_id_attr.as_str(), "new_distance"])
-                .rename(&[("new_distance", "distance")]);
-
-            // Filter out already visited nodes
-            // Note: Difference requires exact tuple match.
-            // Since visited contains (node, dist), and we might have found a shorter path (impossible in BFS)
-            // or longer path to same node. We only care about nodes NOT in visited regardless of distance.
-            // However, relation difference is strict.
-            // A better way is:
-            // new_nodes = candidates.project(node_id) MINUS visited.project(node_id)
-            // Then join back to get distances? No, that's complex.
-
-            // Simpler: Just subtract visited.
-            // In BFS, if we see a node again, it's at a distance >= current.
-            // We only want strict new nodes.
-            // But `difference` includes distance in comparison.
-            // If visited has (A, 0) and candidates has (A, 1), difference keeps (A, 1).
-            // We don't want that. We want to exclude A entirely.
-
-            // Correct approach:
-            // 1. Get visited nodes (just IDs)
-            let visited_ids = visited.project(&[self.node_id_attr.as_str()]);
-            // 2. Get candidate nodes (just IDs)
-            let candidate_ids = next_frontier_candidates.project(&[self.node_id_attr.as_str()]);
-            // 3. New IDs = candidate IDs MINUS visited IDs
-            let new_ids = candidate_ids
-                .difference(&visited_ids)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            // 4. Reconstruct frontier with distances
-            // We join new_ids with next_frontier_candidates to get the distances back.
-            // natural join on node_id
-            let new_frontier = new_ids.join(&next_frontier_candidates)?;
-
-            // But wait, what if `next_frontier_candidates` has duplicates of the same node (from multiple parents)?
-            // BFS level-order guarantees we process them together.
-            // We should deduplicate by taking the one with min distance?
-            // In unweighted BFS, they all have the same distance (current_depth + 1).
-            // So simple projection handles deduplication (Relations are sets).
-
-            if new_frontier.is_empty() {
-                break;
-            }
-
-            // Update visited
-            visited = visited
-                .union(&new_frontier)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-            frontier = new_frontier;
-        }
-
         Ok(visited)
+    }
+
+    fn compute_next_frontier(
+        &self,
+        visited: &Relation,
+        frontier: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        let rename_map = vec![(self.node_id_attr.as_str(), self.from_attr.as_str())];
+        let frontier_renamed = frontier.rename(&rename_map);
+        let joined = frontier_renamed.join(&self.edges)?;
+        let projected = joined.project(&[self.to_attr.as_str(), "distance"]);
+
+        let rename_back_map = vec![(self.to_attr.as_str(), self.node_id_attr.as_str())];
+        let next_nodes = projected.rename(&rename_back_map);
+
+        let next_nodes_inc = next_nodes
+            .extend("new_distance", ScalarType::Int, |t| {
+                let d = t.get_typed::<i64>("distance").unwrap();
+                ScalarValue::Int(d + 1)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        let next_frontier_candidates = next_nodes_inc
+            .project(&[self.node_id_attr.as_str(), "new_distance"])
+            .rename(&[("new_distance", "distance")]);
+
+        let visited_ids = visited.project(&[self.node_id_attr.as_str()]);
+        let candidate_ids = next_frontier_candidates.project(&[self.node_id_attr.as_str()]);
+        let new_ids = candidate_ids
+            .difference(&visited_ids)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        new_ids.join(&next_frontier_candidates)
     }
 
     /// Computes PageRank for all nodes in the graph.
@@ -260,111 +228,96 @@ impl Graph {
         }
 
         let initial_rank = 1.0 / (num_nodes as f64);
+        let mut ranks = self.initialize_pagerank_ranks(initial_rank)?;
+        let out_degrees = self.compute_out_degrees()?;
 
-        // 1. Initialize ranks: (node_id, rank)
-        // We can't easily iterate and insert. Let's use Extend on `nodes`.
-        let mut ranks = self
-            .nodes
+        for _ in 0..iterations {
+            ranks =
+                self.compute_pagerank_iteration(&ranks, &out_degrees, num_nodes, damping_factor)?;
+        }
+
+        Ok(ranks)
+    }
+
+    fn initialize_pagerank_ranks(&self, initial_rank: f64) -> Result<Relation, DatabaseError> {
+        self.nodes
             .project(&[self.node_id_attr.as_str()])
             .extend("rank", ScalarType::Float, move |_| {
                 ScalarValue::Float(initial_rank)
             })
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
 
-        // 2. Precompute out-degrees: (from_node, out_degree)
-        // Group edges by from_attr, count(*).
-        // Summarize requires an aggregation function.
-        let out_degrees = self
-            .edges
+    fn compute_out_degrees(&self) -> Result<Relation, DatabaseError> {
+        self.edges
             .summarize(
                 &[self.from_attr.as_str()],
                 &[Aggregation::count("out_degree")],
             )
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
+
+    fn compute_pagerank_iteration(
+        &self,
+        ranks: &Relation,
+        out_degrees: &Relation,
+        num_nodes: usize,
+        damping_factor: f64,
+    ) -> Result<Relation, DatabaseError> {
+        let rename_map = vec![(self.node_id_attr.as_str(), self.from_attr.as_str())];
+        let ranks_renamed = ranks.rename(&rename_map);
+        let joined_edges = ranks_renamed.join(&self.edges)?;
+        let with_degrees = joined_edges.join(out_degrees)?;
+
+        let contributions = with_degrees
+            .extend("contribution", ScalarType::Float, |t| {
+                let r = t.get_typed::<f64>("rank").unwrap();
+                let d = t.get_typed::<i64>("out_degree").unwrap();
+                if d == 0 {
+                    ScalarValue::Float(0.0)
+                } else {
+                    ScalarValue::Float(r / (d as f64))
+                }
+            })
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
-        // We also need to handle dangling nodes (sink nodes with no outgoing edges).
-        // They accumulate rank but don't distribute it. In standard PageRank, they distribute to everyone.
-        // For this simplified implementation, we'll ignore that distribution (rank sink).
+        let incoming = contributions.project(&[self.to_attr.as_str(), "contribution"]);
+        let rename_back_map = vec![(self.to_attr.as_str(), self.node_id_attr.as_str())];
+        let incoming_renamed = incoming.rename(&rename_back_map);
 
-        for _ in 0..iterations {
-            // Join ranks with edges to distribute score
-            // ranks: (node_id, rank)
-            // edges: (from, to)
-            // out_degrees: (from, out_degree)
+        let new_ranks_sum = incoming_renamed
+            .summarize(
+                &[self.node_id_attr.as_str()],
+                &[Aggregation::sum_float("sum_rank", "contribution")],
+            )
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
-            // Prepare ranks for join: rename node_id -> from
-            let rename_map = vec![(self.node_id_attr.as_str(), self.from_attr.as_str())];
-            let ranks_renamed = ranks.rename(&rename_map);
+        let all_node_ids = self.nodes.project(&[self.node_id_attr.as_str()]);
+        let ranked_node_ids = new_ranks_sum.project(&[self.node_id_attr.as_str()]);
+        let missing_nodes = all_node_ids
+            .difference(&ranked_node_ids)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
-            // Join with edges
-            let joined_edges = ranks_renamed.join(&self.edges)?;
+        let missing_ranks = missing_nodes
+            .extend("sum_rank", ScalarType::Float, |_| ScalarValue::Float(0.0))
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
-            // Join with out_degrees to get divisor
-            let with_degrees = joined_edges.join(&out_degrees)?;
+        let total_ranks = new_ranks_sum
+            .union(&missing_ranks)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
-            // Calculate contribution: rank / out_degree
-            let contributions = with_degrees
-                .extend("contribution", ScalarType::Float, |t| {
-                    let r = t.get_typed::<f64>("rank").unwrap();
-                    let d = t.get_typed::<i64>("out_degree").unwrap();
-                    if d == 0 {
-                        ScalarValue::Float(0.0)
-                    } else {
-                        ScalarValue::Float(r / (d as f64))
-                    }
-                })
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+        let base_score = (1.0 - damping_factor) / (num_nodes as f64);
 
-            // Project: (to, contribution)
-            let incoming = contributions.project(&[self.to_attr.as_str(), "contribution"]);
+        let result = total_ranks
+            .extend("new_rank_final", ScalarType::Float, move |t| {
+                let sum_r = t.get_typed::<f64>("sum_rank").unwrap();
+                ScalarValue::Float(base_score + damping_factor * sum_r)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
+            .project(&[self.node_id_attr.as_str(), "new_rank_final"])
+            .rename(&[("new_rank_final", "rank")]);
 
-            // Rename: to -> node_id
-            let rename_back_map = vec![(self.to_attr.as_str(), self.node_id_attr.as_str())];
-            let incoming_renamed = incoming.rename(&rename_back_map);
-
-            // Summarize: Sum contributions for each node
-            let new_ranks_sum = incoming_renamed
-                .summarize(
-                    &[self.node_id_attr.as_str()],
-                    &[Aggregation::sum_float("sum_rank", "contribution")],
-                )
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            // Note: `new_ranks_sum` only contains nodes that have INCOMING edges.
-            // Nodes with no incoming edges (sources) will be missing.
-            // We must RIGHT JOIN with original nodes? Or Union with missing nodes?
-            // Relvar doesn't have Right Join.
-            // We can take `nodes` project `node_id`, difference `new_ranks_sum` project `node_id`,
-            // extend with 0.0, and Union.
-
-            let all_node_ids = self.nodes.project(&[self.node_id_attr.as_str()]);
-            let ranked_node_ids = new_ranks_sum.project(&[self.node_id_attr.as_str()]);
-            let missing_nodes = all_node_ids
-                .difference(&ranked_node_ids)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            let missing_ranks = missing_nodes
-                .extend("sum_rank", ScalarType::Float, |_| ScalarValue::Float(0.0))
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            let total_ranks = new_ranks_sum
-                .union(&missing_ranks)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            // Apply damping factor: (1 - d) / N + d * sum_rank
-            let base_score = (1.0 - damping_factor) / (num_nodes as f64);
-
-            ranks = total_ranks
-                .extend("new_rank_final", ScalarType::Float, move |t| {
-                    let sum_r = t.get_typed::<f64>("sum_rank").unwrap();
-                    ScalarValue::Float(base_score + damping_factor * sum_r)
-                })
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
-                .project(&[self.node_id_attr.as_str(), "new_rank_final"])
-                .rename(&[("new_rank_final", "rank")]);
-        }
-
-        Ok(ranks)
+        Ok(result)
     }
 }
 


### PR DESCRIPTION
🚮 Smell: `Graph::bfs` and `Graph::pagerank` were "God Functions" exceeding 110 lines each, containing deeply nested loops and inline relational algebra logic that was hard to follow.
✨ Solution: Extracted the initialization and loop body logic into private helper functions (`initialize_bfs_visited`, `compute_next_frontier`, `initialize_pagerank_ranks`, `compute_out_degrees`, `compute_pagerank_iteration`).
🧼 Benefit: Significantly reduces cognitive load. The main `bfs` and `pagerank` functions are now concise and clearly show the high-level iterative algorithm, hiding the dense relational algebra details.
🛡️ Verification: Tests passed. No logic changed. `cargo clippy` run with no warnings.

---
*PR created automatically by Jules for task [17579872476563507218](https://jules.google.com/task/17579872476563507218) started by @madmax983*