### PR TITLE
🎻 Bard: [documentation update] DatabaseError

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -5,3 +5,6 @@
 **Confusion:** The experimental `RelationalVM` was poorly documented with a placeholder example and missing doc-tests for `new`, `step`, and `run` methods. It was unclear how it uses relational algebra to model VM state transitions.
 **Clarification:** Added executable `/// # Examples` doc-tests for the struct and its methods, explicitly documenting how they initialize the VM and apply relational operators (join, restrict, extend, etc.) to perform state updates.
 ## 2026-04-16 - The "extend_into" Example\n**Confusion:** The `extend_into` method was missing an executable doc-test, making it unclear how it differed from `extend`.\n**Clarification:** Added a comprehensive executable doc-test for `extend_into` to demonstrate how it consumes the relation and takes ownership of its tuples.
+## 2025-04-18 - Missing Error Examples
+**Confusion:** The core error enums, such as `DatabaseError`, lacked executable doctests, making it unclear how to match against and properly format the various errors thrown by the relational engine.
+**Clarification:** Added an executable `/// # Examples` block to `DatabaseError` to clearly demonstrate matching variants and formatting the errors to strings.

--- a/relvar-core/src/error.rs
+++ b/relvar-core/src/error.rs
@@ -6,6 +6,22 @@ use crate::values::relation::RelationError;
 use thiserror::Error;
 
 /// Errors that can occur during database operations.
+///
+/// # Examples
+///
+/// ```
+/// use relvar_core::error::DatabaseError;
+///
+/// let err = DatabaseError::RelationAlreadyExists("USERS".to_string());
+/// assert_eq!(err.to_string(), "Relation USERS already exists");
+///
+/// match err {
+///     DatabaseError::RelationAlreadyExists(name) => {
+///         assert_eq!(name, "USERS");
+///     }
+///     _ => unreachable!(),
+/// }
+/// ```
 #[derive(Debug, Error)]
 pub enum DatabaseError {
     /// A storage error occurred.


### PR DESCRIPTION
📖 Chapter: The Core Error Module (`relvar-core/src/error.rs`)
🔦 Insight: Users lacked a concrete example of how to match against and format `DatabaseError`s.
🧪 Example: Added 1 executable doctest for the `DatabaseError` enum demonstrating matching on `RelationAlreadyExists` and verifying its `Display` formatting.
🖼️ Preview: Evaluated visual rendering via `cargo doc --open`.

Also added an entry to `.jules/bard.md` to document this fix.

---
*PR created automatically by Jules for task [13341706791760040827](https://jules.google.com/task/13341706791760040827) started by @madmax983*