### PR TITLE
⚒️ Forge: Refactor vm step function

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -616,3 +616,7 @@ Build it right, make it fast, keep it simple.
 ## 2026-05-19 - Refactor God Function in Automata Accepts
 **Learning:** `relvar/src/experimental/automata.rs` contained a "God Function" `accepts` (78 lines) which combined computing epsilon closures, finding initial active states, processing the input string iteratively, and checking against accepting states. This mixed relational operations with procedural logic, hurting readability.
 **Action:** Applied the "Three-Phase Operator" pattern by extracting `compute_epsilon_closure`, `get_initial_active_states`, `apply_epsilon_closure`, `process_input_string`, and `check_accepting_states` into separate helper functions to drastically improve readability without changing behavior.
+
+## 2024-05-18 - Refactoring God Functions
+**Learning:** The `step` function in relational computations often becomes a "God Function" combining instruction fetching, decoding, execution, and state updates, leading to a pyramid of doom and poor readability.
+**Action:** Extract specific instruction execution (e.g., `execute_add_instruction`) and common state updates (e.g., `increment_pc`) into private helper functions to flatten the main loop.

--- a/relvar/src/experimental/vm.rs
+++ b/relvar/src/experimental/vm.rs
@@ -173,62 +173,70 @@ impl RelationalVM {
             .restrict(|t: &Tuple| t.get_typed::<String>("opcode").unwrap() == "ADD");
 
         if add_inst.cardinality() > 0 {
-            // Join arg2 with registers to get src1 value
-            let src1_join = add_inst
-                .rename(&[("arg2", "reg_id")])
-                .join(&self.registers)?
-                .rename(&[("value", "src1_val")])
-                .rename(&[("reg_id", "arg2")]);
-
-            // Join arg3 with registers to get src2 value
-            let src2_join = src1_join
-                .rename(&[("arg3", "reg_id")])
-                .join(&self.registers)?
-                .rename(&[("value", "src2_val")])
-                .rename(&[("reg_id", "arg3")]);
-
-            // Calculate the new value
-            let evaluated = src2_join
-                .extend("new_val", ScalarType::Int, |t: &Tuple| {
-                    let s1 = t.get_typed::<i64>("src1_val").unwrap();
-                    let s2 = t.get_typed::<i64>("src2_val").unwrap();
-                    ScalarValue::Int(s1 + s2)
-                })
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            // Extract the new register update
-            let new_reg_update = evaluated
-                .project(&["arg1", "new_val"])
-                .rename(&[("arg1", "reg_id"), ("new_val", "value")]);
-
-            // Filter out the old register value
-            let old_reg = evaluated
-                .project(&["arg1"])
-                .rename(&[("arg1", "reg_id")])
-                .join(&self.registers)?;
-
-            self.registers = self
-                .registers
-                .difference(&old_reg)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
-                .union(&new_reg_update)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            // Increment PC
-            self.head = self
-                .head
-                .extend("new_pc", ScalarType::Int, |t: &Tuple| {
-                    let pc = t.get_typed::<i64>("pc").unwrap();
-                    ScalarValue::Int(pc + 1)
-                })
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
-                .project(&["new_pc"])
-                .rename(&[("new_pc", "pc")]);
-
+            self.execute_add_instruction(&add_inst)?;
+            self.increment_pc()?;
             return Ok(true);
         }
 
         Ok(false)
+    }
+
+    fn execute_add_instruction(&mut self, add_inst: &Relation) -> Result<(), DatabaseError> {
+        // Join arg2 with registers to get src1 value
+        let src1_join = add_inst
+            .rename(&[("arg2", "reg_id")])
+            .join(&self.registers)?
+            .rename(&[("value", "src1_val")])
+            .rename(&[("reg_id", "arg2")]);
+
+        // Join arg3 with registers to get src2 value
+        let src2_join = src1_join
+            .rename(&[("arg3", "reg_id")])
+            .join(&self.registers)?
+            .rename(&[("value", "src2_val")])
+            .rename(&[("reg_id", "arg3")]);
+
+        // Calculate the new value
+        let evaluated = src2_join
+            .extend("new_val", ScalarType::Int, |t: &Tuple| {
+                let s1 = t.get_typed::<i64>("src1_val").unwrap();
+                let s2 = t.get_typed::<i64>("src2_val").unwrap();
+                ScalarValue::Int(s1 + s2)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        // Extract the new register update
+        let new_reg_update = evaluated
+            .project(&["arg1", "new_val"])
+            .rename(&[("arg1", "reg_id"), ("new_val", "value")]);
+
+        // Filter out the old register value
+        let old_reg = evaluated
+            .project(&["arg1"])
+            .rename(&[("arg1", "reg_id")])
+            .join(&self.registers)?;
+
+        self.registers = self
+            .registers
+            .difference(&old_reg)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
+            .union(&new_reg_update)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn increment_pc(&mut self) -> Result<(), DatabaseError> {
+        self.head = self
+            .head
+            .extend("new_pc", ScalarType::Int, |t: &Tuple| {
+                let pc = t.get_typed::<i64>("pc").unwrap();
+                ScalarValue::Int(pc + 1)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
+            .project(&["new_pc"])
+            .rename(&[("new_pc", "pc")]);
+        Ok(())
     }
 
     /// Runs the machine until it halts (returns the number of steps taken).


### PR DESCRIPTION
**🚮 Smell:** The `step` function in `relvar/src/experimental/vm.rs` was a 73-line "God Function" combining instruction fetching, validation, decoding ("ADD"), fetching operands, computing the result, updating the register relation, and incrementing the PC relation, all with nested logic.
**✨ Solution:** Applied the "Three-Phase Operator" pattern. Extracted the core "ADD" execution logic into `execute_add_instruction` and the PC incrementing logic into `increment_pc`. The `step` function now cleanly fetches, decodes, and delegates. Added an entry to `.jules/forge.md`.
**🧼 Benefit:** Drastically flattens the execution flow and improves the readability and maintainability of the main `step` loop. 
**🛡️ Verification:** `cargo test` passes. `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` ran without issues. No logic was changed.

---
*PR created automatically by Jules for task [9125010274878343204](https://jules.google.com/task/9125010274878343204) started by @madmax983*