### PR TITLE
⚡ Bolt: [performance improvement] optimize rename_into string allocs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -51,3 +51,7 @@
 ## 2026-05-01 - Avoided Arc clone in DML loop
 **Learning:** `Arc<TupleType>::clone()` incurs reference counting overhead and potential allocation overhead, taking around 14ms per 10k tuple creations as shown in `tuple_creation` bench.
 **Action:** Always borrow reference from wrapper container types instead of cloning Arc explicitly if the borrow lifetime spans the whole needed lifetime block, like `tuple.conforms_to(relation_type.tuple_type())` instead of `.clone()`ing `expected_type`.
+
+## 2024-05-20 - String Allocations in Iterators
+**Learning:** `rename_into` previously consumed a tuple's BTreeMap entirely to scalar values by calling `.into_values()`. However, BTreeMaps also implement `into_iter()` which yields owned `(K, V)` pairs. We were discarding the `K` (the original String key) and creating a brand new String key for every column of every tuple, even if the rename mapping didn't touch it.
+**Action:** Always check if we can reuse the owned strings from an input collection instead of reflexively throwing them away and re-allocating them in an iterator pipeline.

--- a/bolt_plan.txt
+++ b/bolt_plan.txt
@@ -3,3 +3,8 @@
    We can simply compare their `attributes().len()` first, and if equal, use `Iterator::zip` to compare `(name, type)` pairs sequentially.
 2. Complete pre-commit steps.
 3. Submit PR.
+
+* I found that `rename_into` does this:
+`let values_map: BTreeMap<String, _> = new_names.iter().zip(tuple.into_values().into_values()).map(|(new_name, value)| (new_name.clone(), value)).collect();`
+
+which allocates a completely new String key even if `new_name == old_name`. I will optimize this by re-using the old name when they match to avoid unnecessary memory allocations.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,4 +1,4 @@
-💡 What: Optimized `compute_relation_after_update` in `relvar-core/src/database/dml.rs` to borrow `expected_type` as a reference rather than unnecessarily calling `.clone()` on the underlying `Arc<TupleType>`.
-🎯 Why: Avoiding an unnecessary clone call on `Arc<TupleType>` during data modifications. This `Arc` clone was happening repeatedly during setup of the update operations and could easily be avoided by borrowing a reference instead.
-📊 Impact: Minor speedup and removal of an unnecessary clone operation overhead, which could matter under heavy multi-threaded workloads where atomic refcounts are heavily contended. The `tuple_creation` bench showed a minor performance improvement.
-🔬 Measurement: Run bench `tuple_creation` / `group_bench`.
+💡 What: Optimized `rename_into` inside `relvar-core/src/algebra/rename.rs` by re-using the existing String memory allocation when an attribute name does not change.
+🎯 Why: `rename_into` previously extracted the `values` from the tuple, discarded the original String keys via `.into_values()`, and explicitly allocated a new cloned string for every single attribute column of every single tuple using `new_name.clone()`. For relations with a large degree or high tuple count where only one or two fields are being renamed, this resulted in an enormous amount of useless String allocations.
+📊 Impact: Avoids `M * N` String allocations (where M is un-renamed attributes per tuple, and N is the number of tuples).
+🔬 Measurement: Run tests via `cargo test`.

--- a/pre_commit.sh
+++ b/pre_commit.sh
@@ -1,0 +1,3 @@
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+cargo fmt --all

--- a/relvar-core/src/algebra/rename.rs
+++ b/relvar-core/src/algebra/rename.rs
@@ -161,12 +161,22 @@ impl Relation {
 
         // Rename attributes in each tuple by consuming it
         let renamed_tuples = self.into_iter().map(move |tuple| {
-            // Optimization: Zip pre-calculated new names with consumed values.
+            // Optimization: Zip pre-calculated new names with consumed (key, value) pairs.
             // Both iterators follow the sorted order of old attribute names.
+            // By keeping the old key string, we can reuse its memory allocation
+            // if the name didn't actually change, avoiding String cloning.
             let values_map: BTreeMap<String, _> = new_names
                 .iter()
-                .zip(tuple.into_values().into_values())
-                .map(|(new_name, value)| (new_name.clone(), value))
+                .zip(tuple.into_values())
+                .map(|(new_name, (old_name, value))| {
+                    if new_name == &old_name {
+                        // Reuse the existing string allocation
+                        (old_name, value)
+                    } else {
+                        // Must allocate a new string for the changed name
+                        (new_name.clone(), value)
+                    }
+                })
                 .collect();
 
             // Safety:


### PR DESCRIPTION
💡 What: Optimized `rename_into` inside `relvar-core/src/algebra/rename.rs` by re-using the existing String memory allocation when an attribute name does not change.
🎯 Why: `rename_into` previously extracted the `values` from the tuple, discarded the original String keys via `.into_values()`, and explicitly allocated a new cloned string for every single attribute column of every single tuple using `new_name.clone()`. For relations with a large degree or high tuple count where only one or two fields are being renamed, this resulted in an enormous amount of useless String allocations.
📊 Impact: Avoids `M * N` String allocations (where M is un-renamed attributes per tuple, and N is the number of tuples).
🔬 Measurement: Run tests via `cargo test`.

---
*PR created automatically by Jules for task [10539225678512090899](https://jules.google.com/task/10539225678512090899) started by @madmax983*