### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -111,3 +111,12 @@
 ## 2026-04-16 - Extend and Project Missing Branches
 **Learning:** `extend_into` error conditions (computation type mismatch) and empty iterator scenarios, as well as `project` greater-than ordering matches for lexicographical attributes were uncovered. Group, Union, Intersect `_into` functions were also untested.
 **Action:** Wrote tests targeting `extend_into` specifically mirroring existing `extend` tests, and crafted carefully named attribute headings (`"z"`, `"a"`) for `project` to trigger the required merge-sort iteration states, as well as general testing for `_into` consuming variants and error paths for summaries on empty tables.
+## 2026-03-30 - Sentry: Coverage Improvements for relational algebra
+
+**Learning:** There were many gaps in relational algebra operations in `relvar-core`, specifically around missing attributes on hash join build/probe, type mismatches in extend/summarize functions, and extremum empty logic.
+**Action:** Targeted testing for these edge cases proved very effective. Adding inline test suites within the specific algebra source files handles the specific Error paths smoothly.
+## 2024-11-20 - Testing Robustness Using Automated Scripting
+
+**Learning:** When generating coverage tests dynamically via python scripts that perform regex or naive search-and-replace, the codebase becomes incredibly prone to duplicate tests or misaligned nested scopes (especially since Rust `mod tests {` may appear multiple times or scripts may be executed iteratively without cleanup). Also, `f64::MAX + f64::MAX` triggers `!sum.is_finite()` but tests that expect `Result::Err` often fail if the enum match uses a completely incorrect struct or variant due to missing imports.
+
+**Action:** Always maintain an idempotent testing state (`git restore`) between failed scripts, inject fully qualified paths (`crate::types::Relation`) within dynamic scripts to avoid hunting for use declarations, and explicitly verify error bounds (e.g., using `i64::MAX` instead of `f64::MAX` to guarantee predictable integer overflow on constrained checks) when testing internal library logic.

--- a/relvar-core/src/algebra/extend.rs
+++ b/relvar-core/src/algebra/extend.rs
@@ -462,4 +462,50 @@ mod tests {
 
         assert!(found_50 && found_60);
     }
+
+    #[test]
+    fn test_extend_into_fails_if_attribute_exists() {
+        let heading = TupleType::new()
+            .with_attribute("emp_id".to_string(), ScalarType::Int)
+            .with_attribute("name".to_string(), ScalarType::String);
+
+        let rel_type = RelationType::new(heading);
+        let mut relation = Relation::new(rel_type);
+
+        relation
+            .insert(tuple! { emp_id: 1i64, name: "Alice" })
+            .unwrap();
+
+        let result = relation.extend_into("name", ScalarType::String, |t| {
+            t.get("name").unwrap().clone()
+        });
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ExtendError::AttributeExists(_)
+        ));
+    }
+
+    #[test]
+    fn test_extend_into_type_mismatch_fails() {
+        let heading = TupleType::new().with_attribute("emp_id".to_string(), ScalarType::Int);
+
+        let rel_type = RelationType::new(heading);
+        let mut relation = Relation::new(rel_type);
+
+        relation.insert(tuple! { emp_id: 1i64 }).unwrap();
+
+        let result = relation.extend_into("name_length", ScalarType::String, |_| {
+            crate::values::ScalarValue::Int(10)
+        });
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ExtendError::TupleCreation(msg) => {
+                assert!(msg.contains("Type mismatch"));
+            }
+            _ => panic!("Expected TupleCreation error"),
+        }
+    }
 }

--- a/relvar-core/src/algebra/intersect.rs
+++ b/relvar-core/src/algebra/intersect.rs
@@ -293,4 +293,42 @@ mod tests {
         assert!(result.contains(&bob));
         assert!(result.contains(&charlie));
     }
+
+    #[test]
+    fn test_intersect_into_type_mismatch() {
+        let h1 = TupleType::new().with_attribute("x".to_string(), ScalarType::Int);
+        let h2 = TupleType::new().with_attribute("y".to_string(), ScalarType::Int);
+
+        let r1 = Relation::new(RelationType::new(h1));
+        let r2 = Relation::new(RelationType::new(h2));
+
+        let res = r1.intersect_into(&r2);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_intersect_into_success() {
+        let h = TupleType::new().with_attribute("x".to_string(), ScalarType::Int);
+        let mut r1 = Relation::new(RelationType::new(h.clone()));
+        r1.insert(crate::tuple! { x: 1i64 }).unwrap();
+        r1.insert(crate::tuple! { x: 2i64 }).unwrap();
+
+        let mut r2 = Relation::new(RelationType::new(h));
+        r2.insert(crate::tuple! { x: 2i64 }).unwrap();
+        r2.insert(crate::tuple! { x: 3i64 }).unwrap();
+
+        let res = r1.intersect_into(&r2);
+        assert!(res.is_ok());
+        let res_rel = res.unwrap();
+        assert_eq!(res_rel.tuples().count(), 1);
+        assert_eq!(
+            res_rel
+                .tuples()
+                .next()
+                .unwrap()
+                .get_typed::<i64>("x")
+                .unwrap(),
+            2i64
+        );
+    }
 }

--- a/relvar-core/src/algebra/join.rs
+++ b/relvar-core/src/algebra/join.rs
@@ -843,4 +843,90 @@ mod tests {
         let result2 = large.join(&small).unwrap();
         assert_eq!(result2.cardinality(), 1);
     }
+
+    #[test]
+    fn test_join_build_map_missing_attr() {
+        use crate::DatabaseError;
+        let heading = TupleType::new().with_attribute("x".to_string(), ScalarType::Int);
+        let rel_type = RelationType::new(heading.clone());
+        let mut relation = Relation::new(rel_type);
+        relation.insert(crate::tuple! { x: 1i64 }).unwrap();
+
+        let result = super::build_join_map_single(&relation, "y");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DatabaseError::AttributeNotFound(attr, rel) if attr == "y" && rel == "build relation"
+        ));
+    }
+
+    #[test]
+    fn test_probe_and_combine_missing_attr() {
+        use crate::DatabaseError;
+        let heading = TupleType::new().with_attribute("x".to_string(), ScalarType::Int);
+        let rel_type = RelationType::new(heading.clone());
+        let mut relation = Relation::new(rel_type);
+        relation.insert(crate::tuple! { x: 1i64 }).unwrap();
+
+        let build_map = std::collections::HashMap::new();
+        let result = super::probe_and_combine_single(
+            &relation,
+            &build_map,
+            "y",
+            &std::sync::Arc::new(heading),
+        );
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DatabaseError::AttributeNotFound(attr, rel) if attr == "y" && rel == "probe relation"
+        ));
+    }
+
+    #[test]
+    fn test_join_key_eq_diff_values() {
+        let h = TupleType::new()
+            .with_attribute("x".to_string(), ScalarType::Int)
+            .with_attribute("y".to_string(), ScalarType::Int);
+        let rel_type = RelationType::new(h);
+
+        let mut r = Relation::new(rel_type);
+        r.insert(crate::tuple! { x: 1i64, y: 2i64 }).unwrap();
+        r.insert(crate::tuple! { x: 1i64, y: 3i64 }).unwrap();
+
+        let tuples: Vec<_> = r.tuples().collect();
+        let attrs = vec!["x".to_string(), "y".to_string()];
+
+        let key1 = super::JoinKey {
+            tuple: tuples[0],
+            attributes: &attrs,
+        };
+
+        let key2 = super::JoinKey {
+            tuple: tuples[1],
+            attributes: &attrs,
+        };
+
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn test_compute_theta_join_tuples_predicate_returns_false() {
+        let h1 = TupleType::new().with_attribute("x".to_string(), ScalarType::Int);
+        let mut r1 = Relation::new(RelationType::new(h1.clone()));
+        r1.insert(crate::tuple! { x: 1i64 }).unwrap();
+        let h2 = TupleType::new().with_attribute("y".to_string(), ScalarType::Int);
+        let mut r2 = Relation::new(RelationType::new(h2.clone()));
+        r2.insert(crate::tuple! { y: 2i64 }).unwrap();
+
+        let mut res_heading = h1.clone();
+        res_heading = res_heading.with_attribute("y".to_string(), ScalarType::Int);
+
+        let res = super::compute_theta_join_tuples(
+            &r1,
+            &r2,
+            |_, _| false,
+            &std::sync::Arc::new(res_heading),
+        );
+        assert_eq!(res.len(), 0);
+    }
 }

--- a/relvar-core/src/algebra/project.rs
+++ b/relvar-core/src/algebra/project.rs
@@ -403,4 +403,59 @@ mod tests {
         assert_eq!(result.cardinality(), 0);
         assert!(result.is_empty());
     }
+
+    #[test]
+    fn test_project_missing_attributes_ignored() {
+        let heading = TupleType::new()
+            .with_attribute("x".to_string(), ScalarType::Int)
+            .with_attribute("y".to_string(), ScalarType::Int);
+        let rel_type = RelationType::new(heading);
+        let mut relation = Relation::new(rel_type);
+        relation.insert(crate::tuple! { x: 1i64, y: 2i64 }).unwrap();
+
+        let result = relation.project(&["x", "missing_attr"]);
+        assert_eq!(result.degree(), 1);
+        let attr = result
+            .relation_type()
+            .heading()
+            .attributes()
+            .keys()
+            .next()
+            .unwrap();
+        assert_eq!(attr, "x");
+    }
+
+    #[test]
+    fn test_project_into_missing_attributes_ignored() {
+        let heading = TupleType::new()
+            .with_attribute("x".to_string(), ScalarType::Int)
+            .with_attribute("y".to_string(), ScalarType::Int);
+        let rel_type = RelationType::new(heading);
+        let mut relation = Relation::new(rel_type);
+        relation.insert(crate::tuple! { x: 1i64, y: 2i64 }).unwrap();
+
+        let result = relation.project_into(&["y", "missing_attr"]);
+        assert_eq!(result.degree(), 1);
+        let attr = result
+            .relation_type()
+            .heading()
+            .attributes()
+            .keys()
+            .next()
+            .unwrap();
+        assert_eq!(attr, "y");
+    }
+
+    #[test]
+    fn test_project_empty_relation_still_projects_heading() {
+        let heading = TupleType::new()
+            .with_attribute("x".to_string(), ScalarType::Int)
+            .with_attribute("y".to_string(), ScalarType::Int);
+        let rel_type = RelationType::new(heading);
+        let relation = Relation::new(rel_type);
+
+        let result = relation.project(&["x"]);
+        assert_eq!(result.degree(), 1);
+        assert_eq!(result.cardinality(), 0);
+    }
 }

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -1270,4 +1270,53 @@ mod overflow_tests {
         let tuple = result.tuples().next().unwrap();
         assert_eq!(tuple.get_typed::<f64>("avg_price").unwrap(), 15.0);
     }
+
+    #[test]
+    fn test_summarize_grouping_attribute_not_found() {
+        use crate::Relation;
+        use crate::algebra::{Aggregation, AggregationFn};
+        use crate::types::{RelationType, ScalarType, TupleType};
+        let relation = Relation::new(RelationType::new(
+            TupleType::new().with_attribute("qty".to_string(), ScalarType::Int),
+        ));
+
+        let result = relation.summarize(
+            &["missing_attr"],
+            &[Aggregation {
+                result_name: "total_qty".to_string(),
+                result_type: ScalarType::Int,
+                function: AggregationFn::Sum("qty".to_string()),
+            }],
+        );
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), SummarizeError::GroupingAttributeNotFound(attr) if attr == "missing_attr")
+        );
+    }
+
+    #[test]
+    fn test_summarize_min_max_empty() {
+        use crate::Relation;
+        use crate::algebra::{Aggregation, AggregationFn};
+        use crate::types::{RelationType, ScalarType, TupleType};
+        let rel_type = RelationType::new(
+            TupleType::new()
+                .with_attribute("part_id".to_string(), ScalarType::Int)
+                .with_attribute("qty".to_string(), ScalarType::Int),
+        );
+        let relation = Relation::new(rel_type);
+
+        let result = relation.summarize(
+            &["part_id"],
+            &[Aggregation {
+                result_name: "min_qty".to_string(),
+                result_type: ScalarType::Int,
+                function: AggregationFn::Min("qty".to_string()),
+            }],
+        );
+
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().tuples().count(), 0);
+    }
 }

--- a/relvar-core/src/algebra/union.rs
+++ b/relvar-core/src/algebra/union.rs
@@ -285,4 +285,30 @@ mod tests {
         assert!(result.contains(&bob));
         assert!(result.contains(&charlie));
     }
+
+    #[test]
+    fn test_union_into_type_mismatch() {
+        let h1 = TupleType::new().with_attribute("x".to_string(), ScalarType::Int);
+        let h2 = TupleType::new().with_attribute("y".to_string(), ScalarType::Int);
+
+        let r1 = Relation::new(RelationType::new(h1));
+        let r2 = Relation::new(RelationType::new(h2));
+
+        let res = r1.union_into(&r2);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_union_into_success() {
+        let h = TupleType::new().with_attribute("x".to_string(), ScalarType::Int);
+        let mut r1 = Relation::new(RelationType::new(h.clone()));
+        r1.insert(crate::tuple! { x: 1i64 }).unwrap();
+
+        let mut r2 = Relation::new(RelationType::new(h));
+        r2.insert(crate::tuple! { x: 2i64 }).unwrap();
+
+        let res = r1.union_into(&r2);
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().tuples().count(), 2);
+    }
 }


### PR DESCRIPTION
🎯 Target: `relvar-core` algebra modules (`join.rs`, `extend.rs`, `project.rs`, `union.rs`, `intersect.rs`, `summarize.rs`).
💣 Risk: Various complex inner methods in the relational algebra components lacked edge case coverage for `_into` variants, missing attributes, and type mismatches which could lead to uncaught logic errors or panics under specific constraint violations.
🧪 Strategy: Added multiple unit tests mapped inside each respective module's test block (e.g., `test_project_into_attribute_not_found`, `test_union_into_type_mismatch`). Handled edge cases correctly without altering production logic.
🔬 Verification: Run `cargo test -p relvar-core --lib -- algebra`.

---
*PR created automatically by Jules for task [3495549352492602542](https://jules.google.com/task/3495549352492602542) started by @madmax983*