### PR TITLE
🔒 Warden: Bounds checks and checked arithmetic

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -16,3 +16,7 @@
 ## 2026-04-12 - CSV Injection Prevention
 **Threat:** The CSV exporter (`relvar/src/tools/exporter.rs`) blindly exported strings without validation. An attacker could craft a tuple with a `ScalarValue::String` starting with `=`, `+`, `-`, `@`, `\t`, `\r`, or `\n` (e.g. `=cmd|' /C calc'!A0`). When the resulting CSV is opened in spreadsheet software like Excel, the software may interpret this as a formula or DDE execution command, leading to Arbitrary Code Execution on the client's machine (Formula Injection / CSV Injection).
 **Defense:** Inside `format_scalar_csv`, updated `ScalarValue::String` serialization to detect if the first character matches any of the formula execution trigger characters. If a match is found, a single quote (`'`) is safely prepended to the string before standard CSV quoting. This forces spreadsheet engines to interpret the payload safely as a literal string instead of an executable formula.
+
+## 2024-05-18 - [Add bounds checks]
+**Threat:** Buffer overflows via int arithmetic
+**Defense:** Replace arithmetic operations with checked variants

--- a/relvar-storage/src/wal/lsn.rs
+++ b/relvar-storage/src/wal/lsn.rs
@@ -77,7 +77,7 @@ impl Lsn {
     /// assert_eq!(lsn.next(), Lsn::new(43));
     /// ```ignore
     pub fn next(self) -> Self {
-        Self(self.0 + 1)
+        Self(self.0.checked_add(1).expect("LSN overflow"))
     }
 
     /// Extracts the raw numerical value of this `Lsn`.
@@ -172,6 +172,9 @@ impl TransactionIdGenerator {
     /// ```ignore
     pub fn generate(&self) -> TransactionId {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        if id == u64::MAX {
+            panic!("TransactionId overflow");
+        }
         TransactionId(id)
     }
 }

--- a/relvar-storage/src/wal/manager.rs
+++ b/relvar-storage/src/wal/manager.rs
@@ -144,7 +144,7 @@ impl WalManager {
             .checked_add(serialized.len())
             .and_then(|sum| sum.checked_add(16));
 
-        if required_len.map_or(true, |len| len > self.buffer_capacity) {
+        if required_len.is_none_or(|len| len > self.buffer_capacity) {
             self.flush()?;
         }
 

--- a/relvar-storage/src/wal/manager.rs
+++ b/relvar-storage/src/wal/manager.rs
@@ -138,7 +138,13 @@ impl WalManager {
 
         // Auto-flush if buffer would overflow
         // Each record writes: 8 bytes (LSN) + 8 bytes (length) + data
-        if self.buffer.len() + serialized.len() + 16 > self.buffer_capacity {
+        let required_len = self
+            .buffer
+            .len()
+            .checked_add(serialized.len())
+            .and_then(|sum| sum.checked_add(16));
+
+        if required_len.map_or(true, |len| len > self.buffer_capacity) {
             self.flush()?;
         }
 


### PR DESCRIPTION
**🦠 Threat:** Buffer overflows via integer arithmetic logic holes. In `relvar-storage/src/wal/lsn.rs` the LSN sequence could overflow to zero, and in `relvar-storage/src/wal/manager.rs` raw integer additions during buffer length evaluation could theoretically roll over, creating potential DoS or memory corruption vectors.
**🛡️ Defense:** Replaced bare `+ 1` arithmetic with `.checked_add(1).expect("LSN overflow")` for LSNs and explicit panics for `TransactionId` if hitting `u64::MAX` to enforce monotonicity invariants while failing safely. Chained `.checked_add()` validation before memory allocation logic in `manager.rs` to guarantee proper bounds capacity.
**💥 Severity:** Medium. Could result in index out-of-bounds corruption if hit on 32-bit platforms or if seq generator logic hits maximum capacity.
**🧪 Verification:** Ran `cargo clippy`, all tests execute perfectly across local codebase testing targets without regressions or panic errors.

---
*PR created automatically by Jules for task [16333151294814327075](https://jules.google.com/task/16333151294814327075) started by @madmax983*