### PR TITLE
⚒️ Forge: Refactor to_ascii_table into helper functions

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -579,3 +579,7 @@ Build it right, make it fast, keep it simple.
 ## 2024-04-16 - Refactor automl `train` God Function
 **Learning:** `relvar/src/experimental/automl.rs` contained a "God Function" `train` which combined calculating class priors and conditional probabilities in a single long function.
 **Action:** Applied the "Three-Phase Operator" pattern by extracting `calculate_class_priors` and `calculate_conditional_probabilities` into separate helper functions to improve readability without changing behavior.
+
+## 2026-05-15 - Exporter Ascii Table Extraction
+**Learning:** `relvar/src/tools/exporter.rs` contained a long function `to_ascii_table` that combined measuring column widths and formatting tuple rows, drawing borders, and processing the relational structure directly in line.
+**Action:** Extract specific formatting logic into `format_tuple_row`, `draw_table_separator`, and `draw_table_row` helpers. This simplifies `to_ascii_table` into primarily a coordinator that collects constraints, structures rows, and uses straightforward `draw_table_*` operations to output strings.

--- a/relvar/src/tools/exporter.rs
+++ b/relvar/src/tools/exporter.rs
@@ -123,10 +123,11 @@ impl<'a> Ord for SortableTuple<'a> {
 /// assert_eq!(csv, "col1,col2\n1,\"foo\"\n");
 /// ```
 pub fn to_csv(relation: &Relation, delimiter: char) -> Result<String, ExporterError> {
-    let headers: Vec<&String> = relation
+    let headers: Vec<&str> = relation
         .relation_type()
         .heading()
         .attribute_names()
+        .map(|s| s.as_str())
         .collect();
     let mut output = String::new();
 
@@ -254,10 +255,11 @@ pub fn to_json(relation: &Relation) -> Result<String, ExporterError> {
 /// // +-------+-------+
 /// ```
 pub fn to_ascii_table(relation: &Relation) -> String {
-    let headers: Vec<&String> = relation
+    let headers: Vec<&str> = relation
         .relation_type()
         .heading()
         .attribute_names()
+        .map(|s| s.as_str())
         .collect();
     if headers.is_empty() {
         return String::from("(empty relation)");
@@ -270,72 +272,66 @@ pub fn to_ascii_table(relation: &Relation) -> String {
     // Calculate column widths
     let mut widths: Vec<usize> = headers.iter().map(|h| h.len()).collect();
 
-    // Pass 1: Measure data widths and format rows
     let mut rows: Vec<Vec<String>> = Vec::with_capacity(tuples.len());
     for t in &tuples {
-        let mut row: Vec<String> = Vec::with_capacity(headers.len());
-        for (i, h) in headers.iter().enumerate() {
-            let s = if let Some(val) = t.0.get(h) {
-                format_scalar_table(val)
-            } else {
-                String::new()
-            };
-            if s.len() > widths[i] {
-                widths[i] = s.len();
-            }
-            row.push(s);
-        }
-        rows.push(row);
+        rows.push(format_tuple_row(t, &headers, &mut widths));
     }
 
     let mut output = String::new();
 
-    // Helper to draw separator line
-    let draw_sep = |out: &mut String, widths: &[usize]| {
-        out.push('+');
-        for w in widths {
-            out.push('-');
-            out.push_str(&"-".repeat(*w));
-            out.push('-');
-            out.push('+');
-        }
-        out.push('\n');
-    };
+    draw_table_separator(&mut output, &widths);
+    draw_table_row(&mut output, &headers, &widths);
+    draw_table_separator(&mut output, &widths);
 
-    // Top border
-    draw_sep(&mut output, &widths);
-
-    // Header row
-    output.push('|');
-    for (i, header) in headers.iter().enumerate() {
-        output.push(' ');
-        output.push_str(header);
-        output.push_str(&" ".repeat(widths[i] - header.len()));
-        output.push(' ');
-        output.push('|');
-    }
-    output.push('\n');
-
-    // Header separator
-    draw_sep(&mut output, &widths);
-
-    // Data rows
     for row in rows {
-        output.push('|');
-        for (i, cell) in row.iter().enumerate() {
-            output.push(' ');
-            output.push_str(cell);
-            output.push_str(&" ".repeat(widths[i] - cell.len()));
-            output.push(' ');
-            output.push('|');
-        }
-        output.push('\n');
+        draw_table_row(&mut output, &row, &widths);
     }
 
-    // Bottom border
-    draw_sep(&mut output, &widths);
+    draw_table_separator(&mut output, &widths);
 
     output
+}
+
+fn format_tuple_row(t: &SortableTuple, headers: &[&str], widths: &mut [usize]) -> Vec<String> {
+    let mut row: Vec<String> = Vec::with_capacity(headers.len());
+    for (i, h) in headers.iter().enumerate() {
+        let s = if let Some(val) = t.0.get(h) {
+            format_scalar_table(val)
+        } else {
+            String::new()
+        };
+
+        if s.len() > widths[i] {
+            widths[i] = s.len();
+        }
+
+        row.push(s);
+    }
+    row
+}
+
+fn draw_table_separator(out: &mut String, widths: &[usize]) {
+    out.push('+');
+    for w in widths {
+        out.push('-');
+        out.push_str(&"-".repeat(*w));
+        out.push('-');
+        out.push('+');
+    }
+    out.push('\n');
+}
+
+fn draw_table_row<T: AsRef<str>>(out: &mut String, row: &[T], widths: &[usize]) {
+    out.push('|');
+    for (i, cell) in row.iter().enumerate() {
+        let cell_str = cell.as_ref();
+        out.push(' ');
+        out.push_str(cell_str);
+        out.push_str(&" ".repeat(widths[i] - cell_str.len()));
+        out.push(' ');
+        out.push('|');
+    }
+    out.push('\n');
 }
 
 fn format_scalar_csv(val: &ScalarValue) -> String {


### PR DESCRIPTION
🚮 Smell: `to_ascii_table` in `relvar/src/tools/exporter.rs` was a long "God function" (approx 80 lines) combining calculation, row formatting, and table drawing inline.
✨ Solution: Extracted row formatting to `format_tuple_row` and drawing primitives to `draw_table_separator` and `draw_table_row`. Changed mapping of header names from `Vec<&String>` to `Vec<&str>` via `.map(|s| s.as_str())`. Added a `T: AsRef<str>` generic to handle `&[&str]` headers and `&[String]` values without duplication.
🧼 Benefit: Substantially flattens `to_ascii_table` into a high-level orchestration function.
🛡️ Verification: Cargo clippy has no warnings, tests pass, behavior unmodified.

---
*PR created automatically by Jules for task [12023498192458380037](https://jules.google.com/task/12023498192458380037) started by @madmax983*