### PR TITLE
⚒️ Forge: Extract God Function in visualizer

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -605,3 +605,7 @@ Build it right, make it fast, keep it simple.
 ## 2024-05-30 - Extract God Function in VCS Diff
 **Learning:** The `diff` method in `relvar/src/experimental/vcs.rs` was a "God Function" (87 lines) that mixed retrieving tree relations and calculating added/removed/modified files.
 **Action:** Extracted the logic into private helper functions: `get_tree_for_commit`, `compute_added_files`, `compute_removed_files`, and `compute_modified_files`. This flattens the main method and significantly increases code readability without sacrificing logic or safety.
+
+## 2026-04-25 - Extract God Function in visualizer
+**Learning:** `relvar/src/tools/visualizer.rs` contained a long function `to_dot` that combined extracting relations, processing primary key constraints and sorting attributes for nodes, and formatting HTML labels, as well as checking and formatting foreign keys into dot strings all in line. This made the function overly complex.
+**Action:** Applied the "Three-Phase Operator" pattern by extracting node logic into `generate_nodes` and edge logic into `generate_edges`. The main `to_dot` is now simplified to initializing the `digraph` string and coordinating the sub-generators.

--- a/relvar/src/tools/visualizer.rs
+++ b/relvar/src/tools/visualizer.rs
@@ -104,14 +104,18 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
 
         let relvars = self.db.list_relvars();
 
-        // 1. Generate nodes (Tables)
-        for name in &relvars {
-            // Note: We use get_relvar_type() to get the relation structure.
-            // This avoids loading the full relation data.
+        self.generate_nodes(&mut dot, &relvars);
+        self.generate_edges(&mut dot, &relvars);
+
+        dot.push_str("}\n");
+        dot
+    }
+
+    fn generate_nodes(&self, dot: &mut String, relvars: &[String]) {
+        for name in relvars {
             if let Ok(relation_type) = self.db.get_relvar_type(name) {
                 let tuple_type = relation_type.tuple_type();
 
-                // Determine primary key attributes
                 let pk_attrs = if let Some(key_constraints) = self.db.get_key_constraints(name) {
                     if let Some(pk) = key_constraints.primary_key() {
                         pk.attributes().to_vec()
@@ -134,7 +138,6 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
                     table_title
                 ));
 
-                // Sort attributes for consistent output
                 let mut attributes: Vec<_> = tuple_type.attributes().iter().collect();
                 attributes.sort_by(|a, b| a.0.cmp(b.0));
 
@@ -148,8 +151,6 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
                         safe_attr_name
                     };
 
-                    // Note: scalar_type implements Debug, which might contain special chars.
-                    // Ideally we'd escape that too, strictly speaking.
                     let safe_type = escape_html(&format!("{:?}", scalar_type));
 
                     dot.push_str(&format!(
@@ -160,9 +161,10 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
                 dot.push_str("    </table>>];\n\n");
             }
         }
+    }
 
-        // 2. Generate edges (Foreign Keys)
-        for name in &relvars {
+    fn generate_edges(&self, dot: &mut String, relvars: &[String]) {
+        for name in relvars {
             if let Some(fk_constraints) = self.db.get_foreign_key_constraints(name) {
                 for fk in fk_constraints.foreign_keys() {
                     let ref_table = fk.referenced_relation_name();
@@ -179,9 +181,6 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
                 }
             }
         }
-
-        dot.push_str("}\n");
-        dot
     }
 }
 


### PR DESCRIPTION
🚮 Smell
`relvar/src/tools/visualizer.rs` contained a long "God Function" `to_dot` that inline-combined extracting relations, processing primary key constraints, sorting attributes for nodes, formatting HTML labels, and generating DOT strings for both nodes and foreign key edges.

✨ Solution
Applied the "Three-Phase Operator" pattern by extracting the node formatting block into `generate_nodes` and the edge formatting block into `generate_edges`. The main `to_dot` method is now simplified to just initializing the base graph and coordinating the helpers.

🧼 Benefit
Significantly flattens the execution flow of `to_dot`, reducing cognitive load and improving code readability without altering behavior. The logic boundaries for nodes and edges are now clearly separated.

🛡️ Verification
`cargo test`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --all` complete with zero errors. No existing behavior or functionality changed.

---
*PR created automatically by Jules for task [16411709763341249648](https://jules.google.com/task/16411709763341249648) started by @madmax983*