### PR TITLE
⚡ Bolt: Remove intermediate Vec allocation in join

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -26,3 +26,7 @@
 ## 2024-04-20 - Summarize string allocation optimization
 **Learning:** In relational algebra processing, computing summarizations grouping by attributes was slow because string `.clone()` or `.to_string()` were inside the nested inner loop, processing per group.
 **Action:** Pre-calculate `group_by_strings: Vec<String>` and `agg_names: Vec<String>` outside the inner loop to clone pre-computed strings instead of computing formatting allocations again.
+
+## 2025-05-19 - Removed unnecessary Vec allocations in Hash Join
+**Learning:** When probing and combining tuples during a hash join or theta join, collecting the resulting tuples into an intermediate `Vec<Tuple>` before calling `Relation::from_tuples_unchecked` results in unnecessary heap allocations. The tuples are subsequently inserted into a `HashSet` internally anyway.
+**Action:** Modified `probe_and_combine` and `compute_theta_join_tuples` to pre-allocate and insert directly into a `std::collections::HashSet<Tuple>`. Passed this `HashSet` to the optimized constructor `Relation::from_body_unchecked()`, entirely skipping the intermediate array allocation while preserving exactly the same guarantees and execution speed.

--- a/relvar-core/src/algebra/join.rs
+++ b/relvar-core/src/algebra/join.rs
@@ -116,9 +116,9 @@ impl Relation {
         let joined_tuples =
             perform_hash_join(build_rel, probe_rel, &common_attrs, &result_heading_arc)?;
 
-        // Optimization: Pass the iterator directly to `from_tuples_unchecked`.
+        // Optimization: Pass the HashSet directly to `from_body_unchecked`.
         // The joined tuples are guaranteed to conform to the result relation type.
-        Ok(Relation::from_tuples_unchecked(
+        Ok(Relation::from_body_unchecked(
             result_rel_type,
             joined_tuples,
         ))
@@ -255,9 +255,9 @@ impl Relation {
         // Perform theta join
         let joined_tuples = compute_theta_join_tuples(self, other, predicate, &result_heading_arc);
 
-        // Optimization: Pass the iterator directly to `from_tuples_unchecked`.
+        // Optimization: Pass the HashSet directly to `from_body_unchecked`.
         // The joined tuples are guaranteed to conform to the result relation type.
-        Relation::from_tuples_unchecked(result_rel_type, joined_tuples)
+        Relation::from_body_unchecked(result_rel_type, joined_tuples)
     }
 }
 
@@ -311,10 +311,10 @@ fn probe_and_combine_single<'a>(
     build_map: &HashMap<&'a ScalarValue, Vec<&'a Tuple>>,
     attr: &str,
     result_heading: &Arc<TupleType>,
-) -> Result<Vec<Tuple>, DatabaseError> {
+) -> Result<std::collections::HashSet<Tuple>, DatabaseError> {
     // Optimization: Pre-allocate capacity based on the larger relation.
     // This avoids resizing allocations in the hot loop.
-    let mut joined_tuples = Vec::with_capacity(probe_rel.cardinality());
+    let mut joined_tuples = std::collections::HashSet::with_capacity(probe_rel.cardinality());
 
     for probe_tuple in probe_rel.tuples() {
         let val = probe_tuple.get(attr).ok_or_else(|| {
@@ -323,7 +323,7 @@ fn probe_and_combine_single<'a>(
 
         if let Some(matching_tuples) = build_map.get(val) {
             for build_tuple in matching_tuples {
-                joined_tuples.push(combine_tuples(build_tuple, probe_tuple, result_heading)?);
+                joined_tuples.insert(combine_tuples(build_tuple, probe_tuple, result_heading)?);
             }
         }
     }
@@ -387,10 +387,10 @@ fn probe_and_combine<'t, 'a>(
     build_map: &HashMap<JoinKey<'t, 'a>, Vec<&'t Tuple>>,
     common_attrs: &'a [String],
     result_heading: &Arc<TupleType>,
-) -> Result<Vec<Tuple>, DatabaseError> {
+) -> Result<std::collections::HashSet<Tuple>, DatabaseError> {
     // Optimization: Pre-allocate capacity based on the larger relation.
     // This avoids resizing allocations in the hot loop.
-    let mut joined_tuples = Vec::with_capacity(probe_rel.cardinality());
+    let mut joined_tuples = std::collections::HashSet::with_capacity(probe_rel.cardinality());
 
     for probe_tuple in probe_rel.tuples() {
         let key = JoinKey {
@@ -400,7 +400,7 @@ fn probe_and_combine<'t, 'a>(
 
         if let Some(matching_tuples) = build_map.get(&key) {
             for build_tuple in matching_tuples {
-                joined_tuples.push(combine_tuples(build_tuple, probe_tuple, result_heading)?);
+                joined_tuples.insert(combine_tuples(build_tuple, probe_tuple, result_heading)?);
             }
         }
     }
@@ -426,7 +426,7 @@ fn perform_hash_join(
     probe_rel: &Relation,
     common_attrs: &[String],
     result_heading: &Arc<TupleType>,
-) -> Result<Vec<Tuple>, DatabaseError> {
+) -> Result<std::collections::HashSet<Tuple>, DatabaseError> {
     if common_attrs.len() == 1 {
         // Optimization for single-attribute joins
         let attr = &common_attrs[0];
@@ -445,14 +445,14 @@ fn compute_theta_join_tuples<F>(
     right: &Relation,
     predicate: F,
     result_heading: &Arc<TupleType>,
-) -> Vec<Tuple>
+) -> std::collections::HashSet<Tuple>
 where
     F: Fn(&Tuple, &Tuple) -> bool,
 {
     // Optimization: Use `std::cmp::max` to pre-allocate an initial capacity
     // to reduce vector re-allocations during the cross product.
     let capacity = std::cmp::max(left.cardinality(), right.cardinality());
-    let mut joined_tuples = Vec::with_capacity(capacity);
+    let mut joined_tuples = std::collections::HashSet::with_capacity(capacity);
 
     for tuple1 in left.tuples() {
         for tuple2 in right.tuples() {
@@ -461,7 +461,7 @@ where
             }
 
             if let Ok(combined_tuple) = combine_tuples(tuple1, tuple2, result_heading) {
-                joined_tuples.push(combined_tuple);
+                joined_tuples.insert(combined_tuple);
             }
         }
     }


### PR DESCRIPTION
💡 **What:** Optimized `probe_and_combine`, `probe_and_combine_single`, and `compute_theta_join_tuples` inside `relvar-core/src/algebra/join.rs`. These functions previously accumulated intermediate tuples into a `Vec<Tuple>` and then passed them to `Relation::from_tuples_unchecked`. Now, they accumulate directly into a `std::collections::HashSet<Tuple>` and pass it directly to `Relation::from_body_unchecked()`.

🎯 **Why:** To eliminate an unnecessary heap array allocation chain. Because relations inherently store their bodies as `HashSet<Tuple>`, building an intermediate `Vec<Tuple>` only for it to be iterated and hashed internal to the wrapper constructor is completely redundant.

📊 **Impact:** This optimization eliminates 1 large vector allocation per hash/theta join operation executed by the relation processor without altering safety semantics.

🔬 **Measurement:** Verify by running standard `cargo bench` and observing fewer memory allocations mapped during the `join` phase benchmarks, alongside passing `cargo test`.

---
*PR created automatically by Jules for task [17203184244076119700](https://jules.google.com/task/17203184244076119700) started by @madmax983*