### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -4,3 +4,4 @@
 ## 2024-05-15 - [Documenting RelationalVM]
 **Confusion:** The experimental `RelationalVM` was poorly documented with a placeholder example and missing doc-tests for `new`, `step`, and `run` methods. It was unclear how it uses relational algebra to model VM state transitions.
 **Clarification:** Added executable `/// # Examples` doc-tests for the struct and its methods, explicitly documenting how they initialize the VM and apply relational operators (join, restrict, extend, etc.) to perform state updates.
+## 2026-04-16 - The "extend_into" Example\n**Confusion:** The `extend_into` method was missing an executable doc-test, making it unclear how it differed from `extend`.\n**Clarification:** Added a comprehensive executable doc-test for `extend_into` to demonstrate how it consumes the relation and takes ownership of its tuples.

--- a/relvar-core/src/algebra/extend.rs
+++ b/relvar-core/src/algebra/extend.rs
@@ -147,6 +147,26 @@ impl Relation {
     ///
     /// This is an optimized version of `extend` that avoids O(N) tuple clones for the
     /// relation by consuming it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::types::{TupleType, RelationType, ScalarType};
+    /// use relvar_core::values::{Relation, ScalarValue};
+    /// use relvar_core::tuple;
+    ///
+    /// let heading = TupleType::new().with_attribute("id", ScalarType::Int);
+    /// let rel_type = RelationType::new(heading);
+    /// let mut rel = Relation::new(rel_type);
+    /// rel.insert(tuple! { id: 1i64 }).unwrap();
+    ///
+    /// // `extend_into` consumes `rel`, taking ownership of its tuples
+    /// // instead of cloning them.
+    /// let extended = rel.extend_into("double_id", ScalarType::Int, |t| {
+    ///     ScalarValue::Int(t.get_typed::<i64>("id").unwrap() * 2)
+    /// }).unwrap();
+    /// assert_eq!(extended.cardinality(), 1);
+    /// ```
     pub fn extend_into<F>(
         self,
         attr_name: &str,


### PR DESCRIPTION
📖 Chapter: The `Extend` Module
🔦 Insight: The `extend_into` function lacked documentation on how it differs from `extend`. The new example clarifies that it takes ownership of tuples to avoid O(N) clones.
🧪 Example: Added an executable `/// # Examples` block for `extend_into`.
🖼️ Preview: Available via `cargo doc --open`.

---
*PR created automatically by Jules for task [16759735323799816493](https://jules.google.com/task/16759735323799816493) started by @madmax983*