### PR TITLE
🎻 Bard: [documentation update] Add examples and recovery to Error enums

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -27,3 +27,6 @@
 ## 2025-05-19 - The "GarbageCollector" Examples
 **Confusion:** The experimental `GarbageCollector` module lacked executable doc-tests (`/// # Examples` blocks) for its struct and methods (`new` and `mark_and_sweep`). This made it difficult for users to understand how to instantiate the roots, heap, and references relations and run the GC algorithm.
 **Clarification:** Added comprehensive executable doc-tests to `GarbageCollector`, `new`, and `mark_and_sweep` that demonstrate how to construct the necessary relations and see which objects are identified as garbage.
+## 2024-05-18 - [Error Documentation]
+**Confusion:** Error enums were documented with simple `.to_string()` assertions, which was "Dead End" noise failing to explain how to recover.
+**Clarification:** Rewrote doc-tests to include rich `/// # Recovery` sections mapped to each variant, explaining exactly what the error means in the Relational context and how to fix it, using story-driven lore as per Bard's philosophy.

--- a/relvar-core/src/algebra/extend.rs
+++ b/relvar-core/src/algebra/extend.rs
@@ -37,7 +37,25 @@
 use crate::values::{Relation, ScalarValue, Tuple};
 use thiserror::Error;
 
-/// Errors that can occur during extend operations.
+/// The boundaries of extending knowledge.
+///
+/// The `extend` operator breathes new life into a relation by generating new attributes
+/// from existing data. However, the universe has rules.
+///
+/// # Recovery
+/// - **AttributeExists:** You cannot overwrite an existing attribute. Relational attributes are immutable facts. If you want to replace an attribute, you must first `rename` the old one or `project` it away.
+/// - **TupleCreation:** The closure you provided returned a `ScalarValue` that doesn't match the `ScalarType` you promised in the `extend` signature. Ensure your types align.
+///
+/// # Examples
+///
+/// ```
+/// use relvar_core::algebra::ExtendError;
+///
+/// // The user attempted to create a new attribute that collides with an existing one.
+/// // To recover, they should either pick a new name, or `project` away the old attribute.
+/// let error = ExtendError::AttributeExists("id".to_string());
+/// assert!(error.to_string().contains("Attribute 'id' already exists"));
+/// ```
 #[derive(Debug, Error)]
 pub enum ExtendError {
     /// The new attribute name conflicts with an existing attribute.

--- a/relvar-core/src/algebra/summarize.rs
+++ b/relvar-core/src/algebra/summarize.rs
@@ -44,7 +44,26 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use thiserror::Error;
 
-/// Errors that can occur during summarize operations.
+/// Errors that arise when attempting to distill the truth.
+///
+/// The `summarize` operator acts as a lens, focusing many tuples into a single aggregated value.
+/// However, if the lens is flawed (e.g. referencing an attribute that doesn't exist),
+/// the operation will fail.
+///
+/// # Recovery
+/// - **GroupingAttributeNotFound:** You are trying to group by an attribute that is not in the relation. Check your spelling and the relation's heading.
+/// - **ResultAttributeExists:** The name you chose for your aggregated column (e.g. 'total_salary') is already taken by another attribute. Pick a fresh, unique alias.
+///
+/// # Examples
+///
+/// ```
+/// use relvar_core::algebra::SummarizeError;
+///
+/// // The user tried to group by a column that doesn't exist.
+/// // They should inspect the relation's heading to find the correct spelling.
+/// let error = SummarizeError::GroupingAttributeNotFound("salary".to_string());
+/// assert!(error.to_string().contains("Grouping attribute 'salary' does not exist"));
+/// ```
 #[derive(Debug, Error)]
 pub enum SummarizeError {
     /// A specified grouping attribute does not exist in the relation.

--- a/relvar-core/src/algebra/union.rs
+++ b/relvar-core/src/algebra/union.rs
@@ -36,7 +36,28 @@
 use crate::values::Relation;
 use thiserror::Error;
 
-/// Errors that can occur during union operations.
+/// The strict rules of relational matrimony.
+///
+/// In relational theory, two sets can only be united if they speak the exact same language.
+/// This error is returned when an attempt is made to `union` two relations that are not
+/// type-compatible.
+///
+/// # Recovery
+/// - Ensure both relations have the exact same degree (number of attributes).
+/// - Ensure both relations have the exact same attribute names.
+/// - Ensure the scalar types of those attributes match perfectly.
+/// - Use `project` or `rename` to align their headings before attempting the union.
+///
+/// # Examples
+///
+/// ```
+/// use relvar_core::algebra::UnionError;
+///
+/// // The classic blunder: attempting to union apples and oranges.
+/// // The recovery action is to align their headings first using `rename` or `project`.
+/// let error = UnionError;
+/// assert!(error.to_string().contains("Relations must have the same type"));
+/// ```
 #[derive(Debug, Error)]
 #[error("Relations must have the same type (heading) for union")]
 pub struct UnionError;

--- a/relvar-core/src/storage_engine/mod.rs
+++ b/relvar-core/src/storage_engine/mod.rs
@@ -17,7 +17,27 @@ pub(crate) mod in_memory;
 
 pub use in_memory::InMemoryEngine;
 
-/// Errors that can occur during storage operations.
+/// The grim reality of physical storage.
+///
+/// Even the most pristine relational algebra must eventually touch the cold, hard disk.
+/// This enum represents the various ways persistence can fail. From the tragic
+/// loss of a file (`IoError`) to the phantom menace of a missing relation
+/// (`RelationNotFound`).
+///
+/// # Recovery
+/// - **RelationNotFound:** Double check your system catalog. Are you querying a relvar that hasn't been defined yet? Ensure `create_relvar` was called.
+/// - **RelationAlreadyExists:** You're attempting to define a relvar with a name that is already taken. Choose a unique name or drop the existing one.
+///
+/// # Examples
+///
+/// ```
+/// use relvar_core::storage_engine::StorageError;
+///
+/// // An attempt to query a relation that the Storage Engine cannot find in its catalog.
+/// // The proper response is to ensure the table was created before querying.
+/// let err = StorageError::RelationNotFound("EMPLOYEES".to_string());
+/// assert!(err.to_string().contains("EMPLOYEES not found"));
+/// ```
 #[derive(Debug, Error)]
 pub enum StorageError {
     /// The relation already exists.

--- a/relvar/src/tools/importer.rs
+++ b/relvar/src/tools/importer.rs
@@ -45,7 +45,27 @@ use std::io::BufRead;
 use std::rc::Rc;
 use thiserror::Error;
 
-/// Errors that can occur during import.
+/// Errors that halt the import saga.
+///
+/// Importing data from the chaotic outside world into the structured realm
+/// of a relational database is perilous. This enum categorizes the specific
+/// tragedies that can occur, ranging from sheer physical exhaustion (I/O failures)
+/// to philosophical disagreements (Type mismatches).
+///
+/// # Recovery
+/// - **LimitExceeded:** The payload is too massive (e.g. >10MB for JSON). If this occurs, chunk your data into smaller files or streams.
+/// - **TypeError:** Ensure your input data strictly adheres to the scalar types defined in your `RelationType` heading. The error specifies which attribute failed.
+///
+/// # Examples
+///
+/// ```
+/// use relvar::tools::importer::ImporterError;
+///
+/// // Example of a DoS protection limit triggering.
+/// // The user should be informed that their payload is too large, and they should chunk it.
+/// let error = ImporterError::LimitExceeded("Input exceeds 10MB".to_string());
+/// assert!(error.to_string().contains("Size limit exceeded"));
+/// ```
 #[derive(Debug, Error)]
 pub enum ImporterError {
     /// I/O error reading the input.


### PR DESCRIPTION
📖 Chapter: Error Enums (`ExtendError`, `SummarizeError`, `UnionError`, `StorageError`, `ImporterError`)
🔦 Insight: These error types were "Dead Ends" - they lacked meaningful context on why they happened or how to fix them. Added rich lore and a dedicated `# Recovery` section to map each variant to actionable fixes.
🧪 Example: Added 5 executable doc-tests.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [1389172494961310569](https://jules.google.com/task/1389172494961310569) started by @madmax983*