### PR TITLE
🎻 Bard: Document Graph Neural Network module

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -14,3 +14,6 @@
 ## 2026-04-22 - The "GraphNeuralNetwork" Examples
 **Confusion:** The experimental `GraphNeuralNetwork` had no executable doc-tests for the main struct or its `forward` method. This lack of examples made it confusing to understand how to initialize the features, edges, and weights relations and how to execute the forward pass.
 **Clarification:** Added executable `/// # Examples` doc-tests for `GraphNeuralNetwork` and its `forward` method, demonstrating how to construct the necessary relations and perform a forward pass.
+## 2025-04-23 - Documenting Graph Neural Network
+**Confusion:** The experimental `GraphNeuralNetwork` had a placeholder example and missing doc-tests for the main struct and its methods, making it confusing to understand how to initialize the features, edges, and execute the message aggregation pass.
+**Clarification:** Added executable `/// # Examples` doc-tests for `RelationalGNN` and its methods, demonstrating how to construct the necessary relations and perform a forward pass.

--- a/relvar/src/experimental/graph_neural_network.rs
+++ b/relvar/src/experimental/graph_neural_network.rs
@@ -29,7 +29,23 @@ use relvar_core::{algebra::Aggregation, error::DatabaseError, values::Relation};
 /// use relvar_core::types::{RelationType, ScalarType, TupleType};
 /// use relvar_core::values::Relation;
 /// use relvar::experimental::graph_neural_network::RelationalGNN;
-/// // Note: This is a placeholder example
+///
+/// let features_type = RelationType::new(
+///     TupleType::new()
+///         .with_attribute("node_id", ScalarType::Int)
+///         .with_attribute("feature_idx", ScalarType::Int)
+///         .with_attribute("value", ScalarType::Float),
+/// );
+/// let edges_type = RelationType::new(
+///     TupleType::new()
+///         .with_attribute("source_id", ScalarType::Int)
+///         .with_attribute("target_id", ScalarType::Int),
+/// );
+///
+/// let features = Relation::new(features_type);
+/// let edges = Relation::new(edges_type);
+///
+/// let gnn = RelationalGNN::new(features, edges);
 /// ```
 pub struct RelationalGNN {
     /// Schema: (node_id: Int, feature_idx: Int, value: Float)
@@ -40,6 +56,31 @@ pub struct RelationalGNN {
 
 impl RelationalGNN {
     /// Creates a new Relational GNN representation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::types::{RelationType, ScalarType, TupleType};
+    /// use relvar_core::values::Relation;
+    /// use relvar::experimental::graph_neural_network::RelationalGNN;
+    ///
+    /// let features_type = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("node_id", ScalarType::Int)
+    ///         .with_attribute("feature_idx", ScalarType::Int)
+    ///         .with_attribute("value", ScalarType::Float),
+    /// );
+    /// let edges_type = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("source_id", ScalarType::Int)
+    ///         .with_attribute("target_id", ScalarType::Int),
+    /// );
+    ///
+    /// let features = Relation::new(features_type);
+    /// let edges = Relation::new(edges_type);
+    ///
+    /// let gnn = RelationalGNN::new(features, edges);
+    /// ```
     pub fn new(node_features: Relation, edges: Relation) -> Self {
         Self {
             node_features,
@@ -51,6 +92,41 @@ impl RelationalGNN {
     ///
     /// Returns a new relation of updated node features.
     /// Schema: (node_id: Int, feature_idx: Int, value: Float)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::tuple;
+    /// use relvar_core::types::{RelationType, ScalarType, TupleType};
+    /// use relvar_core::values::Relation;
+    /// use relvar::experimental::graph_neural_network::RelationalGNN;
+    ///
+    /// let features_type = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("node_id", ScalarType::Int)
+    ///         .with_attribute("feature_idx", ScalarType::Int)
+    ///         .with_attribute("value", ScalarType::Float),
+    /// );
+    /// let edges_type = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("source_id", ScalarType::Int)
+    ///         .with_attribute("target_id", ScalarType::Int),
+    /// );
+    ///
+    /// let mut features = Relation::new(features_type);
+    /// let mut edges = Relation::new(edges_type);
+    ///
+    /// // Node 1 has a value of 5.0
+    /// features.insert(tuple! { node_id: 1i64, feature_idx: 0i64, value: 5.0f64 }).unwrap();
+    /// // Edge from Node 1 to Node 2
+    /// edges.insert(tuple! { source_id: 1i64, target_id: 2i64 }).unwrap();
+    ///
+    /// let gnn = RelationalGNN::new(features, edges);
+    /// let aggregated = gnn.aggregate_messages().unwrap();
+    ///
+    /// assert_eq!(aggregated.tuples().count(), 1);
+    /// // Node 2 receives the value 5.0 from Node 1
+    /// ```
     pub fn aggregate_messages(&self) -> Result<Relation, DatabaseError> {
         // 1. Rename node_features to match edges source_id
         let features_renamed = self.node_features.rename(&[("node_id", "source_id")]);


### PR DESCRIPTION
📖 Chapter: The `GraphNeuralNetwork` module.
🔦 Insight: The experimental `GraphNeuralNetwork` had a placeholder example and missing doc-tests for the main struct and its methods, making it confusing to understand how to initialize the features, edges, and execute the message aggregation pass. Executable `/// # Examples` doc-tests were added to clarify this process.
🧪 Example: Added 3 executable doctests for `RelationalGNN`, `RelationalGNN::new`, and `RelationalGNN::aggregate_messages`.
🖼️ Preview: Documentation renders successfully.

---
*PR created automatically by Jules for task [711614259478477530](https://jules.google.com/task/711614259478477530) started by @madmax983*