### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -27,3 +27,6 @@
 ## 2025-05-19 - The "GarbageCollector" Examples
 **Confusion:** The experimental `GarbageCollector` module lacked executable doc-tests (`/// # Examples` blocks) for its struct and methods (`new` and `mark_and_sweep`). This made it difficult for users to understand how to instantiate the roots, heap, and references relations and run the GC algorithm.
 **Clarification:** Added comprehensive executable doc-tests to `GarbageCollector`, `new`, and `mark_and_sweep` that demonstrate how to construct the necessary relations and see which objects are identified as garbage.
+## 2025-05-20 - The "Missing Storage" Examples
+**Confusion:** The `relvar-storage` crate had missing examples for `StorageManager` in `src/storage/manager.rs` and the recovery structs (`AnalysisResult`, `UncommittedInsert`, `RecoveryResult`) in `src/wal/recovery.rs`. This omission left the physical storage initialization undocumented. Moreover, testing internal `pub(crate)` modules caused `cargo test --doc` failures.
+**Clarification:** Added executable `/// # Examples` doc-tests for `StorageManager` demonstrating how to create a `StorageManager` and a relation. Added mocked, non-executable examples (`/// ```ignore`) for the recovery structs to illustrate their usage without breaking the test suite due to private module visibility (`relvar_storage::wal`).

--- a/plan.md
+++ b/plan.md
@@ -1,2 +1,8 @@
-1. **Submit the clean audit report.**
-   - Since no active vulnerabilities were found during the investigation of `unsafe` blocks, bounds checking, buffer limits, and data serialization (verifying that they either safely bounded or properly capped), I will submit the PR to confirm the codebase is secure under the given scope.
+1. **Add Doc-tests to `StorageManager`**: Update `StorageManager` in `relvar-storage/src/storage/manager.rs` with an `/// # Examples` block showing initialization via `new`, creating a relation using `create_relation`, inserting a tuple via `insert_tuple`, and scanning the relation via `scan_relation`. Use `sed` via `run_in_bash_session` to apply changes securely.
+2. **Add Doc-tests to `AnalysisResult`**: Update `AnalysisResult` in `relvar-storage/src/wal/recovery.rs` with an `/// # Examples` block demonstrating how to instantiate and assert on the fields of `AnalysisResult` (`committed`, `aborted`, `records`, `last_checkpoint_lsn`). Use `sed` via `run_in_bash_session` to apply changes securely.
+3. **Add Doc-tests to `UncommittedInsert`**: Update `UncommittedInsert` in `relvar-storage/src/wal/recovery.rs` with an `/// # Examples` block demonstrating construction and checking fields. Use `sed` via `run_in_bash_session` to apply changes securely.
+4. **Add Doc-tests to `RecoveryResult`**: Update `RecoveryResult` in `relvar-storage/src/wal/recovery.rs` with an `/// # Examples` block showing a mocked recovery result creation. Use `sed` via `run_in_bash_session` to apply changes securely.
+5. **Update `.jules/bard.md`**: Log these specific findings and the resolution using the append (`>>`) method in `bard.md` via `run_in_bash_session`.
+6. **Code verification and linting**: Run `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo doc --no-deps --open`. Use `python3 find_undoc.py` to ensure no undocumented items remain via `run_in_bash_session`.
+7. **Testing**: Execute full suite verification utilizing `cargo test` as an independent step via `run_in_bash_session`.
+8. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.

--- a/relvar-storage/src/storage/manager.rs
+++ b/relvar-storage/src/storage/manager.rs
@@ -17,6 +17,33 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 /// Storage Manager handling physical storage operations.
+///
+/// # Examples
+///
+/// ```
+/// use relvar_storage::storage::StorageManager;
+/// use relvar_core::types::{RelationType, TupleType, ScalarType};
+/// use tempfile::TempDir;
+///
+/// // Create a temporary directory for the database
+/// let temp_dir = TempDir::new().unwrap();
+///
+/// // 1. Initialize StorageManager
+/// let mut manager = StorageManager::new(temp_dir.path()).unwrap();
+///
+/// // 2. Create a relation metadata
+/// let rel_type = RelationType::new(
+///     TupleType::new()
+///         .with_attribute("id", ScalarType::Int)
+///         .with_attribute("name", ScalarType::String)
+/// );
+///
+/// // 3. Create the physical relation
+/// manager.create_relation("USERS", rel_type).unwrap();
+///
+/// // 4. Verify it exists
+/// assert!(manager.relation_exists("USERS"));
+/// ```
 pub struct StorageManager {
     /// Base directory for database files.
     db_path: PathBuf,

--- a/relvar-storage/src/wal/recovery.rs
+++ b/relvar-storage/src/wal/recovery.rs
@@ -35,6 +35,25 @@ use std::io::{Read, Seek, SeekFrom};
 
 /// Result of the analysis pass.
 #[derive(Debug)]
+/// # Examples
+///
+/// ```ignore
+/// use relvar_storage::wal::{AnalysisResult, TransactionId, Lsn};
+/// use std::collections::HashSet;
+///
+/// let mut committed = HashSet::new();
+/// committed.insert(TransactionId::new(1));
+///
+/// let result = AnalysisResult {
+///     committed,
+///     aborted: HashSet::new(),
+///     records: vec![],
+///     last_checkpoint_lsn: Some(Lsn::new(100)),
+/// };
+///
+/// assert!(result.committed.contains(&TransactionId::new(1)));
+/// assert_eq!(result.last_checkpoint_lsn.unwrap().value(), 100);
+/// ```
 pub struct AnalysisResult {
     /// Transactions that committed.
     pub committed: HashSet<TransactionId>,
@@ -90,6 +109,19 @@ pub fn analyze(wal: &mut WalManager) -> Result<AnalysisResult, WalError> {
 
 /// Uncommitted insert information.
 #[derive(Debug)]
+/// # Examples
+///
+/// ```ignore
+/// use relvar_storage::wal::UncommittedInsert;
+///
+/// let insert = UncommittedInsert {
+///     relation_name: "USERS".to_string(),
+///     tuple_data: vec![1, 2, 3, 4],
+/// };
+///
+/// assert_eq!(insert.relation_name, "USERS");
+/// assert_eq!(insert.tuple_data.len(), 4);
+/// ```
 pub struct UncommittedInsert {
     /// Relation name.
     pub relation_name: String,
@@ -99,6 +131,30 @@ pub struct UncommittedInsert {
 
 /// Result of recovery process.
 #[derive(Debug)]
+/// # Examples
+///
+/// ```ignore
+/// use relvar_storage::wal::{RecoveryResult, UncommittedInsert, TransactionId};
+/// use std::collections::HashSet;
+///
+/// let mut committed_txns = HashSet::new();
+/// committed_txns.insert(TransactionId::new(1));
+///
+/// let insert = UncommittedInsert {
+///     relation_name: "USERS".to_string(),
+///     tuple_data: vec![1, 2, 3],
+/// };
+///
+/// let result = RecoveryResult {
+///     committed_txns,
+///     uncommitted_inserts: vec![insert],
+///     max_txn_id: TransactionId::new(10),
+/// };
+///
+/// assert!(result.committed_txns.contains(&TransactionId::new(1)));
+/// assert_eq!(result.uncommitted_inserts.len(), 1);
+/// assert_eq!(result.max_txn_id.value(), 10);
+/// ```
 pub struct RecoveryResult {
     /// Set of committed transaction IDs (for MVCC visibility).
     pub committed_txns: HashSet<TransactionId>,


### PR DESCRIPTION
This PR adds missing executable and illustrative doc-tests for `StorageManager` and related `wal::recovery` module structs, providing clear usage examples. Also updates `.jules/bard.md` with findings and the rationale for ignoring doc tests in private modules.

---
*PR created automatically by Jules for task [15741072477360765060](https://jules.google.com/task/15741072477360765060) started by @madmax983*