### PR TITLE
⚒️ Forge: Refactored Sudoku God Function

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -591,3 +591,6 @@ Build it right, make it fast, keep it simple.
 ## 2026-04-20 - Refactored next_generation God Function in Genetic Algorithm
 **Learning:** The `next_generation` function in `relvar/src/experimental/genetic_algorithm.rs` was a classic God Function (146 lines) that conflated fitness evaluation, rank-based parent selection, and deterministic crossover reproduction into one continuous block. This violated the 'Three-Phase Operator' pattern and made the relational operations difficult to follow.
 **Action:** Extracted the logic into three cleanly typed private helper functions: `evaluate_fitness`, `select_parents`, and `reproduce`. Returning intermediate relations cleanly via `Result<(Relation, i64), DatabaseError>` flattens the main method and significantly increases code readability without sacrificing logic or safety.
+## 2026-05-18 - Refactor God Function in Sudoku
+**Learning:** The Sudoku solver's main function was an overly long "God Function" that grouped multiple relational logic phases together: possibility generation, constraint filtering via joins, and finding determined values.
+**Action:** Applied the 'Three-Phase Operator' pattern, breaking out possibility calculation, invalid combinations removal, and determining valid cell outcomes into focused, descriptive helper functions.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,10 +1,11 @@
-💡 **What:** I optimized `compute_summarized_tuples` by moving string conversions/cloning (`attr.to_string()` and `agg.result_name.clone()`) out of the inner loop that iterates through relation groups. They are now pre-computed as vectors (`group_by_strings` and `agg_names`), which are reused across all groups.
+🚮 Smell
+The `SudokuSolver::solve` function was an overly long "God Function" (>100 lines) that mixed multiple distinct relational operations—calculating all possibilities, finding invalid outcomes via constraints, and determining cells—into one massive block.
 
-🎯 **Why:** To prevent redundant string allocations. By eliminating `attr.to_string()` and `agg.result_name.clone()` from the inner loop, we avoid O(number_of_groups * attributes) allocations during relational summaries, significantly cutting memory pressure and latency.
+✨ Solution
+Refactored `SudokuSolver::solve` using the "Three-Phase Operator" pattern. Extracted the logic into three cleanly named private helper functions: `compute_all_possibilities`, `compute_invalid_possibilities`, and `find_determined_cells`.
 
-📊 **Measured Improvement:**
-Based on Criterion benchmarks on `algebra` benchmark (summarize operation):
-* **summarize/100:** Improved by ~14% in execution time (from ~22.28us to ~20.35us).
-* **summarize/1000:** Showed a massive ~50% improvement (from ~186.73us to ~95.77us).
-* **Throughput:** For 1000 tuples, throughput skyrocketed from ~5.3 Melem/s to ~10.4 Melem/s.
-*(Note: Minor variance at summarize/5000 is likely cache-related, but 1k groups demonstrated optimal measurable improvements).*
+🧼 Benefit
+Significantly flattens the execution flow, reducing cognitive load and making it much easier to comprehend how the algorithm navigates relational algebra to solve the grid.
+
+🛡️ Verification
+`cargo test`, `cargo clippy`, and `cargo fmt` complete with no errors. No behavior changed.

--- a/relvar/src/experimental/sudoku.rs
+++ b/relvar/src/experimental/sudoku.rs
@@ -103,6 +103,83 @@ impl SudokuSolver {
         Ok(Self { cells, domain })
     }
 
+    fn compute_all_possibilities(&self) -> Result<Relation, DatabaseError> {
+        self.cells
+            .join(&self.domain)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
+
+    fn compute_invalid_possibilities(
+        &self,
+        all_possibilities: &Relation,
+        known: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        // Extract the used values in each row, col, and box from the known cells
+        // First, extend known with box_id by joining with cells
+        let known_with_box = known
+            .join(&self.cells)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        // To find invalid possibilities, we need to join possibilities with known cells
+        // on the constraints: same row, same col, or same box.
+
+        // 1. Invalid due to same row:
+        // rename known(col -> k_col, box_id -> k_box) to avoid collision, join on row, val
+        let mappings = vec![("col", "k_col"), ("box_id", "k_box")];
+        let known_row = known_with_box.rename(&mappings);
+        let invalid_row = all_possibilities
+            .join(&known_row)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+        let invalid_row_proj = invalid_row.project(&["row", "col", "box_id", "val"]);
+
+        // 2. Invalid due to same col:
+        // rename known(row -> k_row, box_id -> k_box) to avoid collision, join on col, val
+        let mappings = vec![("row", "k_row"), ("box_id", "k_box")];
+        let known_col = known_with_box.rename(&mappings);
+        let invalid_col = all_possibilities
+            .join(&known_col)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+        let invalid_col_proj = invalid_col.project(&["row", "col", "box_id", "val"]);
+
+        // 3. Invalid due to same box:
+        // rename known(row -> k_row, col -> k_col) to avoid collision, join on box_id, val
+        let mappings = vec![("row", "k_row"), ("col", "k_col")];
+        let known_box = known_with_box.rename(&mappings);
+        let invalid_box = all_possibilities
+            .join(&known_box)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+        let invalid_box_proj = invalid_box.project(&["row", "col", "box_id", "val"]);
+
+        // Combine all invalid possibilities
+        let all_invalid1 = invalid_row_proj
+            .union(&invalid_col_proj)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+        let all_invalid = all_invalid1
+            .union(&invalid_box_proj)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        Ok(all_invalid)
+    }
+
+    fn find_determined_cells(
+        &self,
+        unknown_possibilities: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        // Group by row, col and count possibilities
+        let counts = unknown_possibilities
+            .summarize(
+                &["row", "col", "box_id"],
+                &[Aggregation::count("num_possibilities")],
+            )
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        // Restrict to those with exactly 1 possibility
+        let determined_cells =
+            counts.restrict(|t| matches!(t.get("num_possibilities"), Some(ScalarValue::Int(1))));
+
+        Ok(determined_cells)
+    }
+
     /// Solves the puzzle given the relation of known values.
     /// The givens relation must have attributes `(row: Int, col: Int, val: Int)`.
     /// # Examples
@@ -117,54 +194,9 @@ impl SudokuSolver {
             let prev_count = known.cardinality();
 
             // Generate all possible cell-value combinations (81 * 9 = 729 tuples)
-            let all_possibilities = self
-                .cells
-                .join(&self.domain)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+            let all_possibilities = self.compute_all_possibilities()?;
 
-            // Extract the used values in each row, col, and box from the known cells
-            // First, extend known with box_id by joining with cells
-            let known_with_box = known
-                .join(&self.cells)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            // To find invalid possibilities, we need to join possibilities with known cells
-            // on the constraints: same row, same col, or same box.
-
-            // 1. Invalid due to same row:
-            // rename known(col -> k_col, box_id -> k_box) to avoid collision, join on row, val
-            let mappings = vec![("col", "k_col"), ("box_id", "k_box")];
-            let known_row = known_with_box.rename(&mappings);
-            let invalid_row = all_possibilities
-                .join(&known_row)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-            let invalid_row_proj = invalid_row.project(&["row", "col", "box_id", "val"]);
-
-            // 2. Invalid due to same col:
-            // rename known(row -> k_row, box_id -> k_box) to avoid collision, join on col, val
-            let mappings = vec![("row", "k_row"), ("box_id", "k_box")];
-            let known_col = known_with_box.rename(&mappings);
-            let invalid_col = all_possibilities
-                .join(&known_col)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-            let invalid_col_proj = invalid_col.project(&["row", "col", "box_id", "val"]);
-
-            // 3. Invalid due to same box:
-            // rename known(row -> k_row, col -> k_col) to avoid collision, join on box_id, val
-            let mappings = vec![("row", "k_row"), ("col", "k_col")];
-            let known_box = known_with_box.rename(&mappings);
-            let invalid_box = all_possibilities
-                .join(&known_box)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-            let invalid_box_proj = invalid_box.project(&["row", "col", "box_id", "val"]);
-
-            // Combine all invalid possibilities
-            let all_invalid1 = invalid_row_proj
-                .union(&invalid_col_proj)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-            let all_invalid = all_invalid1
-                .union(&invalid_box_proj)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+            let all_invalid = self.compute_invalid_possibilities(&all_possibilities, &known)?;
 
             // Remove invalid possibilities from all possibilities
             let valid_possibilities = all_possibilities
@@ -182,17 +214,7 @@ impl SudokuSolver {
                 .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
             // Now find cells that have exactly 1 valid possibility left
-            // Group by row, col and count possibilities
-            let counts = unknown_possibilities
-                .summarize(
-                    &["row", "col", "box_id"],
-                    &[Aggregation::count("num_possibilities")],
-                )
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            // Restrict to those with exactly 1 possibility
-            let determined_cells = counts
-                .restrict(|t| matches!(t.get("num_possibilities"), Some(ScalarValue::Int(1))));
+            let determined_cells = self.find_determined_cells(&unknown_possibilities)?;
 
             // If we found no new determined cells, we are done (or stuck)
             if determined_cells.cardinality() == 0 {


### PR DESCRIPTION
🚮 Smell
The `SudokuSolver::solve` function was an overly long "God Function" (>100 lines) that mixed multiple distinct relational operations—calculating all possibilities, finding invalid outcomes via constraints, and determining cells—into one massive block.

✨ Solution
Refactored `SudokuSolver::solve` using the "Three-Phase Operator" pattern. Extracted the logic into three cleanly named private helper functions: `compute_all_possibilities`, `compute_invalid_possibilities`, and `find_determined_cells`.

🧼 Benefit
Significantly flattens the execution flow, reducing cognitive load and making it much easier to comprehend how the algorithm navigates relational algebra to solve the grid.

🛡️ Verification
`cargo test`, `cargo clippy`, and `cargo fmt` complete with no errors. No behavior changed.

---
*PR created automatically by Jules for task [3395980296041885964](https://jules.google.com/task/3395980296041885964) started by @madmax983*