### PR TITLE
🪒 Razor: refactor error handling

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,8 @@
 **Bloat:** Single-variant enum `ScalarValueError` with a single variant `NotUserDefined` acting as a unit error.
 **Cut:** Converted to unit struct `pub struct ScalarValueError;` for consistency and to reduce boilerplate and nested code matching.
 **Saved:** Unnecessary enum matching for single error condition, simpler `return Err(ScalarValueError);` rather than `return Err(ScalarValueError::NotUserDefined);`
+
+## [Reduction]
+**Bloat:** Single-variant enum `ScalarTypeError` with a single variant `TypeMismatch` acting as a unit error struct but containing fields, in `relvar-core/src/types/scalar.rs`.
+**Cut:** Converted to struct `pub struct ScalarTypeError;` with fields for expected and actual types for consistency and to reduce boilerplate and nested code matching, aligning with the KISS principle.
+**Saved:** Unnecessary enum matching for a single error condition.

--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -48,21 +48,19 @@ use thiserror::Error;
 /// // Attempting to use a String representation for an Int-backed type will fail
 /// let result = relvar_core::values::ScalarValue::select(&emp_id_type, ScalarValue::String("Not an Int".into()));
 ///
-/// assert!(matches!(result, Err(ScalarTypeError::TypeMismatch { .. })));
+/// assert!(matches!(result, Err(ScalarTypeError { .. })));
 /// ```
 #[derive(Debug, Error)]
-pub enum ScalarTypeError {
-    /// A value's type doesn't match the expected type.
-    ///
-    /// This typically occurs when using a selector with a value of the
-    /// wrong representation type.
-    #[error("Type mismatch: expected {expected}, got {actual}")]
-    TypeMismatch {
-        /// The expected type name.
-        expected: String,
-        /// The actual type name of the provided value.
-        actual: String,
-    },
+/// A value's type doesn't match the expected type.
+///
+/// This typically occurs when using a selector with a value of the
+/// wrong representation type.
+#[error("Type mismatch: expected {expected}, got {actual}")]
+pub struct ScalarTypeError {
+    /// The expected type name.
+    pub expected: String,
+    /// The actual type name of the provided value.
+    pub actual: String,
 }
 
 /// Represents a scalar (atomic) type in the relational model.

--- a/relvar-core/src/values/scalar.rs
+++ b/relvar-core/src/values/scalar.rs
@@ -131,7 +131,7 @@ impl ScalarValue {
         match type_def {
             crate::types::ScalarType::UserDefined { representation, .. } => {
                 if !value.is_type(representation) {
-                    return Err(crate::types::scalar::ScalarTypeError::TypeMismatch {
+                    return Err(crate::types::scalar::ScalarTypeError {
                         expected: representation.name().to_string(),
                         actual: value.scalar_type().name().to_string(),
                     });
@@ -143,7 +143,7 @@ impl ScalarValue {
             }
             ty => {
                 if !value.is_type(ty) {
-                    return Err(crate::types::scalar::ScalarTypeError::TypeMismatch {
+                    return Err(crate::types::scalar::ScalarTypeError {
                         expected: ty.name().to_string(),
                         actual: value.scalar_type().name().to_string(),
                     });


### PR DESCRIPTION
Converts `ScalarTypeError` from a single-variant enum to a struct to simplify error handling, aligning with the KISS and Razor principles.

---
*PR created automatically by Jules for task [1811577158448430549](https://jules.google.com/task/1811577158448430549) started by @madmax983*