### PR TITLE
🪒 Razor: [remove SortableTuple wrapper]

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -21,3 +21,8 @@
 **Bloat:** Single-variant enum `RelationError` in `relvar-core/src/values/relation.rs` acting as a unit struct, with an unused variant `DuplicateTuple` and only one used variant `TypeMismatch`.
 **Cut:** Converted to unit struct `pub struct RelationError;` with `#[error("Tuple does not conform to relation type")]` directly. Removed the unused `DuplicateTuple` variant.
 **Saved:** Unnecessary enum matching, simplified error handling code significantly.
+
+## [Reduction]
+**Bloat:** `SortableTuple` wrapper struct and its trait implementations in `relvar/src/tools/exporter.rs`, used only to sort `Tuple` instances for deterministic output.
+**Cut:** Deleted `SortableTuple`. Instead of adding global traits that conflict with structural equality, simply used an inline closure `tuples.sort_by(|a, b| a.values().cmp(b.values()))` when sorting is actually needed in the exporter.
+**Saved:** Unnecessary wrapper type, boilerplate trait implementations, and avoided hazardous global trait bounds on `Tuple`.

--- a/relvar/src/tools/exporter.rs
+++ b/relvar/src/tools/exporter.rs
@@ -47,7 +47,6 @@
 //! ```
 
 use relvar_core::values::{Relation, ScalarValue, Tuple};
-use std::cmp::Ordering;
 use thiserror::Error;
 
 /// Errors that can occur during export.
@@ -66,28 +65,6 @@ pub enum ExporterError {
     /// formatting error
     #[error("Formatting error: {0}")]
     FmtError(#[from] std::fmt::Error),
-}
-
-/// A wrapper around a tuple to allow sorting.
-///
-/// Tuples in Relvar are unordered sets, but for deterministic export
-/// we need a consistent ordering.
-#[derive(Debug, PartialEq, Eq)]
-struct SortableTuple<'a>(&'a Tuple);
-
-impl<'a> PartialOrd for SortableTuple<'a> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<'a> Ord for SortableTuple<'a> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // Tuples are compared by their values.
-        // Since Tuple stores values in a BTreeMap, iterating values()
-        // yields them in key-sorted order, which is perfect for deterministic comparison.
-        self.0.values().cmp(other.0.values())
-    }
 }
 
 /// Exports the relation to a CSV string.
@@ -141,8 +118,8 @@ pub fn to_csv(relation: &Relation, delimiter: char) -> Result<String, ExporterEr
     output.push('\n');
 
     // Sort tuples
-    let mut tuples: Vec<SortableTuple> = relation.tuples().map(SortableTuple).collect();
-    tuples.sort();
+    let mut tuples: Vec<&Tuple> = relation.tuples().collect();
+    tuples.sort_by(|a, b| a.values().cmp(b.values()));
 
     // Write rows
     for tuple in tuples {
@@ -150,7 +127,7 @@ pub fn to_csv(relation: &Relation, delimiter: char) -> Result<String, ExporterEr
             if i > 0 {
                 output.push(delimiter);
             }
-            if let Some(val) = tuple.0.get(header) {
+            if let Some(val) = tuple.get(header) {
                 output.push_str(&format_scalar_csv(val));
             }
         }
@@ -202,14 +179,14 @@ pub fn to_csv(relation: &Relation, delimiter: char) -> Result<String, ExporterEr
 /// ```
 pub fn to_json(relation: &Relation) -> Result<String, ExporterError> {
     // Sort tuples first
-    let mut tuples: Vec<SortableTuple> = relation.tuples().map(SortableTuple).collect();
-    tuples.sort();
+    let mut tuples: Vec<&Tuple> = relation.tuples().collect();
+    tuples.sort_by(|a, b| a.values().cmp(b.values()));
 
     let mut json_tuples = Vec::with_capacity(tuples.len());
     for tuple in tuples {
         let mut obj = serde_json::Map::new();
         // Tuple::values() returns &BTreeMap, so iteration is already sorted by key
-        let map = tuple.0.values();
+        let map = tuple.values();
         for (key, val) in map {
             obj.insert(key.clone(), scalar_to_json(val));
         }
@@ -266,8 +243,8 @@ pub fn to_ascii_table(relation: &Relation) -> String {
     }
 
     // Sort tuples
-    let mut tuples: Vec<SortableTuple> = relation.tuples().map(SortableTuple).collect();
-    tuples.sort();
+    let mut tuples: Vec<&Tuple> = relation.tuples().collect();
+    tuples.sort_by(|a, b| a.values().cmp(b.values()));
 
     // Calculate column widths
     let mut widths: Vec<usize> = headers.iter().map(|h| h.len()).collect();
@@ -292,10 +269,10 @@ pub fn to_ascii_table(relation: &Relation) -> String {
     output
 }
 
-fn format_tuple_row(t: &SortableTuple, headers: &[&str], widths: &mut [usize]) -> Vec<String> {
+fn format_tuple_row(t: &Tuple, headers: &[&str], widths: &mut [usize]) -> Vec<String> {
     let mut row: Vec<String> = Vec::with_capacity(headers.len());
     for (i, h) in headers.iter().enumerate() {
-        let s = if let Some(val) = t.0.get(h) {
+        let s = if let Some(val) = t.get(h) {
             format_scalar_table(val)
         } else {
             String::new()


### PR DESCRIPTION
This PR implements a "Razor" simplification by removing the `SortableTuple` wrapper struct and its `PartialOrd` / `Ord` trait implementations in `relvar/src/tools/exporter.rs`. 

The `SortableTuple` was previously used as a one-off abstraction to deterministically sort tuples prior to formatting them into CSV, JSON, and ASCII Table outputs.

Instead of keeping this abstraction or creating hazardous global trait implementations on the `Tuple` structure itself (which structurally shouldn't directly implement `Ord`), the deterministic sorting behavior has been flattened directly inline. Uses of `.map(SortableTuple).collect(); tuples.sort();` were replaced directly with `tuples.sort_by(|a, b| a.values().cmp(b.values()))`.

This achieves the same outcome, fully removes the single-variant struct bloat, eliminates the unnecessary trait dependencies, and simplifies the codebase according to KISS.

---
*PR created automatically by Jules for task [5304365129859160625](https://jules.google.com/task/5304365129859160625) started by @madmax983*