### PR TITLE
⚒️ Forge: refactor visualizer to_dot method

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -627,3 +627,7 @@ Build it right, make it fast, keep it simple.
 ## 2026-05-01 - Extract God Function in CYK Parser
 **Learning:** `relvar/src/experimental/parser.rs` contained a "God Function" `parse` (over 65 lines) which combined initializing the parse table, generating new entries, and looping until fixpoint.
 **Action:** Applied the 'Three-Phase Operator' pattern by extracting `initialize_parse_table` and `compute_new_entries` into separate private helper functions to dramatically improve readability and modularity without changing behavior.
+
+## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
+**Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
+**Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.

--- a/relvar/src/tools/visualizer.rs
+++ b/relvar/src/tools/visualizer.rs
@@ -104,8 +104,16 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
 
         let relvars = self.db.list_relvars();
 
+        self.generate_nodes(&relvars, &mut dot);
+        self.generate_edges(&relvars, &mut dot);
+
+        dot.push_str("}\n");
+        dot
+    }
+
+    fn generate_nodes(&self, relvars: &[String], dot: &mut String) {
         // 1. Generate nodes (Tables)
-        for name in &relvars {
+        for name in relvars {
             // Note: We use get_relvar_type() to get the relation structure.
             // This avoids loading the full relation data.
             if let Ok(relation_type) = self.db.get_relvar_type(name) {
@@ -160,9 +168,11 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
                 dot.push_str("    </table>>];\n\n");
             }
         }
+    }
 
+    fn generate_edges(&self, relvars: &[String], dot: &mut String) {
         // 2. Generate edges (Foreign Keys)
-        for name in &relvars {
+        for name in relvars {
             if let Some(fk_constraints) = self.db.get_foreign_key_constraints(name) {
                 for fk in fk_constraints.foreign_keys() {
                     let ref_table = fk.referenced_relation_name();
@@ -179,9 +189,6 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
                 }
             }
         }
-
-        dot.push_str("}\n");
-        dot
     }
 }
 


### PR DESCRIPTION
🚮 Smell: The `to_dot` method in `SchemaVisualizer` was a "God Function", containing inline generation logic for both Nodes and Edges which made it hard to read and test.
✨ Solution: Extracted the node and edge generation mapping logics into cleanly named private helper functions `generate_nodes` and `generate_edges` in the `SchemaVisualizer` struct.
🧼 Benefit: Significantly reduces cognitive load when reading `to_dot` and improves modularity without losing efficiency.
🛡️ Verification: Checked via `cargo clippy`, `cargo fmt`, and full `cargo test`. All passed. No logic was altered.

---
*PR created automatically by Jules for task [999604376152638783](https://jules.google.com/task/999604376152638783) started by @madmax983*