### PR TITLE
⚒️ Forge: Refactor Turing Machine step and VCS diff God Functions

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -597,3 +597,11 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-24 - Extract Fire Steps in PetriNet
 **Learning:** The `fire` method in `PetriNet` is an overly long 'God Function' (71 lines) that mixes multiple distinct relational operations—checking enablement, calculating deltas for consumed/produced tokens, calculating net deltas, and updating places—into one massive block.
 **Action:** Refactor `fire` using the 'Three-Phase Operator' pattern (or similar). Extract the logic into cleanly named private helper functions (e.g., `compute_deltas`, `update_places`) to flatten the execution flow and improve readability.
+
+## 2024-05-30 - Extract God Function in Turing Machine Step
+**Learning:** `relvar/src/experimental/turing.rs` contained a "God Function" `step` (74 lines) which combined reading current configuration, updating the tape, and updating the head. This violated the 'Three-Phase Operator' pattern and made the logic harder to follow.
+**Action:** Applied the 'Three-Phase Operator' pattern by extracting `get_current_configuration`, `update_tape`, and `update_head` into separate helper functions to improve clarity without changing logic.
+
+## 2024-05-30 - Extract God Function in VCS Diff
+**Learning:** The `diff` method in `relvar/src/experimental/vcs.rs` was a "God Function" (87 lines) that mixed retrieving tree relations and calculating added/removed/modified files.
+**Action:** Extracted the logic into private helper functions: `get_tree_for_commit`, `compute_added_files`, `compute_removed_files`, and `compute_modified_files`. This flattens the main method and significantly increases code readability without sacrificing logic or safety.

--- a/relvar/src/experimental/turing.rs
+++ b/relvar/src/experimental/turing.rs
@@ -70,6 +70,24 @@ impl TuringMachine {
     /// // Note: This is a placeholder example
     /// ```
     pub fn step(&mut self) -> Result<bool, DatabaseError> {
+        let current_config = self.get_current_configuration()?;
+
+        // 2. Find the transition to apply by joining with `transitions`.
+        // Result heading: (current_state, read_symbol, pos, next_state, write_symbol, move_dir)
+        let matched_transition = current_config.join(&self.transitions)?;
+
+        if matched_transition.cardinality() == 0 {
+            // No matching transition found; machine halts.
+            return Ok(false);
+        }
+
+        self.update_tape(&matched_transition)?;
+        self.update_head(&matched_transition)?;
+
+        Ok(true)
+    }
+
+    fn get_current_configuration(&self) -> Result<Relation, DatabaseError> {
         // 1. Read the symbol under the head.
         // We join `head` (state, pos) with `tape` (pos, symbol).
         // If the pos is not on the tape, it's a blank symbol.
@@ -90,19 +108,12 @@ impl TuringMachine {
 
         // At this point, `current_symbol_rel` has heading (state, pos, symbol) with exactly 1 tuple.
         // Rename `state` -> `current_state` and `symbol` -> `read_symbol` to match `transitions`.
-        let current_config = current_symbol_rel
+        Ok(current_symbol_rel
             .rename(&[("state", "current_state")])
-            .rename(&[("symbol", "read_symbol")]);
+            .rename(&[("symbol", "read_symbol")]))
+    }
 
-        // 2. Find the transition to apply by joining with `transitions`.
-        // Result heading: (current_state, read_symbol, pos, next_state, write_symbol, move_dir)
-        let matched_transition = current_config.join(&self.transitions)?;
-
-        if matched_transition.cardinality() == 0 {
-            // No matching transition found; machine halts.
-            return Ok(false);
-        }
-
+    fn update_tape(&mut self, matched_transition: &Relation) -> Result<(), DatabaseError> {
         // 3. Update the tape.
         // We need to write `write_symbol` at `pos`.
         // First, extract the new symbol to write.
@@ -125,6 +136,10 @@ impl TuringMachine {
             .union(&cell_to_write)
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
+        Ok(())
+    }
+
+    fn update_head(&mut self, matched_transition: &Relation) -> Result<(), DatabaseError> {
         // 4. Update the head position and state.
         // Head needs (state, pos).
         // The new pos = old pos + move_dir.
@@ -140,8 +155,7 @@ impl TuringMachine {
             .rename(&[("new_pos", "pos")]);
 
         self.head = new_head;
-
-        Ok(true)
+        Ok(())
     }
 
     /// Runs the machine until it halts (returns the number of steps taken).

--- a/relvar/src/experimental/vcs.rs
+++ b/relvar/src/experimental/vcs.rs
@@ -144,58 +144,80 @@ impl RelVcs {
         commit_a_hash: &str,
         commit_b_hash: &str,
     ) -> Result<Relation, DatabaseError> {
-        // 1. Get Tree A
-        let commit_a = self
-            .commits
-            .restrict(|t| t.get_typed::<String>("commit_hash").unwrap() == commit_a_hash);
-        if commit_a.cardinality() == 0 {
-            return Err(DatabaseError::AlgebraError(format!(
-                "Commit A '{}' not found",
-                commit_a_hash
-            )));
-        }
-        let tree_a = commit_a
-            .join(&self.trees)
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
-            .project(&["path", "blob_hash"]);
+        let tree_a = self.get_tree_for_commit(commit_a_hash)?;
+        let tree_b = self.get_tree_for_commit(commit_b_hash)?;
 
-        // 2. Get Tree B
-        let commit_b = self
-            .commits
-            .restrict(|t| t.get_typed::<String>("commit_hash").unwrap() == commit_b_hash);
-        if commit_b.cardinality() == 0 {
-            return Err(DatabaseError::AlgebraError(format!(
-                "Commit B '{}' not found",
-                commit_b_hash
-            )));
-        }
-        let tree_b = commit_b
-            .join(&self.trees)
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
-            .project(&["path", "blob_hash"]);
-
-        // 3. Find Added Files (In B but not in A by path)
         let paths_a = tree_a.project(&["path"]);
         let paths_b = tree_b.project(&["path"]);
-        let added_paths = paths_b
-            .difference(&paths_a)
+
+        let added = self.compute_added_files(&paths_a, &paths_b)?;
+        let removed = self.compute_removed_files(&paths_a, &paths_b)?;
+        let modified = self.compute_modified_files(&tree_a, &tree_b)?;
+
+        // 6. Union all differences
+        let diff1 = added
+            .union(&removed)
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-        let added = added_paths
+        let full_diff = diff1
+            .union(&modified)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        Ok(full_diff)
+    }
+
+    fn get_tree_for_commit(&self, commit_hash: &str) -> Result<Relation, DatabaseError> {
+        let commit = self
+            .commits
+            .restrict(|t| t.get_typed::<String>("commit_hash").unwrap() == commit_hash);
+        if commit.cardinality() == 0 {
+            return Err(DatabaseError::AlgebraError(format!(
+                "Commit '{}' not found",
+                commit_hash
+            )));
+        }
+        Ok(commit
+            .join(&self.trees)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
+            .project(&["path", "blob_hash"]))
+    }
+
+    fn compute_added_files(
+        &self,
+        paths_a: &Relation,
+        paths_b: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        // 3. Find Added Files (In B but not in A by path)
+        let added_paths = paths_b
+            .difference(paths_a)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+        added_paths
             .extend("status", ScalarType::String, |_| {
                 ScalarValue::String("added".to_string())
             })
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
 
+    fn compute_removed_files(
+        &self,
+        paths_a: &Relation,
+        paths_b: &Relation,
+    ) -> Result<Relation, DatabaseError> {
         // 4. Find Removed Files (In A but not in B by path)
         let removed_paths = paths_a
-            .difference(&paths_b)
+            .difference(paths_b)
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-        let removed = removed_paths
+        removed_paths
             .extend("status", ScalarType::String, |_| {
                 ScalarValue::String("removed".to_string())
             })
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
 
+    fn compute_modified_files(
+        &self,
+        tree_a: &Relation,
+        tree_b: &Relation,
+    ) -> Result<Relation, DatabaseError> {
         // 5. Find Modified Files (In both, but blob_hash differs)
         let tree_a_renamed = tree_a.rename(&[("blob_hash", "blob_hash_a")]);
         let tree_b_renamed = tree_b.rename(&[("blob_hash", "blob_hash_b")]);
@@ -210,21 +232,11 @@ impl RelVcs {
         });
 
         let modified_paths = modified_files.project(&["path"]);
-        let modified = modified_paths
+        modified_paths
             .extend("status", ScalarType::String, |_| {
                 ScalarValue::String("modified".to_string())
             })
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-        // 6. Union all differences
-        let diff1 = added
-            .union(&removed)
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-        let full_diff = diff1
-            .union(&modified)
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-        Ok(full_diff)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
     }
 }
 


### PR DESCRIPTION
🚮 Smell:
- `step` in `TuringMachine` was a 74-line "God Function" combining reading configuration, updating tape, and updating head.
- `diff` in `RelVcs` was an 87-line "God Function" combining retrieving tree relations and calculating added/removed/modified files.

✨ Solution:
- Applied the "Three-Phase Operator" pattern.
- Extracted `get_current_configuration`, `update_tape`, and `update_head` in `TuringMachine::step`.
- Extracted `get_tree_for_commit`, `compute_added_files`, `compute_removed_files`, and `compute_modified_files` in `RelVcs::diff`.

🧼 Benefit:
- Significantly improves readability and separation of concerns without sacrificing logic or safety. Flattens deep nesting and limits the scope of variables.

🛡️ Verification:
- Tests passed. No logic changed. `cargo clippy`, `cargo fmt`, and `cargo test` executed successfully.

---
*PR created automatically by Jules for task [14507137785328671112](https://jules.google.com/task/14507137785328671112) started by @madmax983*