### PR TITLE
⚡ Bolt: [Optimization] Remove intermediate Vec allocation in group operator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,6 @@
 ## 2025-05-21 - [Ungroup Operator Allocation Removal]
 **Learning:** In the `ungroup` operator, the intermediate results were collected into a `Vec<Tuple>` and then passed into `Relation::from_tuples_unchecked`, which iterated through the `Vec` to populate a `HashSet`.
 **Action:** Changed the internal accumulator `compute_ungrouped_tuples` to directly return `HashSet<Tuple>`, pre-allocated with the correct capacity, and used `Relation::from_body_unchecked` to bypass the intermediate `Vec` allocation entirely.
+## 2024-05-22 - [Group Operator Allocation Removal]
+**Learning:** In the `group` operator, intermediate RVA results were being collected into a `Vec<Tuple>` and then passed to `Relation::from_tuples_unchecked`, which creates a redundant heap allocation since we know we are building a set.
+**Action:** Modified `group_tuples` to directly accumulate tuples into a `HashSet<Tuple>`, and used `Relation::from_body_unchecked` to bypass the intermediate `Vec` allocation entirely, eliminating a redundant allocation.

--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -279,8 +279,9 @@ fn group_tuples<'a>(
     grouping_attrs: &[String],
     attrs_to_group: &[&str],
     rva_heading_arc: std::sync::Arc<TupleType>,
-) -> HashMap<Vec<&'a ScalarValue>, Vec<Tuple>> {
-    let mut groups: HashMap<Vec<&'a ScalarValue>, Vec<Tuple>> = HashMap::new();
+) -> HashMap<Vec<&'a ScalarValue>, std::collections::HashSet<Tuple>> {
+    let mut groups: HashMap<Vec<&'a ScalarValue>, std::collections::HashSet<Tuple>> =
+        HashMap::new();
 
     // Pre-allocate attribute name strings
     let attr_names: Vec<String> = attrs_to_group.iter().map(|a| a.to_string()).collect();
@@ -305,9 +306,13 @@ fn group_tuples<'a>(
         let rva_tuple = Tuple::new_unchecked(rva_heading_arc.clone(), rva_values);
 
         if let Some(group) = groups.get_mut(key_buffer.as_slice()) {
-            group.push(rva_tuple);
+            group.insert(rva_tuple);
         } else {
-            groups.insert(key_buffer.clone(), vec![rva_tuple]);
+            groups.insert(key_buffer.clone(), {
+                let mut s = std::collections::HashSet::new();
+                s.insert(rva_tuple);
+                s
+            });
         }
     }
 
@@ -341,7 +346,7 @@ fn compute_grouped_tuples(
         // Create RVA relation
         // Optimization: the tuples returned by the grouping step are guaranteed to be valid
         // since they were constructed with `rva_heading_arc`.
-        let rva_relation = Relation::from_tuples_unchecked(rva_relation_type.clone(), rva_tuples);
+        let rva_relation = Relation::from_body_unchecked(rva_relation_type.clone(), rva_tuples);
         values.insert(rva_name.to_string(), ScalarValue::Relation(rva_relation));
 
         let tuple = Tuple::new_unchecked(result_heading_arc.clone(), values);


### PR DESCRIPTION
💡 What: The `group` operator was using an intermediate `Vec<Tuple>` to collect the RVA tuples, which were then passed to `Relation::from_tuples_unchecked`. This involved a redundant heap allocation, as the final step constructs a `HashSet` from those tuples. The optimization changes `group_tuples` to directly accumulate into `std::collections::HashSet<Tuple>`, and then bypasses the internal Vec iteration by passing it directly to `Relation::from_body_unchecked`.
🎯 Why: In relational operations, unnecessary memory allocations (like populating an intermediate Vec only to immediately turn it into a HashSet) reduce execution speed and increase memory consumption, especially when processing many groups or large datasets.
📊 Impact: Eliminates one `Vec` allocation per grouped RVA relation, allowing the relation builder to directly adopt the pre-populated set buffer.
🔬 Measurement: Run `cargo bench` (if available) or `cargo test -p relvar-core`.

---
*PR created automatically by Jules for task [14212357702304126032](https://jules.google.com/task/14212357702304126032) started by @madmax983*