### PR TITLE
⚡ Bolt: [performance improvement] add extend_into to avoid tuple cloning

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2025-04-13 - [Performance optimizations for relational operators]
 **Learning:** Checking cardinality (`self.cardinality()` vs `other.cardinality()`) allows iteration over the smaller `HashSet` when performing set-based `intersect` and `union` operations. Also, performing short-circuit optimization by checking `is_empty()` skips `.clone()` and allocation overheads completely when applying set `difference` and `intersect`.
 **Action:** Always check relation size or employ fast-paths via `is_empty()` when doing set operations (especially O(N*M) or O(N) ops mapping to hash set operations) before allocating `HashSet`s or creating iterators.
+
+## 2024-05-24 - [Optimization] Added extend_into for in-place relation extension
+**Learning:** `Relation::extend` clones tuples unnecessarily when we could consume the original relation to extend it in place, avoiding redundant tuple allocation overhead.
+**Action:** Implemented `extend_into` alongside `extend` to take ownership of tuples. This is part of the `_into` family optimization.

--- a/relvar-core/src/algebra/extend.rs
+++ b/relvar-core/src/algebra/extend.rs
@@ -125,6 +125,47 @@ impl Relation {
         // - create_extended_tuple ensures the computed value type matches
         Ok(Relation::from_body_unchecked(new_rel_type, extended_tuples))
     }
+
+    /// Computes the extension of this relation, consuming it.
+    ///
+    /// This is an optimized version of `extend` that avoids O(N) tuple clones for the
+    /// relation by consuming it.
+    pub fn extend_into<F>(
+        self,
+        attr_name: &str,
+        attr_type: crate::types::ScalarType,
+        compute: F,
+    ) -> Result<Relation, ExtendError>
+    where
+        F: Fn(&Tuple) -> ScalarValue,
+    {
+        // Check if attribute already exists
+        if self.relation_type().has_attribute(attr_name) {
+            return Err(ExtendError::AttributeExists(attr_name.to_string()));
+        }
+
+        // Create new heading with the additional attribute
+        let mut new_heading = self.relation_type().tuple_type().clone();
+        new_heading = new_heading.with_attribute(attr_name.to_string(), attr_type.clone());
+
+        let new_rel_type = crate::types::RelationType::new(new_heading.clone());
+        let new_heading_arc = std::sync::Arc::new(new_heading);
+
+        let mut extended_tuples = std::collections::HashSet::with_capacity(self.cardinality());
+
+        // Take ownership of the tuples from self
+        for tuple in self.into_iter() {
+            extended_tuples.insert(create_extended_tuple_owned(
+                tuple,
+                attr_name,
+                &attr_type,
+                &new_heading_arc,
+                &compute,
+            )?);
+        }
+
+        Ok(Relation::from_body_unchecked(new_rel_type, extended_tuples))
+    }
 }
 
 /// Helper function to create a single extended tuple.
@@ -158,6 +199,34 @@ where
     // Safety: We verified the new value's type above, and existing values
     // are known to be valid because they come from a valid Tuple.
     // Using new_unchecked avoids O(N) validation per tuple where N is degree.
+    Ok(Tuple::new_unchecked(new_heading.clone(), new_values))
+}
+
+/// Helper function to create a single extended tuple by taking ownership of the source tuple.
+fn create_extended_tuple_owned<F>(
+    tuple: Tuple,
+    attr_name: &str,
+    attr_type: &crate::types::ScalarType,
+    new_heading: &std::sync::Arc<crate::types::TupleType>,
+    compute: &F,
+) -> Result<Tuple, ExtendError>
+where
+    F: Fn(&Tuple) -> ScalarValue,
+{
+    let computed_value = compute(&tuple);
+
+    if !computed_value.is_type(attr_type) {
+        return Err(ExtendError::TupleCreation(format!(
+            "Type mismatch for attribute '{}': expected {}, got {}",
+            attr_name,
+            attr_type.name(),
+            computed_value.scalar_type().name()
+        )));
+    }
+
+    let mut new_values = tuple.into_values();
+    new_values.insert(attr_name.to_string(), computed_value);
+
     Ok(Tuple::new_unchecked(new_heading.clone(), new_values))
 }
 
@@ -311,5 +380,49 @@ mod tests {
             }
             _ => panic!("Expected TupleCreation error"),
         }
+    }
+
+    #[test]
+    fn test_extend_into_adds_computed_attribute() {
+        let heading = TupleType::new()
+            .with_attribute("price".to_string(), ScalarType::Int)
+            .with_attribute("quantity".to_string(), ScalarType::Int);
+
+        let rel_type = RelationType::new(heading);
+        let mut relation = Relation::new(rel_type);
+
+        relation
+            .insert(tuple! { price: 10i64, quantity: 5i64 })
+            .unwrap();
+        relation
+            .insert(tuple! { price: 20i64, quantity: 3i64 })
+            .unwrap();
+
+        let result = relation
+            .extend_into("total", ScalarType::Int, |t| {
+                let price = t.get_typed::<i64>("price").unwrap();
+                let quantity = t.get_typed::<i64>("quantity").unwrap();
+                crate::values::ScalarValue::Int(price * quantity)
+            })
+            .unwrap();
+
+        assert_eq!(result.degree(), 3);
+        assert_eq!(result.cardinality(), 2);
+
+        let mut found_50 = false;
+        let mut found_60 = false;
+
+        for tuple in result.tuples() {
+            if let Some(crate::values::ScalarValue::Int(total)) = tuple.get("total") {
+                if *total == 50 {
+                    found_50 = true;
+                }
+                if *total == 60 {
+                    found_60 = true;
+                }
+            }
+        }
+
+        assert!(found_50 && found_60);
     }
 }

--- a/relvar-core/src/values/tuple.rs
+++ b/relvar-core/src/values/tuple.rs
@@ -194,6 +194,8 @@ impl Tuple {
         M: IntoIterator<Item = (String, ScalarValue)>,
     {
         let tuple_type: Arc<TupleType> = tuple_type.into();
+        // pre-allocate if the iterator provides a size hint
+        // However BTreeMap does not support with_capacity in std yet. So just create a new one.
         let mut values_map = BTreeMap::new();
 
         // Validate values during collection to avoid double iteration and allocations on invalid data


### PR DESCRIPTION
💡 What: Added `extend_into` to `Relation`, avoiding an O(N) clone overhead on the entire inner tuple values map. Added `create_extended_tuple_owned` to support this.
🎯 Why: `Relation::extend` maps over each tuple by calling `tuple.values().clone()` to modify and return a new tuple. When executing sequential algebra where the intermediate `Relation` is fully owned, consuming it saves a full map clone.
📊 Impact: Reduces O(N) BTreeMap clone overhead and allocations across `extend` operations when intermediate relations can be mutated/consumed in place.
🔬 Measurement: Run `cargo test` and observe `test_extend_into_adds_computed_attribute` passes.

---
*PR created automatically by Jules for task [11007459907115585675](https://jules.google.com/task/11007459907115585675) started by @madmax983*