### PR TITLE
⚒️ Forge: Refactor pivot God Function

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -571,3 +571,7 @@ Build it right, make it fast, keep it simple.
 **Learning:** Enigma machine's `encrypt` function was over 120 lines long because of large inline closures and duplicated mapping logic.
 **Action:** Refactored by extracting the forward/backward rotor passes and the static mapping into private associated functions. The main `encrypt` function is now much cleaner and easier to read.
 ## 2026-04-14 - Refactored God Functions in Graph algorithms\n**Learning:** The `bfs` and `pagerank` functions in `relvar/src/experimental/graph.rs` were extremely large and deeply nested, making the relational algebra logic hard to follow.\n**Action:** Extracted the core loop bodies and initialization steps into private helper functions. This flattens the main functions into readable iterations and clarifies the boundaries of the relational operations.
+
+## 2026-04-15 - Refactor pivot God Function
+**Learning:** The pivot function mixed validation, schema construction, and data grouping in one massive block.
+**Action:** Applied the Three-Phase Operator pattern to extract these distinct steps into helper functions.

--- a/relvar/src/experimental/pivot.rs
+++ b/relvar/src/experimental/pivot.rs
@@ -91,6 +91,35 @@ pub fn pivot(
 ) -> Result<Relation, DatabaseError> {
     let heading = relation.relation_type().heading();
 
+    let (group_attrs, new_columns) =
+        scan_columns_and_validate(relation, heading, on_attr, value_attr)?;
+
+    let value_type = heading.get_attribute_type(value_attr).unwrap();
+    let new_rel_type = construct_pivot_heading(
+        heading,
+        &group_attrs,
+        &new_columns,
+        value_type,
+        &default_value,
+    )?;
+
+    group_and_build_tuples(
+        relation,
+        on_attr,
+        value_attr,
+        &group_attrs,
+        &new_columns,
+        &default_value,
+        &new_rel_type,
+    )
+}
+
+fn scan_columns_and_validate(
+    relation: &Relation,
+    heading: &TupleType,
+    on_attr: &str,
+    value_attr: &str,
+) -> Result<(Vec<String>, BTreeSet<String>), DatabaseError> {
     if !heading.has_attribute(on_attr) {
         return Err(DatabaseError::AttributeNotFound(
             on_attr.to_string(),
@@ -128,14 +157,22 @@ pub fn pivot(
         }
     }
 
-    // Construct new heading
+    Ok((group_attrs, new_columns))
+}
+
+fn construct_pivot_heading(
+    heading: &TupleType,
+    group_attrs: &[String],
+    new_columns: &BTreeSet<String>,
+    value_type: &relvar_core::types::ScalarType,
+    default_value: &ScalarValue,
+) -> Result<RelationType, DatabaseError> {
     let mut new_heading = TupleType::new();
-    for attr in &group_attrs {
+    for attr in group_attrs {
         let ty = heading.get_attribute_type(attr).unwrap();
         new_heading = new_heading.with_attribute(attr, ty.clone());
     }
 
-    let value_type = heading.get_attribute_type(value_attr).unwrap();
     if !default_value.is_type(value_type) {
         return Err(DatabaseError::AlgebraError(format!(
             "Default value type ({:?}) mismatch with value attribute ({:?})",
@@ -144,11 +181,22 @@ pub fn pivot(
         )));
     }
 
-    for col in &new_columns {
+    for col in new_columns {
         new_heading = new_heading.with_attribute(col, value_type.clone());
     }
 
-    let new_rel_type = RelationType::new(new_heading);
+    Ok(RelationType::new(new_heading))
+}
+
+fn group_and_build_tuples(
+    relation: &Relation,
+    on_attr: &str,
+    value_attr: &str,
+    group_attrs: &[String],
+    new_columns: &BTreeSet<String>,
+    default_value: &ScalarValue,
+    new_rel_type: &RelationType,
+) -> Result<Relation, DatabaseError> {
     let mut result_relation = Relation::new(new_rel_type.clone());
 
     // Group data
@@ -160,7 +208,7 @@ pub fn pivot(
 
     for tuple in sorted_tuples {
         let mut group_key = Vec::with_capacity(group_attrs.len());
-        for attr in &group_attrs {
+        for attr in group_attrs {
             group_key.push(tuple.get(attr).unwrap().clone());
         }
 
@@ -180,8 +228,8 @@ pub fn pivot(
         for (i, attr) in group_attrs.iter().enumerate() {
             tuple_values.insert(attr.clone(), group_key[i].clone());
         }
-        for col in &new_columns {
-            let val = cell_map.get(col).unwrap_or(&default_value).clone();
+        for col in new_columns {
+            let val = cell_map.get(col).unwrap_or(default_value).clone();
             tuple_values.insert(col.clone(), val);
         }
         let tuple = Tuple::new(new_rel_type.heading().clone(), tuple_values)


### PR DESCRIPTION
**🚮 Smell:** The `pivot` function was a God Function mixing validation, schema construction, and grouping data in one massive block.
**✨ Solution:** Applied the Three-Phase Operator pattern to extract these distinct steps into well-named helper functions (`scan_columns_and_validate`, `construct_pivot_heading`, and `group_and_build_tuples`).
**🧼 Benefit:** Drastically improves code clarity by abstracting implementation details behind intention-revealing function names.
**🛡️ Verification:** Verified code successfully compiles and passes tests without regressions.

---
*PR created automatically by Jules for task [9592573487114884489](https://jules.google.com/task/9592573487114884489) started by @madmax983*