### PR TITLE
⚒️ Forge: Refactor expert_system infer loop

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -620,3 +620,7 @@ Build it right, make it fast, keep it simple.
 ## 2024-05-18 - Refactoring God Functions
 **Learning:** The `step` function in relational computations often becomes a "God Function" combining instruction fetching, decoding, execution, and state updates, leading to a pyramid of doom and poor readability.
 **Action:** Extract specific instruction execution (e.g., `execute_add_instruction`) and common state updates (e.g., `increment_pc`) into private helper functions to flatten the main loop.
+
+## 2025-05-15 - Refactored God Function in Relational Logic
+**Learning:** Found a god function `infer` in `relvar/src/experimental/expert_system.rs` executing a massive loop. This is a common anti-pattern where relational logic execution is all piled into one large loop without clean conceptual boundaries. This makes the code difficult to read.
+**Action:** Applied the 'Three-Phase Operator' pattern by extracting the massive chunk of looping logic into clear, domain-specific sub-phases (`compute_total_conditions`, `find_triggered_rules`, and `derive_new_facts`). This dramatically improved readability and clarity. Will continue extracting logic into smaller, properly typed helper functions.

--- a/relvar/src/experimental/expert_system.rs
+++ b/relvar/src/experimental/expert_system.rs
@@ -70,59 +70,21 @@ impl ExpertSystem {
             return Ok(current_facts);
         }
 
-        // Pre-compute the total number of conditions per rule
-        let total_conditions = self
-            .rule_conditions
-            .summarize(&["rule_id"], &[Aggregation::count("total_conds")])
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+        let total_conditions = self.compute_total_conditions()?;
 
         loop {
-            // Rename 'fact' to 'condition' to join with rule_conditions
-            let facts_as_conds = current_facts.rename(&[("fact", "condition")]);
-
-            // Which conditions are satisfied?
-            let satisfied_conditions = self.rule_conditions.join(&facts_as_conds)?;
-
-            // If no conditions are satisfied at all, we can't trigger anything new
-            if satisfied_conditions.cardinality() == 0 {
-                break;
-            }
-
-            // Count satisfied conditions per rule
-            let satisfied_counts = satisfied_conditions
-                .summarize(&["rule_id"], &[Aggregation::count("satisfied_conds")])
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            // Join totals with satisfied counts
-            let rule_stats = total_conditions.join(&satisfied_counts)?;
-
-            // Filter rules where satisfied_conds == total_conds
-            let triggered_rules = rule_stats
-                .restrict(|t| {
-                    let total = t.get_typed::<i64>("total_conds").unwrap_or(0);
-                    let satisfied = t.get_typed::<i64>("satisfied_conds").unwrap_or(0);
-                    total == satisfied
-                })
-                .project(&["rule_id"]);
+            let triggered_rules = self.find_triggered_rules(&current_facts, &total_conditions)?;
 
             if triggered_rules.cardinality() == 0 {
                 break;
             }
 
-            // Get conclusions for triggered rules
-            let new_conclusions = triggered_rules.join(&self.rule_conclusions)?;
+            let new_facts = self.derive_new_facts(&triggered_rules)?;
 
-            // Project and rename to match facts schema
-            let new_facts = new_conclusions
-                .project(&["conclusion"])
-                .rename(&[("conclusion", "fact")]);
-
-            // Union with current facts
             let next_facts = current_facts
                 .union(&new_facts)
                 .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
-            // Check for fixpoint (no new facts added)
             let diff = next_facts
                 .difference(&current_facts)
                 .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
@@ -135,6 +97,47 @@ impl ExpertSystem {
         }
 
         Ok(current_facts)
+    }
+
+    fn compute_total_conditions(&self) -> Result<Relation, DatabaseError> {
+        self.rule_conditions
+            .summarize(&["rule_id"], &[Aggregation::count("total_conds")])
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
+
+    fn find_triggered_rules(
+        &self,
+        current_facts: &Relation,
+        total_conditions: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        let facts_as_conds = current_facts.rename(&[("fact", "condition")]);
+        let satisfied_conditions = self.rule_conditions.join(&facts_as_conds)?;
+
+        if satisfied_conditions.cardinality() == 0 {
+            return Ok(satisfied_conditions.project(&["rule_id"]));
+        }
+
+        let satisfied_counts = satisfied_conditions
+            .summarize(&["rule_id"], &[Aggregation::count("satisfied_conds")])
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        let rule_stats = total_conditions.join(&satisfied_counts)?;
+
+        Ok(rule_stats
+            .restrict(|t| {
+                let total = t.get_typed::<i64>("total_conds").unwrap_or(0);
+                let satisfied = t.get_typed::<i64>("satisfied_conds").unwrap_or(0);
+                total == satisfied
+            })
+            .project(&["rule_id"]))
+    }
+
+    fn derive_new_facts(&self, triggered_rules: &Relation) -> Result<Relation, DatabaseError> {
+        let new_conclusions = triggered_rules.join(&self.rule_conclusions)?;
+
+        Ok(new_conclusions
+            .project(&["conclusion"])
+            .rename(&[("conclusion", "fact")]))
     }
 }
 


### PR DESCRIPTION
🚮 **Smell:** 
The `infer` function inside `relvar/src/experimental/expert_system.rs` was acting as a "God Function". It was quite long and contained deeply nested relational logic inside an infinite loop, acting as a "Pyramid of Doom". Relational database logic merged with loop conditionals in one block made it extremely difficult to parse visually.

✨ **Solution:** 
Refactored the core looping logic into three small, clearly named private helper methods following the "Three-Phase Operator" pattern:
- `compute_total_conditions`
- `find_triggered_rules`
- `derive_new_facts`
The loop now cleanly orchestrates these helpers with early breaks.

🧼 **Benefit:** 
This flattens the structure, reduces cognitive load significantly, and isolates discrete operations into testable and easy-to-read segments. Types act as documentation for each phase.

🛡️ **Verification:** 
- `cargo fmt --all` run.
- `cargo clippy --all-targets --all-features -- -D warnings` run.
- `cargo test` passed.
- No logic was changed, and the internal tests specific to the expert system continue to function correctly.

---
*PR created automatically by Jules for task [4729491811529992998](https://jules.google.com/task/4729491811529992998) started by @madmax983*