### PR TITLE
⚡ Bolt: Remove allocations in cmp_relation_types

### DIFF
--- a/bolt_plan.txt
+++ b/bolt_plan.txt
@@ -1,0 +1,5 @@
+1. I will focus on optimizing `cmp_relation_types` inside `relvar-core/src/types/scalar.rs` to avoid creating two intermediate `Vec` allocations during every comparison.
+   Because `TupleType`'s attributes are stored in a `BTreeMap`, they can be iterated directly in sorted order. We can avoid `Vec` collections and `sort_by_key` altogether.
+   We can simply compare their `attributes().len()` first, and if equal, use `Iterator::zip` to compare `(name, type)` pairs sequentially.
+2. Complete pre-commit steps.
+3. Submit PR.

--- a/relvar-core/src/types/scalar.rs
+++ b/relvar-core/src/types/scalar.rs
@@ -401,25 +401,19 @@ impl ScalarType {
         b: &crate::types::RelationType,
     ) -> std::cmp::Ordering {
         use std::cmp::Ordering;
-        let a_attrs: Vec<_> = a
-            .heading()
-            .attribute_names()
-            .map(|n| (n, a.heading().get_attribute_type(n).unwrap()))
-            .collect();
-        let b_attrs: Vec<_> = b
-            .heading()
-            .attribute_names()
-            .map(|n| (n, b.heading().get_attribute_type(n).unwrap()))
-            .collect();
 
-        match a_attrs.len().cmp(&b_attrs.len()) {
+        let a_heading = a.heading();
+        let b_heading = b.heading();
+
+        match a_heading.degree().cmp(&b_heading.degree()) {
             Ordering::Equal => {
-                let mut a_sorted = a_attrs;
-                let mut b_sorted = b_attrs;
-                a_sorted.sort_by_key(|(name, _)| *name);
-                b_sorted.sort_by_key(|(name, _)| *name);
-
-                for ((a_name, a_ty), (b_name, b_ty)) in a_sorted.iter().zip(b_sorted.iter()) {
+                // Since `TupleType::attributes()` returns a BTreeMap, we can iterate
+                // over attributes directly in sorted order without allocating a Vec or sorting.
+                for ((a_name, a_ty), (b_name, b_ty)) in a_heading
+                    .attributes()
+                    .iter()
+                    .zip(b_heading.attributes().iter())
+                {
                     match a_name.cmp(b_name) {
                         Ordering::Equal => match a_ty.cmp(b_ty) {
                             Ordering::Equal => continue,


### PR DESCRIPTION
💡 What: Replaced intermediate `Vec` allocation and sorting with direct iteration over `BTreeMap`s in `cmp_relation_types`.
🎯 Why: `BTreeMap` already iterates in sorted order, so collecting to a `Vec` and sorting it is redundant and incurs two heap allocations per comparison.
📊 Impact: Eliminates two `Vec` allocations per `RelationType` comparison, directly impacting performance when comparing nested relations or sorting headers.
🔬 Measurement: Run `cargo test` to verify logic remains unchanged.

---
*PR created automatically by Jules for task [3002757510798242869](https://jules.google.com/task/3002757510798242869) started by @madmax983*