### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -1,3 +1,6 @@
 ## 2025-04-09 - The "Missing" Examples
 **Confusion:** A significant number of public functions and structs in the codebase lack executable doc-tests (`/// # Examples` blocks). This makes it difficult for users to understand how to use these APIs, particularly in experimental modules like `graph`, `ecs`, `blockchain`, `matrix`, `neural_network`, `raytracer`, `synth`, `turing`, etc.
 **Clarification:** Executable doc-tests have been systematically added to public structs and methods to ensure every module tells a story and provides a copy-pasteable usage example, fulfilling Bard's philosophy that "A good example is worth 1,000 lines of explanation."
+## 2024-05-15 - [Documenting RelationalVM]
+**Confusion:** The experimental `RelationalVM` was poorly documented with a placeholder example and missing doc-tests for `new`, `step`, and `run` methods. It was unclear how it uses relational algebra to model VM state transitions.
+**Clarification:** Added executable `/// # Examples` doc-tests for the struct and its methods, explicitly documenting how they initialize the VM and apply relational operators (join, restrict, extend, etc.) to perform state updates.

--- a/relvar/src/experimental/vm.rs
+++ b/relvar/src/experimental/vm.rs
@@ -19,12 +19,42 @@ use relvar_core::{
 };
 
 /// A Relational Virtual Machine.
+///
+/// This demonstrates representing computation via relational algebra operations,
+/// turning a CPU's state transitions into relational joins and extends.
+///
 /// # Examples
 ///
 /// ```
-/// use relvar::{Relation, RelationType, ScalarType, TupleType};
+/// use relvar_core::{tuple, Relation, RelationType, ScalarType, TupleType};
 /// use relvar::experimental::vm::RelationalVM;
-/// // Note: This is a placeholder example
+///
+/// // Set up a minimal VM environment:
+/// let reg_type = RelationType::new(TupleType::new()
+///     .with_attribute("reg_id", ScalarType::String)
+///     .with_attribute("value", ScalarType::Int));
+/// let mut registers = Relation::new(reg_type);
+/// registers.insert(tuple! { reg_id: "R1", value: 5i64 }).unwrap();
+///
+/// let mem_type = RelationType::new(TupleType::new()
+///     .with_attribute("address", ScalarType::Int)
+///     .with_attribute("value", ScalarType::Int));
+/// let memory = Relation::new(mem_type);
+///
+/// let prog_type = RelationType::new(TupleType::new()
+///     .with_attribute("pc", ScalarType::Int)
+///     .with_attribute("opcode", ScalarType::String)
+///     .with_attribute("arg1", ScalarType::String)
+///     .with_attribute("arg2", ScalarType::String)
+///     .with_attribute("arg3", ScalarType::String));
+/// let program = Relation::new(prog_type);
+///
+/// let head_type = RelationType::new(TupleType::new()
+///     .with_attribute("pc", ScalarType::Int));
+/// let mut head = Relation::new(head_type);
+/// head.insert(tuple! { pc: 0i64 }).unwrap();
+///
+/// let vm = RelationalVM::new(registers, memory, program, head);
 /// ```
 pub struct RelationalVM {
     /// The registers of the VM. Schema: (reg_id: String, value: Int)
@@ -39,6 +69,39 @@ pub struct RelationalVM {
 
 impl RelationalVM {
     /// Creates a new Relational VM.
+    ///
+    /// This exists to initialize the state relations that hold the VM's current configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::{tuple, Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::experimental::vm::RelationalVM;
+    ///
+    /// let reg_type = RelationType::new(TupleType::new()
+    ///     .with_attribute("reg_id", ScalarType::String)
+    ///     .with_attribute("value", ScalarType::Int));
+    /// let registers = Relation::new(reg_type);
+    ///
+    /// let mem_type = RelationType::new(TupleType::new()
+    ///     .with_attribute("address", ScalarType::Int)
+    ///     .with_attribute("value", ScalarType::Int));
+    /// let memory = Relation::new(mem_type);
+    ///
+    /// let prog_type = RelationType::new(TupleType::new()
+    ///     .with_attribute("pc", ScalarType::Int)
+    ///     .with_attribute("opcode", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String)
+    ///     .with_attribute("arg3", ScalarType::String));
+    /// let program = Relation::new(prog_type);
+    ///
+    /// let head_type = RelationType::new(TupleType::new()
+    ///     .with_attribute("pc", ScalarType::Int));
+    /// let head = Relation::new(head_type);
+    ///
+    /// let vm = RelationalVM::new(registers, memory, program, head);
+    /// ```
     pub fn new(registers: Relation, memory: Relation, program: Relation, head: Relation) -> Self {
         Self {
             registers,
@@ -49,7 +112,51 @@ impl RelationalVM {
     }
 
     /// Computes the next step of the VM.
+    ///
     /// Evaluates the machine step and yields `true` if it progressed, or `false` if it halted (no matching instruction).
+    /// This exists to demonstrate applying relational algebra (joins, restricts, and extends)
+    /// to update state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::{tuple, Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::experimental::vm::RelationalVM;
+    ///
+    /// let reg_type = RelationType::new(TupleType::new()
+    ///     .with_attribute("reg_id", ScalarType::String)
+    ///     .with_attribute("value", ScalarType::Int));
+    /// let mut registers = Relation::new(reg_type);
+    /// registers.insert(tuple! { reg_id: "R1", value: 10i64 }).unwrap();
+    /// registers.insert(tuple! { reg_id: "R2", value: 20i64 }).unwrap();
+    /// registers.insert(tuple! { reg_id: "R3", value: 0i64 }).unwrap();
+    ///
+    /// let mem_type = RelationType::new(TupleType::new()
+    ///     .with_attribute("address", ScalarType::Int)
+    ///     .with_attribute("value", ScalarType::Int));
+    /// let memory = Relation::new(mem_type);
+    ///
+    /// let prog_type = RelationType::new(TupleType::new()
+    ///     .with_attribute("pc", ScalarType::Int)
+    ///     .with_attribute("opcode", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String)
+    ///     .with_attribute("arg3", ScalarType::String));
+    /// let mut program = Relation::new(prog_type);
+    /// // ADD instruction: R3 = R1 + R2
+    /// program.insert(tuple! { pc: 0i64, opcode: "ADD", arg1: "R3", arg2: "R1", arg3: "R2" }).unwrap();
+    ///
+    /// let head_type = RelationType::new(TupleType::new()
+    ///     .with_attribute("pc", ScalarType::Int));
+    /// let mut head = Relation::new(head_type);
+    /// head.insert(tuple! { pc: 0i64 }).unwrap();
+    ///
+    /// let mut vm = RelationalVM::new(registers, memory, program, head);
+    ///
+    /// // Take one step
+    /// let advanced = vm.step().unwrap();
+    /// assert!(advanced);
+    /// ```
     pub fn step(&mut self) -> Result<bool, DatabaseError> {
         // Fetch current instruction
         let current_inst = self.head.join(&self.program)?;
@@ -125,6 +232,50 @@ impl RelationalVM {
     }
 
     /// Runs the machine until it halts (returns the number of steps taken).
+    ///
+    /// This exists to continuously evaluate the relational state machine until an end condition
+    /// is met (i.e. `step` returns `false` due to an unhandled or missing program instruction).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::{tuple, Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::experimental::vm::RelationalVM;
+    ///
+    /// let reg_type = RelationType::new(TupleType::new()
+    ///     .with_attribute("reg_id", ScalarType::String)
+    ///     .with_attribute("value", ScalarType::Int));
+    /// let mut registers = Relation::new(reg_type);
+    /// registers.insert(tuple! { reg_id: "R1", value: 5i64 }).unwrap();
+    /// registers.insert(tuple! { reg_id: "R2", value: 7i64 }).unwrap();
+    /// registers.insert(tuple! { reg_id: "R3", value: 0i64 }).unwrap();
+    ///
+    /// let mem_type = RelationType::new(TupleType::new()
+    ///     .with_attribute("address", ScalarType::Int)
+    ///     .with_attribute("value", ScalarType::Int));
+    /// let memory = Relation::new(mem_type);
+    ///
+    /// let prog_type = RelationType::new(TupleType::new()
+    ///     .with_attribute("pc", ScalarType::Int)
+    ///     .with_attribute("opcode", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String)
+    ///     .with_attribute("arg3", ScalarType::String));
+    /// let mut program = Relation::new(prog_type);
+    /// // ADD instruction: R3 = R1 + R2
+    /// program.insert(tuple! { pc: 0i64, opcode: "ADD", arg1: "R3", arg2: "R1", arg3: "R2" }).unwrap();
+    ///
+    /// let head_type = RelationType::new(TupleType::new()
+    ///     .with_attribute("pc", ScalarType::Int));
+    /// let mut head = Relation::new(head_type);
+    /// head.insert(tuple! { pc: 0i64 }).unwrap();
+    ///
+    /// let mut vm = RelationalVM::new(registers, memory, program, head);
+    ///
+    /// // Run up to 10 steps. It will halt after 1 step since pc=1 has no instruction.
+    /// let steps = vm.run(10).unwrap();
+    /// assert_eq!(steps, 1);
+    /// ```
     pub fn run(&mut self, max_steps: usize) -> Result<usize, DatabaseError> {
         for step in 0..max_steps {
             if !self.step()? {


### PR DESCRIPTION
📖 **Chapter:** The `experimental::vm::RelationalVM` module.
🔦 **Insight:** Added context to explain *why* the VM methods exist—demonstrating that a system's state transitions can be entirely modeled and executed via relational algebra (joins, extends, restricts).
🧪 **Example:** Replaced the placeholder example on the struct and added 3 new executable `/// # Examples` doc-tests for `new`, `step`, and `run` methods.
🖼️ **Preview:** Successfully verified clean output via `cargo doc --no-deps`.

---
*PR created automatically by Jules for task [11152201144594882616](https://jules.google.com/task/11152201144594882616) started by @madmax983*