### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -30,3 +30,6 @@
 ## 2024-05-18 - [Error Documentation]
 **Confusion:** Error enums were documented with simple `.to_string()` assertions, which was "Dead End" noise failing to explain how to recover.
 **Clarification:** Rewrote doc-tests to include rich `/// # Recovery` sections mapped to each variant, explaining exactly what the error means in the Relational context and how to fix it, using story-driven lore as per Bard's philosophy.
+## 2025-05-19 - Documenting Knowledge Graph
+**Confusion:** The experimental `KnowledgeGraph` had no executable doc-tests (`/// # Examples` blocks) for its struct or its core methods (`new`, `insert`, `query`), and its `TriplePattern` struct was similarly undocumented. This made it difficult for users to understand how to initialize the graph, insert triples, and construct patterns for querying.
+**Clarification:** Added executable doc-tests to `KnowledgeGraph` and its methods that demonstrate how to construct the graph, insert relation triples, and query them.

--- a/relvar-core/src/experimental/knowledge_graph.rs
+++ b/relvar-core/src/experimental/knowledge_graph.rs
@@ -3,6 +3,19 @@ use crate::types::{RelationType, ScalarType, TupleType};
 use crate::values::Relation;
 
 /// A Knowledge Graph modeled purely using relational algebra.
+/// # Examples
+///
+/// ```
+/// use relvar_core::experimental::knowledge_graph::{KnowledgeGraph, TriplePattern};
+///
+/// let mut kg = KnowledgeGraph::new();
+/// kg.insert("Alice", "knows", "Bob").unwrap();
+///
+/// let patterns = vec![TriplePattern::new("Alice", "knows", "?person")];
+/// let result = kg.query(&patterns).unwrap();
+///
+/// assert_eq!(result.cardinality(), 1);
+/// ```
 pub struct KnowledgeGraph {
     /// A single relation storing triples (subject, predicate, object)
     pub triples: Relation,
@@ -10,6 +23,14 @@ pub struct KnowledgeGraph {
 
 impl KnowledgeGraph {
     /// Create a new empty Knowledge Graph.
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::KnowledgeGraph;
+    ///
+    /// let kg = KnowledgeGraph::new();
+    /// assert_eq!(kg.triples.cardinality(), 0);
+    /// ```
     pub fn new() -> Self {
         let heading = TupleType::new()
             .with_attribute("subject", ScalarType::String)
@@ -22,6 +43,15 @@ impl KnowledgeGraph {
     }
 
     /// Insert a new triple into the Knowledge Graph.
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::KnowledgeGraph;
+    ///
+    /// let mut kg = KnowledgeGraph::new();
+    /// kg.insert("Alice", "likes", "Rust").unwrap();
+    /// assert_eq!(kg.triples.cardinality(), 1);
+    /// ```
     pub fn insert(
         &mut self,
         subject: &str,
@@ -41,6 +71,29 @@ impl KnowledgeGraph {
 
     /// Query the graph using a basic graph pattern (BGP).
     /// A pattern is represented as a list of `TriplePattern` structs.
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::{KnowledgeGraph, TriplePattern};
+    ///
+    /// let mut kg = KnowledgeGraph::new();
+    /// kg.insert("Alice", "knows", "Bob").unwrap();
+    /// kg.insert("Bob", "likes", "Rust").unwrap();
+    ///
+    /// let patterns = vec![
+    ///     TriplePattern::new("Alice", "knows", "?friend"),
+    ///     TriplePattern::new("?friend", "likes", "?lang"),
+    /// ];
+    ///
+    /// let result = kg.query(&patterns).unwrap();
+    /// assert_eq!(result.cardinality(), 1);
+    ///
+    /// let expected_tuple = relvar_core::tuple! {
+    ///     friend: "Bob",
+    ///     lang: "Rust"
+    /// };
+    /// assert!(result.contains(&expected_tuple));
+    /// ```
     pub fn query(&self, patterns: &[TriplePattern]) -> Result<Relation, DatabaseError> {
         if patterns.is_empty() {
             return Err(DatabaseError::AlgebraError("Empty BGP".to_string()));
@@ -119,6 +172,16 @@ pub struct TriplePattern {
 
 impl TriplePattern {
     /// Create a new TriplePattern
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::TriplePattern;
+    ///
+    /// let pattern = TriplePattern::new("?person", "knows", "Bob");
+    /// assert_eq!(pattern.subject, "?person");
+    /// assert_eq!(pattern.predicate, "knows");
+    /// assert_eq!(pattern.object, "Bob");
+    /// ```
     pub fn new(subject: &str, predicate: &str, object: &str) -> Self {
         Self {
             subject: subject.to_string(),


### PR DESCRIPTION
- 📖 Chapter: The `KnowledgeGraph` module
- 🔦 Insight: Explained how to insert triples and construct patterns for querying the knowledge graph.
- 🧪 Example: Added executable doctests to `KnowledgeGraph`, `TriplePattern`, and their methods.

---
*PR created automatically by Jules for task [14323225448652120474](https://jules.google.com/task/14323225448652120474) started by @madmax983*