### PR TITLE
🔒 Warden: Prevent memory exhaustion DoS in JSON exporter

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -1,0 +1,3 @@
+## 2026-04-22 - [Prevent DoS in JSON Exporter]
+**Threat:** Memory exhaustion DoS when exporting large relations to JSON due to in-memory accumulation of all tuples and single large string allocation.
+**Defense:** Changed `to_json` to accept `std::io::Write` sink and stream serialized JSON iteratively using `SerializeSeq`.

--- a/relvar/src/tools/exporter.rs
+++ b/relvar/src/tools/exporter.rs
@@ -38,8 +38,10 @@
 //! assert!(csv.contains("1,\"Alice\""));
 //!
 //! // Export to JSON
-//! let json = exporter::to_json(&relation).unwrap();
-//! assert!(json.contains("\"name\": \"Alice\""));
+//! let mut json_buf = Vec::new();
+//! exporter::to_json(&relation, &mut json_buf).unwrap();
+//! let json_str = String::from_utf8(json_buf).unwrap();
+//! assert!(json_str.contains("\"name\": \"Alice\""));
 //!
 //! // Export to ASCII Table
 //! let table = exporter::to_ascii_table(&relation);
@@ -47,6 +49,7 @@
 //! ```
 
 use relvar_core::values::{Relation, ScalarValue, Tuple};
+use serde::ser::{SerializeSeq, Serializer};
 use std::cmp::Ordering;
 use thiserror::Error;
 
@@ -178,7 +181,7 @@ pub fn to_csv(relation: &Relation, delimiter: char) -> Result<String, ExporterEr
 ///
 /// # Returns
 ///
-/// A pretty-printed JSON string.
+/// Returns `Ok(())` on success. Output is written to the provided writer.
 ///
 /// # Examples
 ///
@@ -192,7 +195,9 @@ pub fn to_csv(relation: &Relation, delimiter: char) -> Result<String, ExporterEr
 /// let mut relation = Relation::new(RelationType::new(heading));
 /// relation.insert(tuple! { id: 1i64 }).unwrap();
 ///
-/// let json = to_json(&relation).unwrap();
+/// let mut buf = Vec::new();
+/// to_json(&relation, &mut buf).unwrap();
+/// let json = String::from_utf8(buf).unwrap();
 /// // [
 /// //   {
 /// //     "id": 1
@@ -200,12 +205,14 @@ pub fn to_csv(relation: &Relation, delimiter: char) -> Result<String, ExporterEr
 /// // ]
 /// assert!(json.contains("\"id\": 1"));
 /// ```
-pub fn to_json(relation: &Relation) -> Result<String, ExporterError> {
+pub fn to_json<W: std::io::Write>(relation: &Relation, writer: W) -> Result<(), ExporterError> {
     // Sort tuples first
     let mut tuples: Vec<SortableTuple> = relation.tuples().map(SortableTuple).collect();
     tuples.sort();
 
-    let mut json_tuples = Vec::with_capacity(tuples.len());
+    let mut serializer = serde_json::Serializer::pretty(writer);
+    let mut seq = serializer.serialize_seq(Some(tuples.len()))?;
+
     for tuple in tuples {
         let mut obj = serde_json::Map::new();
         // Tuple::values() returns &BTreeMap, so iteration is already sorted by key
@@ -213,10 +220,11 @@ pub fn to_json(relation: &Relation) -> Result<String, ExporterError> {
         for (key, val) in map {
             obj.insert(key.clone(), scalar_to_json(val));
         }
-        json_tuples.push(serde_json::Value::Object(obj));
+        seq.serialize_element(&obj)?;
     }
 
-    serde_json::to_string_pretty(&json_tuples).map_err(ExporterError::JsonError)
+    seq.end()?;
+    Ok(())
 }
 
 /// Exports the relation to a formatted ASCII table.
@@ -422,8 +430,9 @@ mod tests {
     fn test_to_json() {
         let relation = create_test_relation();
 
-        let json = to_json(&relation).unwrap();
-        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let mut buf = Vec::new();
+        to_json(&relation, &mut buf).unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&buf).unwrap();
 
         assert!(val.is_array());
         let arr = val.as_array().unwrap();
@@ -492,8 +501,9 @@ mod tests {
         let tuple = Tuple::new(relation.relation_type().heading().clone(), values).unwrap();
         relation.insert(tuple).unwrap();
 
-        let json = to_json(&relation).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let mut buf = Vec::new();
+        to_json(&relation, &mut buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&buf).unwrap();
         let obj = &parsed[0];
 
         assert_eq!(obj["int_col"], 123);


### PR DESCRIPTION
🦠 Threat: Memory exhaustion DoS when exporting large relations to JSON due to in-memory accumulation of all tuples and single large string allocation.
🛡️ Defense: Changed `to_json` to accept an `std::io::Write` sink and stream serialized JSON iteratively using `serde::ser::SerializeSeq`.
💥 Severity: High - exporting large datasets could easily panic the server.
🧪 Verification: Unit tests updated to write to `Vec<u8>` buffers, and the full test suite runs successfully.

---
*PR created automatically by Jules for task [2103748055764113576](https://jules.google.com/task/2103748055764113576) started by @madmax983*