### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -30,3 +30,6 @@
 ## 2024-05-18 - [Error Documentation]
 **Confusion:** Error enums were documented with simple `.to_string()` assertions, which was "Dead End" noise failing to explain how to recover.
 **Clarification:** Rewrote doc-tests to include rich `/// # Recovery` sections mapped to each variant, explaining exactly what the error means in the Relational context and how to fix it, using story-driven lore as per Bard's philosophy.
+## 2024-05-04 - [The Knowledge Graph Mystery]
+**Confusion:** The `experimental::knowledge_graph` module lacked documentation explaining *why* a graph was being built using pure relational algebra. The public structs and functions also lacked executable examples demonstrating how to use the API to insert triples and evaluate Basic Graph Patterns.
+**Clarification:** Added storytelling module-level documentation (`//!`) explaining how graphs are just interconnected relations. Added comprehensive `/// # Examples` doctests to `KnowledgeGraph` and its methods to show how standard relational operations simulate complex graph traversals.

--- a/relvar-core/src/experimental/knowledge_graph.rs
+++ b/relvar-core/src/experimental/knowledge_graph.rs
@@ -1,15 +1,69 @@
+//! The Knowledge Graph module.
+//!
+//! Why build a Knowledge Graph out of relational algebra? Because graphs are fundamentally
+//! just interconnected relations! This module exists to demonstrate how the foundational
+//! operations of relational algebra (like [`Relation::restrict`], [`Relation::project`],
+//! and [`Relation::join`]) can be composed to build powerful abstractions.
+//!
+//! Rather than building a separate graph database engine with complex traversal algorithms,
+//! we represent the entire graph as a single relation of triples: `(subject, predicate, object)`.
+//! Graph queries (like finding all friends of a person) are simply evaluated as a sequence of
+//! relational restrictions (to find a starting node) and joins (to traverse edges).
+//!
+//! This module showcases the expressive power of the relational model.
+
 use crate::error::DatabaseError;
 use crate::types::{RelationType, ScalarType, TupleType};
 use crate::values::Relation;
 
 /// A Knowledge Graph modeled purely using relational algebra.
+///
+/// Under the hood, this struct maintains a single relation storing all data as
+/// `(subject, predicate, object)` triples. This approach, known as the Resource
+/// Description Framework (RDF) model, allows us to flexibly store any kind of
+/// interconnected data without rigid, predefined schemas.
+///
+/// # Examples
+///
+/// ```
+/// use relvar_core::experimental::knowledge_graph::{KnowledgeGraph, TriplePattern};
+///
+/// let mut kg = KnowledgeGraph::new();
+///
+/// // We build our graph by inserting facts
+/// kg.insert("Alice", "knows", "Bob").unwrap();
+/// kg.insert("Bob", "knows", "Charlie").unwrap();
+/// kg.insert("Bob", "age", "30").unwrap();
+///
+/// // We can query the graph using variables (prefixed with '?')
+/// let patterns = vec![
+///     TriplePattern::new("Alice", "knows", "?friend"),
+///     TriplePattern::new("?friend", "age", "?age"),
+/// ];
+///
+/// // The result is a standard Relation containing our bindings!
+/// let result = kg.query(&patterns).unwrap();
+/// assert_eq!(result.cardinality(), 1);
+/// ```
 pub struct KnowledgeGraph {
     /// A single relation storing triples (subject, predicate, object)
     pub triples: Relation,
 }
 
 impl KnowledgeGraph {
-    /// Create a new empty Knowledge Graph.
+    /// Creates a new, empty Knowledge Graph.
+    ///
+    /// This establishes the foundational schema: a single relation with a heading of
+    /// `(subject: String, predicate: String, object: String)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::KnowledgeGraph;
+    ///
+    /// let kg = KnowledgeGraph::new();
+    /// assert_eq!(kg.triples.cardinality(), 0);
+    /// ```
     pub fn new() -> Self {
         let heading = TupleType::new()
             .with_attribute("subject", ScalarType::String)
@@ -21,7 +75,23 @@ impl KnowledgeGraph {
         }
     }
 
-    /// Insert a new triple into the Knowledge Graph.
+    /// Inserts a new triple into the Knowledge Graph.
+    ///
+    /// The triple `(subject, predicate, object)` represents a single fact. For example,
+    /// `("Alice", "knows", "Bob")` establishes a directed edge from Alice to Bob.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`DatabaseError::AlgebraError`] if the underlying relation insertion fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::KnowledgeGraph;
+    ///
+    /// let mut kg = KnowledgeGraph::new();
+    /// kg.insert("Earth", "orbits", "Sun").unwrap();
+    /// ```
     pub fn insert(
         &mut self,
         subject: &str,
@@ -39,8 +109,29 @@ impl KnowledgeGraph {
         Ok(())
     }
 
-    /// Query the graph using a basic graph pattern (BGP).
-    /// A pattern is represented as a list of `TriplePattern` structs.
+    /// Queries the graph using a Basic Graph Pattern (BGP).
+    ///
+    /// A pattern is a list of [`TriplePattern`]s. The engine evaluates each pattern by
+    /// mapping known values to restrictions and unknown values (starting with `?`) to
+    /// projections and renames. The results of individual patterns are then combined
+    /// using natural joins to enforce that shared variables bind to the same values.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`DatabaseError::AlgebraError`] if the pattern list is empty or if
+    /// any underlying relational operations (like joins) fail.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::{KnowledgeGraph, TriplePattern};
+    ///
+    /// let mut kg = KnowledgeGraph::new();
+    /// kg.insert("Alice", "likes", "Rust").unwrap();
+    ///
+    /// let patterns = vec![TriplePattern::new("?person", "likes", "Rust")];
+    /// let result = kg.query(&patterns).unwrap();
+    /// ```
     pub fn query(&self, patterns: &[TriplePattern]) -> Result<Relation, DatabaseError> {
         if patterns.is_empty() {
             return Err(DatabaseError::AlgebraError("Empty BGP".to_string()));
@@ -118,7 +209,22 @@ pub struct TriplePattern {
 }
 
 impl TriplePattern {
-    /// Create a new TriplePattern
+    /// Creates a new TriplePattern.
+    ///
+    /// A pattern node that begins with a `?` is treated as a variable. All other nodes
+    /// are treated as concrete string values that must match exactly.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::TriplePattern;
+    ///
+    /// // Match exact relationships
+    /// let p1 = TriplePattern::new("Alice", "knows", "Bob");
+    ///
+    /// // Match any object for a specific subject and predicate
+    /// let p2 = TriplePattern::new("Alice", "knows", "?friend");
+    /// ```
     pub fn new(subject: &str, predicate: &str, object: &str) -> Self {
         Self {
             subject: subject.to_string(),


### PR DESCRIPTION
* 📖 Chapter: The `KnowledgeGraph` module
* 🔦 Insight: Explained why graphs can be modeled and traversed purely using relational algebra primitives instead of complex graph databases.
* 🧪 Example: Added 5 executable doctests for struct instantiation, data insertion, and basic graph pattern queries.
* 🖼️ Preview: Formatted with standard backticks, `# Errors` sections, and intra-doc links for clickable discovery.

---
*PR created automatically by Jules for task [4113148939505617655](https://jules.google.com/task/4113148939505617655) started by @madmax983*