### PR TITLE
🔒 Warden: Fix DoS in JSON Serialization via Streaming

### DIFF
--- a/relvar-storage/src/storage/catalog.rs
+++ b/relvar-storage/src/storage/catalog.rs
@@ -42,7 +42,7 @@ use relvar_core::types::RelationType;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
-use std::io::{BufReader, Read, Write};
+use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -219,16 +219,18 @@ impl Catalog {
     /// assert!(path.exists());
     /// ```
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), CatalogError> {
-        let contents = serde_json::to_string_pretty(self)
-            .map_err(|e| CatalogError::Serialization(e.to_string()))?;
-
         let mut file = OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
             .open(path)?;
 
-        file.write_all(contents.as_bytes())?;
+        {
+            let mut writer = std::io::BufWriter::new(&mut file);
+            serde_json::to_writer_pretty(&mut writer, self)
+                .map_err(|e| CatalogError::Serialization(e.to_string()))?;
+        }
+
         file.sync_all()?;
 
         Ok(())
@@ -554,6 +556,7 @@ mod tests {
 
     #[test]
     fn test_catalog_load_limit() {
+        use std::io::Write;
         let temp_file = NamedTempFile::new().unwrap();
         let path = temp_file.path();
 


### PR DESCRIPTION
**🦠 Threat:**
The application was vulnerable to Denial of Service (DoS) attacks causing Out-Of-Memory (OOM) crashes via unbounded memory allocation during JSON serialization. `relvar-storage/src/storage/catalog.rs` and `relvar/src/tools/exporter.rs` were using `serde_json::to_string_pretty` and collecting entire datasets into memory (either as JSON strings or vectors of `serde_json::Value` objects) before writing them.

**🛡️ Defense:**
Replaced `to_string_pretty` in-memory allocations with streaming serialization.
- In `relvar-storage/src/storage/catalog.rs`, used `serde_json::to_writer_pretty` with a `BufWriter` directly against the open file.
- In `relvar/src/tools/exporter.rs`, introduced `to_json_writer` utilizing `serde::ser::SerializeSeq` to stream individual tuples directly to the output writer.

**💥 Severity:**
High - An attacker could crash the server by simply requesting an export of a large relation or forcing the database to save a heavily populated catalog.

**🧪 Verification:**
- Created `test_dos.sh` and temporary Rust integration tests locally to verify OOM occurrences on `to_string_pretty` vs successful completion with the streaming fix.
- Ran `cargo check`, `cargo test`, `cargo clippy`, and `cargo fmt`.
- Updated Warden journal `(.jules/warden.md)` with the findings.

---
*PR created automatically by Jules for task [16507974704740430921](https://jules.google.com/task/16507974704740430921) started by @madmax983*