### PR TITLE
🪒 Razor: [Simplify `RelationError`]

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -17,3 +17,7 @@
 **Bloat:** Single-variant enum `ScalarTypeError` with a single variant `TypeMismatch` acting as a unit error struct but containing fields, in `relvar-core/src/types/scalar.rs`.
 **Cut:** Converted to struct `pub struct ScalarTypeError;` with fields for expected and actual types for consistency and to reduce boilerplate and nested code matching, aligning with the KISS principle.
 **Saved:** Unnecessary enum matching for a single error condition.
+## [Reduction]
+**Bloat:** Single-variant enum `RelationError` in `relvar-core/src/values/relation.rs` acting as a unit struct, with an unused variant `DuplicateTuple` and only one used variant `TypeMismatch`.
+**Cut:** Converted to unit struct `pub struct RelationError;` with `#[error("Tuple does not conform to relation type")]` directly. Removed the unused `DuplicateTuple` variant.
+**Saved:** Unnecessary enum matching, simplified error handling code significantly.

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -49,28 +49,11 @@ use thiserror::Error;
 /// use relvar_core::values::RelationError;
 ///
 /// // This error occurs when a tuple does not match a relation's heading.
-/// let error = RelationError::TypeMismatch;
+/// let error = RelationError;
 /// ```
 #[derive(Debug, Error)]
-pub enum RelationError {
-    /// A tuple doesn't conform to the relation's type (heading).
-    ///
-    /// This occurs when attempting to insert a tuple with a different
-    /// structure (different attribute names or types) than what the
-    /// relation expects. The tuple must have exactly the same attributes
-    /// with the same types as defined in the relation's heading.
-    #[error("Tuple does not conform to relation type")]
-    TypeMismatch,
-
-    /// A duplicate tuple was detected.
-    ///
-    /// This error is used in contexts where uniqueness is strictly enforced
-    /// and silent deduplication is not desired (e.g., bulk loading with strict validation).
-    /// Standard insert operations typically return `Ok(false)` for duplicates
-    /// rather than this error, adhering to set semantics.
-    #[error("Duplicate tuple")]
-    DuplicateTuple,
-}
+#[error("Tuple does not conform to relation type")]
+pub struct RelationError;
 
 /// A relation value consisting of a heading and a body.
 ///
@@ -255,7 +238,7 @@ impl Relation {
     ///
     /// # Errors
     ///
-    /// Returns [`RelationError::TypeMismatch`] if any tuple doesn't conform
+    /// Returns [`RelationError`] if any tuple doesn't conform
     /// to the relation type.
     ///
     /// # Examples
@@ -314,7 +297,7 @@ impl Relation {
             if Some(current_type_ptr) != last_checked_type_ptr {
                 // Slow path: full comparison
                 if current_type_ref != expected_heading {
-                    return Err(RelationError::TypeMismatch);
+                    return Err(RelationError);
                 }
                 // If match, update cache
                 last_checked_type_ptr = Some(current_type_ptr);
@@ -482,7 +465,7 @@ impl Relation {
     ///
     /// # Errors
     ///
-    /// Returns [`RelationError::TypeMismatch`] if the tuple doesn't conform
+    /// Returns [`RelationError`] if the tuple doesn't conform
     /// to the relation's type.
     ///
     /// # Examples
@@ -520,7 +503,7 @@ impl Relation {
     pub fn insert(&mut self, tuple: Tuple) -> Result<bool, RelationError> {
         // Verify tuple conforms to the relation type
         if tuple.tuple_type() != self.relation_type.heading() {
-            return Err(RelationError::TypeMismatch);
+            return Err(RelationError);
         }
 
         Ok(self.body.insert(tuple))
@@ -754,7 +737,7 @@ mod tests {
 
         let result = relation.insert(wrong_tuple);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), RelationError::TypeMismatch));
+        assert!(matches!(result.unwrap_err(), RelationError));
     }
 
     #[test]
@@ -839,7 +822,7 @@ mod tests {
         let tuples = vec![valid_tuple.clone(), invalid_tuple.clone()];
         let rel = Relation::from_tuples(rel_type.clone(), tuples);
         assert!(rel.is_err());
-        assert!(matches!(rel.unwrap_err(), RelationError::TypeMismatch));
+        assert!(matches!(rel.unwrap_err(), RelationError));
 
         // Case 3: Invalid first
         // The first tuple fails immediately.


### PR DESCRIPTION
**Bloat:** The `RelationError` enum in `relvar-core/src/values/relation.rs` had two variants (`TypeMismatch` and `DuplicateTuple`), but `DuplicateTuple` was dead code never used or returned in the codebase.
**Cut:** Converted `RelationError` to a unit struct, assigning the error string `#[error("Tuple does not conform to relation type")]` directly to the struct. Replaced all occurrences of `RelationError::TypeMismatch` with `RelationError`.
**Saved:** Unnecessary enum matching and unused `DuplicateTuple` dead code, adhering to the Razor philosophy of simplifying 1-variant enums to unit structs.

Assumptions: Since `DuplicateTuple` was unused and explicit duplicate handling isn't currently required, simplifying `RelationError` is the safe, intended optimization.

---
*PR created automatically by Jules for task [1511430064334464619](https://jules.google.com/task/1511430064334464619) started by @madmax983*