### PR TITLE
⚡ Bolt: [Performance optimization] Remove intermediate Vec allocations in Join operators

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -26,3 +26,6 @@
 ## 2024-04-20 - Summarize string allocation optimization
 **Learning:** In relational algebra processing, computing summarizations grouping by attributes was slow because string `.clone()` or `.to_string()` were inside the nested inner loop, processing per group.
 **Action:** Pre-calculate `group_by_strings: Vec<String>` and `agg_names: Vec<String>` outside the inner loop to clone pre-computed strings instead of computing formatting allocations again.
+## 2026-05-20 - [Join Operators Allocation Removal]
+**Learning:** In relational algebra processing operations like `join` and `theta_join`, combining tuples and collecting them into an intermediate `Vec` before passing them to `Relation::from_tuples_unchecked` results in redundant heap allocations and iteration overhead (as `from_tuples_unchecked` itself iterates the collection and performs `.insert()` into a `HashSet`).
+**Action:** When a method processes and returns a new set of valid tuples, accumulate them directly into a pre-allocated `HashSet` (`HashSet::with_capacity()`) and use `Relation::from_body_unchecked()` to construct the final relation structure immediately, thereby bypassing the intermediate `Vec` allocation entirely.

--- a/relvar-core/src/algebra/join.rs
+++ b/relvar-core/src/algebra/join.rs
@@ -43,7 +43,7 @@
 use crate::error::DatabaseError;
 use crate::types::{RelationType, TupleType};
 use crate::values::{Relation, ScalarValue, Tuple};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
@@ -116,9 +116,9 @@ impl Relation {
         let joined_tuples =
             perform_hash_join(build_rel, probe_rel, &common_attrs, &result_heading_arc)?;
 
-        // Optimization: Pass the iterator directly to `from_tuples_unchecked`.
-        // The joined tuples are guaranteed to conform to the result relation type.
-        Ok(Relation::from_tuples_unchecked(
+        // Optimization: Construct the Relation directly from the HashSet buffer,
+        // skipping the intermediate `Vec` allocation and `.insert()` iteration sequence entirely.
+        Ok(Relation::from_body_unchecked(
             result_rel_type,
             joined_tuples,
         ))
@@ -255,9 +255,9 @@ impl Relation {
         // Perform theta join
         let joined_tuples = compute_theta_join_tuples(self, other, predicate, &result_heading_arc);
 
-        // Optimization: Pass the iterator directly to `from_tuples_unchecked`.
-        // The joined tuples are guaranteed to conform to the result relation type.
-        Relation::from_tuples_unchecked(result_rel_type, joined_tuples)
+        // Optimization: Construct the Relation directly from the HashSet buffer,
+        // skipping the intermediate `Vec` allocation and `.insert()` iteration sequence entirely.
+        Relation::from_body_unchecked(result_rel_type, joined_tuples)
     }
 }
 
@@ -311,10 +311,11 @@ fn probe_and_combine_single<'a>(
     build_map: &HashMap<&'a ScalarValue, Vec<&'a Tuple>>,
     attr: &str,
     result_heading: &Arc<TupleType>,
-) -> Result<Vec<Tuple>, DatabaseError> {
-    // Optimization: Pre-allocate capacity based on the larger relation.
-    // This avoids resizing allocations in the hot loop.
-    let mut joined_tuples = Vec::with_capacity(probe_rel.cardinality());
+) -> Result<HashSet<Tuple>, DatabaseError> {
+    // Optimization: Pre-allocate a `HashSet` instead of a `Vec` to accumulate tuples.
+    // This directly avoids the redundant intermediate heap allocation of a `Vec`
+    // which would otherwise just be iterated over and consumed to construct the final `HashSet`.
+    let mut joined_tuples = HashSet::with_capacity(probe_rel.cardinality());
 
     for probe_tuple in probe_rel.tuples() {
         let val = probe_tuple.get(attr).ok_or_else(|| {
@@ -323,7 +324,7 @@ fn probe_and_combine_single<'a>(
 
         if let Some(matching_tuples) = build_map.get(val) {
             for build_tuple in matching_tuples {
-                joined_tuples.push(combine_tuples(build_tuple, probe_tuple, result_heading)?);
+                joined_tuples.insert(combine_tuples(build_tuple, probe_tuple, result_heading)?);
             }
         }
     }
@@ -387,10 +388,11 @@ fn probe_and_combine<'t, 'a>(
     build_map: &HashMap<JoinKey<'t, 'a>, Vec<&'t Tuple>>,
     common_attrs: &'a [String],
     result_heading: &Arc<TupleType>,
-) -> Result<Vec<Tuple>, DatabaseError> {
-    // Optimization: Pre-allocate capacity based on the larger relation.
-    // This avoids resizing allocations in the hot loop.
-    let mut joined_tuples = Vec::with_capacity(probe_rel.cardinality());
+) -> Result<HashSet<Tuple>, DatabaseError> {
+    // Optimization: Pre-allocate a `HashSet` instead of a `Vec` to accumulate tuples.
+    // This directly avoids the redundant intermediate heap allocation of a `Vec`
+    // which would otherwise just be iterated over and consumed to construct the final `HashSet`.
+    let mut joined_tuples = HashSet::with_capacity(probe_rel.cardinality());
 
     for probe_tuple in probe_rel.tuples() {
         let key = JoinKey {
@@ -400,7 +402,7 @@ fn probe_and_combine<'t, 'a>(
 
         if let Some(matching_tuples) = build_map.get(&key) {
             for build_tuple in matching_tuples {
-                joined_tuples.push(combine_tuples(build_tuple, probe_tuple, result_heading)?);
+                joined_tuples.insert(combine_tuples(build_tuple, probe_tuple, result_heading)?);
             }
         }
     }
@@ -426,7 +428,7 @@ fn perform_hash_join(
     probe_rel: &Relation,
     common_attrs: &[String],
     result_heading: &Arc<TupleType>,
-) -> Result<Vec<Tuple>, DatabaseError> {
+) -> Result<HashSet<Tuple>, DatabaseError> {
     if common_attrs.len() == 1 {
         // Optimization for single-attribute joins
         let attr = &common_attrs[0];
@@ -445,14 +447,16 @@ fn compute_theta_join_tuples<F>(
     right: &Relation,
     predicate: F,
     result_heading: &Arc<TupleType>,
-) -> Vec<Tuple>
+) -> HashSet<Tuple>
 where
     F: Fn(&Tuple, &Tuple) -> bool,
 {
-    // Optimization: Use `std::cmp::max` to pre-allocate an initial capacity
-    // to reduce vector re-allocations during the cross product.
+    // Optimization: Pre-allocate an initial capacity for the HashSet directly
+    // based on `std::cmp::max` of the two relations to mitigate resizing overhead.
+    // By returning a `HashSet` rather than a `Vec`, we completely eliminate a
+    // redundant intermediate collection allocation step.
     let capacity = std::cmp::max(left.cardinality(), right.cardinality());
-    let mut joined_tuples = Vec::with_capacity(capacity);
+    let mut joined_tuples = HashSet::with_capacity(capacity);
 
     for tuple1 in left.tuples() {
         for tuple2 in right.tuples() {
@@ -461,7 +465,7 @@ where
             }
 
             if let Ok(combined_tuple) = combine_tuples(tuple1, tuple2, result_heading) {
-                joined_tuples.push(combined_tuple);
+                joined_tuples.insert(combined_tuple);
             }
         }
     }


### PR DESCRIPTION
💡 What: Changed the internal return type of join tuple processing functions (hash join and theta join) from `Vec<Tuple>` to `HashSet<Tuple>`. 
🎯 Why: `Relation::from_tuples_unchecked` allocates a `HashSet` and iterates over an input sequence. By passing a pre-allocated `Vec<Tuple>`, we were paying a double-allocation penalty. By pre-allocating the `HashSet` directly in the processing routines and using `Relation::from_body_unchecked`, we eliminate the intermediate list completely.
📊 Impact: Eliminates one large heap allocation and `O(N)` loop per join operation, preventing reallocation spikes and redundant hash insertions on query results.
🔬 Measurement: Run the standard `cargo bench` and check memory profiles for `probe_and_combine` allocations. Tested via `cargo test --all-targets --all-features`.

---
*PR created automatically by Jules for task [15752220837922083927](https://jules.google.com/task/15752220837922083927) started by @madmax983*