### PR TITLE
⚒️ Forge: Extract God Functions in Game of Life and PageRank

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -609,3 +609,7 @@ Build it right, make it fast, keep it simple.
 ## 2026-05-19 - Extract God Function in Logic Circuit Simulator
 **Learning:** `relvar/src/experimental/circuit.rs` contained a "God Function" `tick` (79 lines) which combined evaluating binary gates, evaluating unary gates, and combining their outputs into the next state.
 **Action:** Applied the "Three-Phase Operator" pattern by extracting `evaluate_binary_gates`, `evaluate_unary_gates`, and `combine_outputs` into separate helper functions to improve readability and code organization without changing behavior.
+
+## 2024-06-25 - Extract God Function in Game of Life and PageRank
+**Learning:** `relvar-core/src/experimental/game_of_life.rs`, `relvar/src/experimental/cellular_automaton.rs`, and `relvar-core/src/experimental/pagerank.rs` contained "God Functions" (`next_generation` and `pagerank_iteration`) over 70 lines long.
+**Action:** Applied the "Three-Phase Operator" pattern by extracting their logical phases into separate helper functions (`generate_offsets`, `calculate_neighbor_counts`, `apply_rules` for Game of Life; `calculate_contributions`, `distribute_and_aggregate_ranks`, `apply_damping_factor` for PageRank) to improve readability without changing behavior.

--- a/relvar-core/src/experimental/game_of_life.rs
+++ b/relvar-core/src/experimental/game_of_life.rs
@@ -35,7 +35,12 @@ use std::collections::HashMap;
 /// assert_eq!(blinker_v.cardinality(), 3);
 /// ```
 pub fn next_generation(alive_cells: &Relation) -> Result<Relation, crate::error::DatabaseError> {
-    // 1. Offsets
+    let offsets = generate_offsets();
+    let counts_renamed = calculate_neighbor_counts(alive_cells, &offsets)?;
+    apply_rules(alive_cells, &counts_renamed)
+}
+
+fn generate_offsets() -> Relation {
     let off_heading = TupleType::new()
         .with_attribute("dx", ScalarType::Int)
         .with_attribute("dy", ScalarType::Int);
@@ -52,9 +57,15 @@ pub fn next_generation(alive_cells: &Relation) -> Result<Relation, crate::error:
             offsets.insert(tuple).unwrap();
         }
     }
+    offsets
+}
 
+fn calculate_neighbor_counts(
+    alive_cells: &Relation,
+    offsets: &Relation,
+) -> Result<Relation, crate::error::DatabaseError> {
     // 2. Cross Join to generate all neighbors
-    let cross = alive_cells.join(&offsets)?;
+    let cross = alive_cells.join(offsets)?;
 
     // 3. Extend to compute actual neighbor coordinates (nx, ny)
     let ext1 = cross
@@ -89,10 +100,15 @@ pub fn next_generation(alive_cells: &Relation) -> Result<Relation, crate::error:
         .map_err(|e| crate::error::DatabaseError::AlgebraError(e.to_string()))?;
 
     // 6. Rename back to (x, y)
-    let counts_renamed = counts.rename(&[("nx", "x"), ("ny", "y")]);
+    Ok(counts.rename(&[("nx", "x"), ("ny", "y")]))
+}
 
+fn apply_rules(
+    alive_cells: &Relation,
+    counts_renamed: &Relation,
+) -> Result<Relation, crate::error::DatabaseError> {
     // 7. Rule 1: Stays Alive (alive cells with 2 or 3 neighbors)
-    let alive_with_neighbors = alive_cells.join(&counts_renamed)?;
+    let alive_with_neighbors = alive_cells.join(counts_renamed)?;
     let stays_alive = alive_with_neighbors
         .restrict(|t: &Tuple| {
             let count = t.get_typed::<i64>("n_count").unwrap();
@@ -110,11 +126,9 @@ pub fn next_generation(alive_cells: &Relation) -> Result<Relation, crate::error:
         .map_err(|e| crate::error::DatabaseError::AlgebraError(e.to_string()))?;
 
     // 9. Union for next generation
-    let next_gen = stays_alive
+    stays_alive
         .union(&born)
-        .map_err(|e| crate::error::DatabaseError::AlgebraError(e.to_string()))?;
-
-    Ok(next_gen)
+        .map_err(|e| crate::error::DatabaseError::AlgebraError(e.to_string()))
 }
 
 #[cfg(test)]

--- a/relvar-core/src/experimental/pagerank.rs
+++ b/relvar-core/src/experimental/pagerank.rs
@@ -43,6 +43,12 @@ pub fn pagerank_iteration(
     damping_factor: f64,
     num_nodes: usize,
 ) -> Result<Relation, DatabaseError> {
+    let contributions = calculate_contributions(&edges, &ranks)?;
+    let new_ranks_summed = distribute_and_aggregate_ranks(&edges, &contributions)?;
+    apply_damping_factor(&new_ranks_summed, damping_factor, num_nodes)
+}
+
+fn calculate_contributions(edges: &Relation, ranks: &Relation) -> Result<Relation, DatabaseError> {
     // 1. Calculate outgoing edge count for each node
     // Relation with attributes: source (Int), out_degree (Int)
     let out_degrees = edges
@@ -61,7 +67,7 @@ pub fn pagerank_iteration(
     // 3. Calculate rank contribution
     // Contribution = rank / out_degree
     // Relation with attributes: node (Int), rank (Float), out_degree (Int), contribution (Float)
-    let contributions = node_info
+    node_info
         .extend("contribution", ScalarType::Float, |t| {
             let rank = t.get_typed::<f64>("rank").unwrap_or(0.0);
             let out_degree = t.get_typed::<i64>("out_degree").unwrap_or(1);
@@ -73,8 +79,13 @@ pub fn pagerank_iteration(
             };
             ScalarValue::Float(rank / out_degree_float)
         })
-        .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+        .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+}
 
+fn distribute_and_aggregate_ranks(
+    edges: &Relation,
+    contributions: &Relation,
+) -> Result<Relation, DatabaseError> {
     // 4. Join edges with contributions to distribute rank
     // edges: source, target
     // contributions: node, rank, out_degree, contribution
@@ -83,19 +94,25 @@ pub fn pagerank_iteration(
     // Join on "node"
     // Result attributes: node (source), target, rank, out_degree, contribution
     let distributed = edges_renamed
-        .join(&contributions)
+        .join(contributions)
         .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
     // 5. Aggregate received rank per target node
     // Group by target, sum contributions
     // Relation with attributes: target (Int), sum_contribution (Float)
-    let new_ranks_summed = distributed
+    distributed
         .summarize(
             &["target"],
             &[Aggregation::sum_float("sum_contribution", "contribution")],
         )
-        .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+        .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+}
 
+fn apply_damping_factor(
+    new_ranks_summed: &Relation,
+    damping_factor: f64,
+    num_nodes: usize,
+) -> Result<Relation, DatabaseError> {
     // Rename target back to node
     let new_ranks_renamed = new_ranks_summed.rename(&[("target", "node")]);
 
@@ -110,8 +127,7 @@ pub fn pagerank_iteration(
         .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
     // Project out the temporary sum_contribution to return only (node, rank)
-    let result = final_ranks.project(&["node", "rank"]);
-    Ok(result)
+    Ok(final_ranks.project(&["node", "rank"]))
 }
 
 #[cfg(test)]

--- a/relvar/src/experimental/cellular_automaton.rs
+++ b/relvar/src/experimental/cellular_automaton.rs
@@ -62,7 +62,12 @@ impl CellularAutomaton {
     /// // Note: This is a placeholder example
     /// ```
     pub fn next_generation(&self) -> Result<Relation, DatabaseError> {
-        // 1. Create neighbor offsets relation: (dx, dy)
+        let offsets = Self::generate_offsets()?;
+        let counts_xy = Self::calculate_neighbor_counts(&self.cells, &offsets)?;
+        Self::apply_rules(&self.cells, &counts_xy)
+    }
+
+    fn generate_offsets() -> Result<Relation, DatabaseError> {
         let offset_heading = TupleType::new()
             .with_attribute("dx".to_string(), ScalarType::Int)
             .with_attribute("dy".to_string(), ScalarType::Int);
@@ -78,10 +83,16 @@ impl CellularAutomaton {
                 }
             }
         }
+        Ok(offsets)
+    }
 
+    fn calculate_neighbor_counts(
+        cells: &Relation,
+        offsets: &Relation,
+    ) -> Result<Relation, DatabaseError> {
         // 2. Cartesian product of cells and offsets
         // Since they share no common attributes, a natural join acts as a cartesian product.
-        let cartesian = self.cells.join(&offsets)?;
+        let cartesian = cells.join(offsets)?;
 
         // 3. Compute neighbor coordinates: nx = x + dx, ny = y + dy
         let neighbors = cartesian
@@ -106,14 +117,16 @@ impl CellularAutomaton {
 
         // Rename back to x, y
         let rename_map = vec![("nx", "x"), ("ny", "y")];
-        let counts_xy = neighbor_counts.rename(&rename_map);
+        Ok(neighbor_counts.rename(&rename_map))
+    }
 
+    fn apply_rules(cells: &Relation, counts_xy: &Relation) -> Result<Relation, DatabaseError> {
         // 5. Apply Game of Life rules
 
         // Find surviving cells: alive cells with 2 or 3 neighbors
-        // Join with self.cells effectively acts as an intersection/filter for "is alive"
+        // Join with cells effectively acts as an intersection/filter for "is alive"
         let surviving = counts_xy
-            .join(&self.cells)?
+            .join(cells)?
             .restrict(|t| {
                 let count = t.get_typed::<i64>("n_count").unwrap();
                 count == 2 || count == 3
@@ -127,15 +140,13 @@ impl CellularAutomaton {
 
         // Dead cells are cells with exactly 3 neighbors minus the currently alive cells
         let births = exactly_three
-            .difference(&self.cells)
+            .difference(cells)
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
         // Union surviving and births
-        let next_gen = surviving
+        surviving
             .union(&births)
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-        Ok(next_gen)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
     }
 }
 


### PR DESCRIPTION
- 🚮 Smell: "God Functions" (`next_generation` and `pagerank_iteration`) in Game of Life and PageRank were over 70 lines long and mixed multiple logical phases into single blocks.
- ✨ Solution: Applied the "Three-Phase Operator" pattern to extract logic into helper functions (`generate_offsets`, `calculate_neighbor_counts`, `apply_rules` for Game of Life; `calculate_contributions`, `distribute_and_aggregate_ranks`, `apply_damping_factor` for PageRank).
- 🧼 Benefit: Drastically improved readability by flattening structure and separating logic without changing behavior.
- 🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [3580737672474644716](https://jules.google.com/task/3580737672474644716) started by @madmax983*