### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/relvar-core/src/algebra/semijoin.rs
+++ b/relvar-core/src/algebra/semijoin.rs
@@ -250,7 +250,38 @@ impl Relation {
         })
     }
 
-    /// Alias for [`semijoin_into`](Self::semijoin_into) with Tutorial D syntax.
+    /// Alias for [`semijoin_into`](Self::semijoin_into) using the terminology from Date's Tutorial D.
+    /// This method is identical in behavior to `semijoin_into`. It filters the current relation
+    /// to retain only those tuples that have a matching tuple in the `other` relation over their
+    /// common attributes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::{tuple, Relation, RelationType, ScalarType, TupleType};
+    ///
+    /// let rel_type1 = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("id", ScalarType::Int)
+    ///         .with_attribute("name", ScalarType::String)
+    /// );
+    ///
+    /// let rel_type2 = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("id", ScalarType::Int)
+    ///         .with_attribute("role", ScalarType::String)
+    /// );
+    ///
+    /// let mut employees = Relation::new(rel_type1);
+    /// employees.insert(tuple! { id: 1i64, name: "Alice" }).unwrap();
+    /// employees.insert(tuple! { id: 2i64, name: "Bob" }).unwrap();
+    ///
+    /// let mut roles = Relation::new(rel_type2);
+    /// roles.insert(tuple! { id: 1i64, role: "Admin" }).unwrap();
+    ///
+    /// let result = employees.matching_into(&roles);
+    /// assert_eq!(result.cardinality(), 1); // Only emp 1 matches
+    /// ```
     pub fn matching_into(self, other: &Relation) -> Self {
         self.semijoin_into(other)
     }
@@ -442,7 +473,38 @@ impl Relation {
         })
     }
 
-    /// Alias for [`semidifference_into`](Self::semidifference_into) with Tutorial D syntax.
+    /// Alias for [`semidifference_into`](Self::semidifference_into) using the terminology from Date's Tutorial D.
+    /// This method is identical in behavior to `semidifference_into`. It filters the current relation
+    /// to retain only those tuples that have NO matching tuple in the `other` relation over their
+    /// common attributes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::{tuple, Relation, RelationType, ScalarType, TupleType};
+    ///
+    /// let rel_type1 = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("id", ScalarType::Int)
+    ///         .with_attribute("name", ScalarType::String)
+    /// );
+    ///
+    /// let rel_type2 = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("id", ScalarType::Int)
+    ///         .with_attribute("role", ScalarType::String)
+    /// );
+    ///
+    /// let mut employees = Relation::new(rel_type1);
+    /// employees.insert(tuple! { id: 1i64, name: "Alice" }).unwrap();
+    /// employees.insert(tuple! { id: 2i64, name: "Bob" }).unwrap();
+    ///
+    /// let mut roles = Relation::new(rel_type2);
+    /// roles.insert(tuple! { id: 1i64, role: "Admin" }).unwrap();
+    ///
+    /// let result = employees.not_matching_into(&roles);
+    /// assert_eq!(result.cardinality(), 1); // Only emp 2 has no matching role
+    /// ```
     pub fn not_matching_into(self, other: &Relation) -> Self {
         self.semidifference_into(other)
     }

--- a/relvar/src/experimental/parser.rs
+++ b/relvar/src/experimental/parser.rs
@@ -66,6 +66,45 @@ impl CykParser {
     /// and returns the complete parse table.
     ///
     /// The input relation must have the schema: `(pos: Int, char: String)`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::{tuple, Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::experimental::parser::CykParser;
+    ///
+    /// // 1. Setup a simple grammar: S -> "a"
+    /// let term_type = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("lhs", ScalarType::String)
+    ///         .with_attribute("rhs", ScalarType::String)
+    /// );
+    /// let mut terminals = Relation::new(term_type);
+    /// terminals.insert(tuple! { lhs: "S", rhs: "a" }).unwrap();
+    ///
+    /// let non_term_type = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("lhs", ScalarType::String)
+    ///         .with_attribute("rhs1", ScalarType::String)
+    ///         .with_attribute("rhs2", ScalarType::String)
+    /// );
+    /// let non_terminals = Relation::new(non_term_type);
+    ///
+    /// let parser = CykParser::new(terminals, non_terminals);
+    ///
+    /// // 2. Create input relation for string "a"
+    /// let input_type = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("pos", ScalarType::Int)
+    ///         .with_attribute("char", ScalarType::String)
+    /// );
+    /// let mut input = Relation::new(input_type);
+    /// input.insert(tuple! { pos: 0i64, char: "a" }).unwrap();
+    ///
+    /// // 3. Parse and verify
+    /// let parse_table = parser.parse(&input).unwrap();
+    /// assert_eq!(parse_table.cardinality(), 1);
+    /// ```
     pub fn parse(&self, input: &Relation) -> Result<Relation, DatabaseError> {
         // Step 1: Initialize parse table with terminal matches (length = 1)
         let init = input
@@ -134,6 +173,28 @@ impl CykParser {
     }
 
     /// Checks if a string is accepted by the grammar given its start symbol and length.
+    /// It queries the `parse_table` produced by `parse` to see if there is an entry
+    /// spanning the entire input length starting from position 0 for the given `start_symbol`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::{tuple, Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::experimental::parser::CykParser;
+    ///
+    /// // Build a parse table entry representing successful parse of "S" from pos 0 length 1
+    /// let parse_table_type = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("start", ScalarType::Int)
+    ///         .with_attribute("length", ScalarType::Int)
+    ///         .with_attribute("non_terminal", ScalarType::String)
+    /// );
+    /// let mut parse_table = Relation::new(parse_table_type);
+    /// parse_table.insert(tuple! { start: 0i64, length: 1i64, non_terminal: "S" }).unwrap();
+    ///
+    /// let accepted = CykParser::is_accepted(&parse_table, "S", 1).unwrap();
+    /// assert!(accepted);
+    /// ```
     pub fn is_accepted(
         parse_table: &Relation,
         start_symbol: &str,


### PR DESCRIPTION
📖 Chapter: Documented the `semijoin.rs` and `parser.rs` modules.
🔦 Insight: Explained the Tutorial D syntax aliases for semijoin/semidifference and clarified how to initialize input relations and use the CYK parse table.
🧪 Example: Added 4 executable doctests ensuring the methods are easily understood and copy-pasteable.
🖼️ Preview: Documentation is fully rendered and verifiable via `cargo doc`.

---
*PR created automatically by Jules for task [767348494120171520](https://jules.google.com/task/767348494120171520) started by @madmax983*