### PR TITLE
🎻 Bard: Document GraphNeuralNetwork and forward examples

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -11,3 +11,6 @@
 ## 2025-05-16 - The "PetriNet" Examples
 **Confusion:** The experimental `PetriNet` module had no executable doc-tests for the main struct or its methods (`new`, `add_place`, `add_transition`, `add_input_arc`, `add_output_arc`, `enabled_transitions`, and `fire`). This lack of examples made it confusing to understand how to initialize the Petri Net, configure places and transitions, or execute simulation steps (firing transitions).
 **Clarification:** Added executable `/// # Examples` doc-tests for `PetriNet` and all its methods, demonstrating how to construct a simple Petri Net and how transitions consume/produce tokens dynamically.
+## 2026-04-22 - The "GraphNeuralNetwork" Examples
+**Confusion:** The experimental `GraphNeuralNetwork` had no executable doc-tests for the main struct or its `forward` method. This lack of examples made it confusing to understand how to initialize the features, edges, and weights relations and how to execute the forward pass.
+**Clarification:** Added executable `/// # Examples` doc-tests for `GraphNeuralNetwork` and its `forward` method, demonstrating how to construct the necessary relations and perform a forward pass.

--- a/relvar/src/experimental/gnn.rs
+++ b/relvar/src/experimental/gnn.rs
@@ -28,17 +28,61 @@ use relvar_core::{
 };
 
 /// A Relational Graph Neural Network.
+///
+/// The `GraphNeuralNetwork` structurally organizes message passing over a graph modeled as standard relations.
+/// It operates purely via relational algebra combinations: joins, summaries, and extends.
+///
 /// # Examples
 ///
 /// ```
-/// use relvar::{Relation, RelationType, ScalarType, TupleType};
+/// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
 /// use relvar::experimental::gnn::GraphNeuralNetwork;
-/// // Note: This is a placeholder example
+///
+/// // 1. Features: Node 1 has a value of 1.0, Node 3 has a value of 2.0.
+/// let mut features = Relation::new(RelationType::new(
+///     TupleType::new()
+///         .with_attribute("node_id", ScalarType::Int)
+///         .with_attribute("in_idx", ScalarType::Int)
+///         .with_attribute("value", ScalarType::Float)
+/// ));
+/// features.insert(tuple! { node_id: 1i64, in_idx: 0i64, value: 1.0 }).unwrap();
+/// features.insert(tuple! { node_id: 3i64, in_idx: 0i64, value: 2.0 }).unwrap();
+///
+/// // 2. Edges: Both Node 1 and Node 3 point to Node 2.
+/// let mut edges = Relation::new(RelationType::new(
+///     TupleType::new()
+///         .with_attribute("src", ScalarType::Int)
+///         .with_attribute("dst", ScalarType::Int)
+/// ));
+/// edges.insert(tuple! { src: 1i64, dst: 2i64 }).unwrap();
+/// edges.insert(tuple! { src: 3i64, dst: 2i64 }).unwrap();
+///
+/// // 3. Weights: Transformation weight from in_idx 0 to out_idx 0 is 0.5.
+/// let mut weights = Relation::new(RelationType::new(
+///     TupleType::new()
+///         .with_attribute("in_idx", ScalarType::Int)
+///         .with_attribute("out_idx", ScalarType::Int)
+///         .with_attribute("weight", ScalarType::Float)
+/// ));
+/// weights.insert(tuple! { in_idx: 0i64, out_idx: 0i64, weight: 0.5 }).unwrap();
+///
+/// // Perform the forward pass.
+/// let output = GraphNeuralNetwork::forward(&features, &edges, &weights).unwrap();
+///
+/// // Node 2 receives aggregated sum (1.0 + 2.0) = 3.0.
+/// // Applied weight (3.0 * 0.5) = 1.5.
+/// assert_eq!(output.cardinality(), 1);
+/// assert!(output.contains(&tuple! { node_id: 2i64, in_idx: 0i64, value: 1.5 }));
 /// ```
 pub struct GraphNeuralNetwork;
 
 impl GraphNeuralNetwork {
     /// Computes a single forward pass of the GNN.
+    ///
+    /// This applies a relational interpretation of Message Passing:
+    /// 1. Joins the feature vectors with edge relationships.
+    /// 2. Summarizes the values across incoming edges (aggregation).
+    /// 3. Computes the linear transformation using a join with layer weights.
     ///
     /// # Arguments
     /// * `features` - Relation with schema `(node_id: Int, in_idx: Int, value: Float)`
@@ -48,6 +92,32 @@ impl GraphNeuralNetwork {
     /// # Returns
     /// * A new Relation with schema `(node_id: Int, in_idx: Int, value: Float)` representing
     ///   the computed output features.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
+    /// use relvar::experimental::gnn::GraphNeuralNetwork;
+    ///
+    /// // Minimal example for a single node passing a value along an edge.
+    /// let mut features = Relation::new(RelationType::new(TupleType::new()
+    ///     .with_attribute("node_id", ScalarType::Int).with_attribute("in_idx", ScalarType::Int).with_attribute("value", ScalarType::Float)));
+    /// features.insert(tuple! { node_id: 10i64, in_idx: 0i64, value: 5.0 }).unwrap();
+    ///
+    /// let mut edges = Relation::new(RelationType::new(TupleType::new()
+    ///     .with_attribute("src", ScalarType::Int).with_attribute("dst", ScalarType::Int)));
+    /// edges.insert(tuple! { src: 10i64, dst: 20i64 }).unwrap();
+    ///
+    /// let mut weights = Relation::new(RelationType::new(TupleType::new()
+    ///     .with_attribute("in_idx", ScalarType::Int).with_attribute("out_idx", ScalarType::Int).with_attribute("weight", ScalarType::Float)));
+    /// weights.insert(tuple! { in_idx: 0i64, out_idx: 0i64, weight: 2.0 }).unwrap();
+    ///
+    /// // Compute the forward step.
+    /// let output = GraphNeuralNetwork::forward(&features, &edges, &weights).unwrap();
+    ///
+    /// // Node 20 aggregated value 5.0 * weight 2.0 = 10.0
+    /// assert!(output.contains(&tuple! { node_id: 20i64, in_idx: 0i64, value: 10.0 }));
+    /// ```
     pub fn forward(
         features: &Relation,
         edges: &Relation,


### PR DESCRIPTION
📖 Chapter: The `GraphNeuralNetwork` module.
🔦 Insight: Explained the relational concept of Message Passing, showing how features, edges, and weights join, summarize, and extend over relations instead of matrices.
🧪 Example: Added 2 executable doctests (one for the struct, one for `forward`), plus the `.jules/bard.md` journal entry.
🖼️ Preview: Evaluated successfully with `cargo doc --open`.

---
*PR created automatically by Jules for task [15984317311923121809](https://jules.google.com/task/15984317311923121809) started by @madmax983*