### PR TITLE
⚡ Bolt: [performance improvement] Remove intermediate Vec allocations in group and summarize

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,12 @@
 ## 2025-05-19 - [Divide Filter Intermediate Vec Removal]
 **Learning:** In the `divide` operator's internal helper `filter_matching_candidates`, passing the `candidates` parameter by reference (`&Relation`), filtering its tuples via iteration, and collecting them into a `Vec<Tuple>` creates an intermediate heap allocation. Later, this `Vec` is passed into `Relation::from_tuples_unchecked`. Since `candidates` is an intermediate relation constructed just before this filtering step (as a projection of the dividend onto the remainder attributes), we own it.
 **Action:** By modifying `filter_matching_candidates` to take `candidates: Relation` by value and using `candidates.restrict_into(|candidate| { ... })`, we can apply the set filtering in-place using `HashSet::retain`. This safely bypasses creating the intermediate `Vec` entirely and reduces heap allocations to zero during the filter phase.
+## 2025-05-21 - [Summarize Operator Allocation Removal]
+**Learning:** In the `summarize` operator, the intermediate results were collected into a `Vec<Tuple>` and then passed into `Relation::from_tuples_unchecked`, which then iterated through the `Vec` to populate a `HashSet`.
+**Action:** Changed the internal accumulator `compute_summarized_tuples` to directly return `HashSet<Tuple>`, pre-allocated with the correct capacity, and used `Relation::from_body_unchecked` to bypass the intermediate `Vec` allocation entirely.
+## 2025-05-21 - [Group Operator Allocation Removal]
+**Learning:** In the `group` operator, the intermediate results were collected into a `Vec<Tuple>` and then passed into `Relation::from_tuples_unchecked`, which iterated through the `Vec` to populate a `HashSet`.
+**Action:** Changed the internal accumulator `compute_grouped_tuples` to directly return `HashSet<Tuple>`, pre-allocated with the correct capacity, and used `Relation::from_body_unchecked` to bypass the intermediate `Vec` allocation entirely.
+## 2025-05-21 - [Ungroup Operator Allocation Removal]
+**Learning:** In the `ungroup` operator, the intermediate results were collected into a `Vec<Tuple>` and then passed into `Relation::from_tuples_unchecked`, which iterated through the `Vec` to populate a `HashSet`.
+**Action:** Changed the internal accumulator `compute_ungrouped_tuples` to directly return `HashSet<Tuple>`, pre-allocated with the correct capacity, and used `Relation::from_body_unchecked` to bypass the intermediate `Vec` allocation entirely.

--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -139,7 +139,7 @@ impl Relation {
 
         // Optimization: the tuples returned by `compute_grouped_tuples` are
         // guaranteed to be valid since they were constructed with `result_heading`.
-        Ok(Relation::from_tuples_unchecked(
+        Ok(Relation::from_body_unchecked(
             RelationType::new(result_heading),
             result_tuples,
         ))
@@ -181,7 +181,7 @@ impl Relation {
 
         // Optimization: the tuples returned by `compute_ungrouped_tuples` are
         // guaranteed to be valid since they were constructed with `result_heading`.
-        Ok(Relation::from_tuples_unchecked(
+        Ok(Relation::from_body_unchecked(
             RelationType::new(result_heading),
             result_tuples,
         ))
@@ -321,14 +321,14 @@ fn compute_grouped_tuples(
     result_heading: &TupleType,
     rva_heading: &TupleType,
     rva_name: &str,
-) -> Result<Vec<Tuple>, GroupError> {
+) -> Result<std::collections::HashSet<Tuple>, GroupError> {
     let rva_heading_arc = std::sync::Arc::new(rva_heading.clone());
     let result_heading_arc = std::sync::Arc::new(result_heading.clone());
 
     let groups = group_tuples(relation, grouping_attrs, attrs_to_group, rva_heading_arc);
 
     // Build result tuples
-    let mut result_tuples = Vec::with_capacity(groups.len());
+    let mut result_tuples = std::collections::HashSet::with_capacity(groups.len());
     let rva_relation_type = RelationType::new(rva_heading.clone());
     for (key, rva_tuples) in groups {
         let mut values = std::collections::BTreeMap::new();
@@ -345,7 +345,7 @@ fn compute_grouped_tuples(
         values.insert(rva_name.to_string(), ScalarValue::Relation(rva_relation));
 
         let tuple = Tuple::new_unchecked(result_heading_arc.clone(), values);
-        result_tuples.push(tuple);
+        result_tuples.insert(tuple);
     }
 
     Ok(result_tuples)
@@ -412,7 +412,7 @@ fn compute_ungrouped_tuples(
     rva_name: &str,
     result_heading: &TupleType,
     rva_relation_type: &RelationType,
-) -> Result<Vec<Tuple>, UngroupError> {
+) -> Result<std::collections::HashSet<Tuple>, UngroupError> {
     // Perform an initial pass to sum the cardinality of the target RVAs
     // to pre-allocate the exact needed capacity, avoiding dynamic heap reallocations.
     let mut total_capacity = 0;
@@ -422,7 +422,7 @@ fn compute_ungrouped_tuples(
             _ => return Err(UngroupError::NotRelationValued(rva_name.to_string())),
         }
     }
-    let mut result_tuples = Vec::with_capacity(total_capacity);
+    let mut result_tuples = std::collections::HashSet::with_capacity(total_capacity);
     let result_heading_arc = std::sync::Arc::new(result_heading.clone());
 
     for tuple in relation.tuples() {
@@ -453,7 +453,7 @@ fn compute_ungrouped_tuples(
 
             // Re-use the cloned heading_arc
             let result_tuple = Tuple::new_unchecked(heading_arc.clone(), values);
-            result_tuples.push(result_tuple);
+            result_tuples.insert(result_tuple);
         }
     }
 

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -474,7 +474,7 @@ impl Relation {
     ///
     /// # Performance
     ///
-    /// Pre-allocates the `result_tuples` vector using `Vec::with_capacity(groups.len())`.
+    /// Pre-allocates the `result_tuples` set using `HashSet::with_capacity(groups.len())`.
     /// Because the exact number of output tuples is known after grouping the input,
     /// this prevents dynamic heap reallocations when constructing the resulting relation.
     /// # Examples
@@ -516,7 +516,7 @@ impl Relation {
         // Optimization: Pass the iterator directly to `from_tuples_unchecked`
         // instead of collecting into an intermediate `Vec`. The tuples are
         // guaranteed to be valid since they were constructed with `result_heading_arc`.
-        Ok(Relation::from_tuples_unchecked(
+        Ok(Relation::from_body_unchecked(
             result_rel_type,
             result_tuples,
         ))
@@ -528,8 +528,8 @@ impl Relation {
         aggregations: &[Aggregation],
         groups: &HashMap<Vec<&ScalarValue>, Vec<&Tuple>>,
         result_heading_arc: &std::sync::Arc<TupleType>,
-    ) -> Result<Vec<Tuple>, SummarizeError> {
-        let mut result_tuples = Vec::with_capacity(groups.len());
+    ) -> Result<std::collections::HashSet<Tuple>, SummarizeError> {
+        let mut result_tuples = std::collections::HashSet::with_capacity(groups.len());
 
         for (key, group_tuples) in groups {
             let mut values = std::collections::BTreeMap::new();
@@ -548,7 +548,7 @@ impl Relation {
             // Using new_unchecked avoids O(N) validation per tuple where N is degree,
             // since we've already validated the grouping and aggregation attributes
             let tuple = Tuple::new_unchecked(result_heading_arc.clone(), values);
-            result_tuples.push(tuple);
+            result_tuples.insert(tuple);
         }
         Ok(result_tuples)
     }


### PR DESCRIPTION
💡 What: Changed the internal accumulators (`compute_grouped_tuples`, `compute_ungrouped_tuples`, `compute_summarized_tuples`) in the `group`, `ungroup`, and `summarize` relational operators to directly build and return a `HashSet<Tuple>`, and construct the final `Relation` using `Relation::from_body_unchecked`.
🎯 Why: Previously, these methods collected tuples into an intermediate `Vec<Tuple>`, which was then passed to `Relation::from_tuples_unchecked`. That constructor simply iterates the `Vec` to populate the internal `HashSet`, meaning the initial `Vec` allocation and iteration was entirely redundant overhead.
📊 Impact: Eliminates an O(N) array allocation, memory copy, and iteration pass for every invocation of the `group`, `ungroup`, and `summarize` algebraic operations.
🔬 Measurement: Verified via `cargo test` that set semantics and logic are strictly preserved.

---
*PR created automatically by Jules for task [16608244690709218139](https://jules.google.com/task/16608244690709218139) started by @madmax983*