### PR TITLE
🔒 Warden: Prevent float overflow in SUM/AVG aggregation

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -1,3 +1,7 @@
 ## 2026-04-22 - [Prevent DoS in JSON Exporter]
 **Threat:** Memory exhaustion DoS when exporting large relations to JSON due to in-memory accumulation of all tuples and single large string allocation.
 **Defense:** Changed `to_json` to accept `std::io::Write` sink and stream serialized JSON iteratively using `SerializeSeq`.
+
+## 2026-04-23 - [Float Overflow in Aggregation]
+**Threat:** Floating point overflow during SUM/AVG operations yielding Infinity, potentially leading to logic bugs.
+**Defense:** Added a check to ensure the aggregated sum remains finite, returning an error on overflow.

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -308,7 +308,7 @@ impl Aggregation {
         tuples: &[&Tuple],
     ) -> Result<ScalarValue, SummarizeError> {
         if self.result_type == ScalarType::Float {
-            let mut sum = 0.0;
+            let mut sum = 0.0_f64;
             for tuple in tuples {
                 let value = tuple.get_typed::<f64>(attr_name).ok_or_else(|| {
                     SummarizeError::AggregationError(format!(
@@ -317,6 +317,11 @@ impl Aggregation {
                     ))
                 })?;
                 sum += value;
+            }
+            if !sum.is_finite() {
+                return Err(SummarizeError::AggregationError(
+                    "Float overflow in SUM".to_string(),
+                ));
             }
             Ok(ScalarValue::Float(sum))
         } else {
@@ -387,7 +392,7 @@ impl Aggregation {
         attr_name: &str,
         tuples: &[&Tuple],
     ) -> Result<ScalarValue, SummarizeError> {
-        let mut sum = 0.0;
+        let mut sum = 0.0_f64;
         for tuple in tuples {
             let value = tuple.get_typed::<f64>(attr_name).ok_or_else(|| {
                 SummarizeError::AggregationError(format!(
@@ -396,6 +401,11 @@ impl Aggregation {
                 ))
             })?;
             sum += value;
+        }
+        if !sum.is_finite() {
+            return Err(SummarizeError::AggregationError(
+                "Float overflow in AVG".to_string(),
+            ));
         }
         let avg = sum / tuples.len() as f64;
         Ok(ScalarValue::Float(avg))

--- a/relvar-core/tests/warden_sum_float_overflow.rs
+++ b/relvar-core/tests/warden_sum_float_overflow.rs
@@ -1,0 +1,52 @@
+use relvar_core::algebra::Aggregation;
+use relvar_core::tuple;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
+use relvar_core::values::Relation;
+
+#[test]
+fn test_sum_float_overflow() {
+    let heading = TupleType::new()
+        .with_attribute("id", ScalarType::Int)
+        .with_attribute("price", ScalarType::Float);
+
+    let rel_type = RelationType::new(heading);
+    let mut relation = Relation::new(rel_type);
+
+    relation
+        .insert(tuple! { id: 1i64, price: f64::MAX })
+        .unwrap();
+    relation
+        .insert(tuple! { id: 2i64, price: f64::MAX })
+        .unwrap();
+
+    let sum_agg = Aggregation::sum_float("total_price", "price");
+    let result = relation.summarize(&[], &[sum_agg]);
+
+    assert!(result.is_err(), "Expected an error due to float overflow");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("Float overflow") || err_msg.contains("AggregationError"));
+}
+
+#[test]
+fn test_avg_float_overflow() {
+    let heading = TupleType::new()
+        .with_attribute("id", ScalarType::Int)
+        .with_attribute("price", ScalarType::Float);
+
+    let rel_type = RelationType::new(heading);
+    let mut relation = Relation::new(rel_type);
+
+    relation
+        .insert(tuple! { id: 1i64, price: f64::MAX })
+        .unwrap();
+    relation
+        .insert(tuple! { id: 2i64, price: f64::MAX })
+        .unwrap();
+
+    let avg_agg = Aggregation::avg("avg_price", "price");
+    let result = relation.summarize(&[], &[avg_agg]);
+
+    assert!(result.is_err(), "Expected an error due to float overflow");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("Float overflow") || err_msg.contains("AggregationError"));
+}


### PR DESCRIPTION
🦠 **Threat:** Floating point overflow during `SUM` and `AVG` aggregation operations yielding `Infinity` (or `-Infinity`), which can cause logic bugs or panics downstream (e.g., during JSON serialization since `serde_json` doesn't support infinity by default).

🛡️ **Defense:** Added an explicit `.is_finite()` check inside `compute_sum` and `compute_avg_float`. If an overflow occurs, it safely returns a `SummarizeError::AggregationError` rather than propagating an invalid numerical state.

💥 **Severity:** High - Can lead to silent corruption of aggregated metrics or application denial of service (panics) when interacting with external libraries.

🧪 **Verification:** Added a targeted test case (`warden_sum_float_overflow.rs`) that pushes `f64::MAX` to a relation and attempts to calculate both the sum and the average, explicitly asserting that it fails safely with an error rather than silently succeeding. All tests, including the new security suite, pass. Checked via `cargo test`, `cargo clippy`, and `cargo audit`.

---
*PR created automatically by Jules for task [13720279645970779475](https://jules.google.com/task/13720279645970779475) started by @madmax983*