### PR TITLE
⚒️ Forge: Refactor visualizer to_dot method

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -627,3 +627,7 @@ Build it right, make it fast, keep it simple.
 ## 2026-05-01 - Extract God Function in CYK Parser
 **Learning:** `relvar/src/experimental/parser.rs` contained a "God Function" `parse` (over 65 lines) which combined initializing the parse table, generating new entries, and looping until fixpoint.
 **Action:** Applied the 'Three-Phase Operator' pattern by extracting `initialize_parse_table` and `compute_new_entries` into separate private helper functions to dramatically improve readability and modularity without changing behavior.
+
+## 2024-05-24 - Visualizer Refactoring
+**Learning:** `relvar/src/tools/visualizer.rs` had a `to_dot` function that was becoming a "God Function" (nearly 90 lines long) with deep nesting and multiple responsibilities (generating nodes, generating edges, formatting).
+**Action:** Extracted the core loop bodies into helper functions `generate_node`, `get_primary_key_attributes`, and `generate_edges` to significantly flatten the structure and make `to_dot` much easier to read and maintain.

--- a/relvar/src/tools/visualizer.rs
+++ b/relvar/src/tools/visualizer.rs
@@ -106,82 +106,90 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
 
         // 1. Generate nodes (Tables)
         for name in &relvars {
-            // Note: We use get_relvar_type() to get the relation structure.
-            // This avoids loading the full relation data.
-            if let Ok(relation_type) = self.db.get_relvar_type(name) {
-                let tuple_type = relation_type.tuple_type();
-
-                // Determine primary key attributes
-                let pk_attrs = if let Some(key_constraints) = self.db.get_key_constraints(name) {
-                    if let Some(pk) = key_constraints.primary_key() {
-                        pk.attributes().to_vec()
-                    } else {
-                        Vec::new()
-                    }
-                } else {
-                    Vec::new()
-                };
-
-                let node_id = escape_dot_id(name);
-                let table_title = escape_html(name);
-
-                dot.push_str(&format!(
-                    "    {} [label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\" cellpadding=\"4\">\n",
-                    node_id
-                ));
-                dot.push_str(&format!(
-                    "        <tr><td bgcolor=\"lightgrey\" colspan=\"2\"><b>{}</b></td></tr>\n",
-                    table_title
-                ));
-
-                // Sort attributes for consistent output
-                let mut attributes: Vec<_> = tuple_type.attributes().iter().collect();
-                attributes.sort_by(|a, b| a.0.cmp(b.0));
-
-                for (attr_name, scalar_type) in attributes {
-                    let is_pk = pk_attrs.contains(attr_name);
-                    let safe_attr_name = escape_html(attr_name);
-
-                    let display_name = if is_pk {
-                        format!("<u>{}</u>", safe_attr_name)
-                    } else {
-                        safe_attr_name
-                    };
-
-                    // Note: scalar_type implements Debug, which might contain special chars.
-                    // Ideally we'd escape that too, strictly speaking.
-                    let safe_type = escape_html(&format!("{:?}", scalar_type));
-
-                    dot.push_str(&format!(
-                        "        <tr><td align=\"left\">{}</td><td align=\"left\">{}</td></tr>\n",
-                        display_name, safe_type
-                    ));
-                }
-                dot.push_str("    </table>>];\n\n");
-            }
+            self.generate_node(&mut dot, name);
         }
 
         // 2. Generate edges (Foreign Keys)
         for name in &relvars {
-            if let Some(fk_constraints) = self.db.get_foreign_key_constraints(name) {
-                for fk in fk_constraints.foreign_keys() {
-                    let ref_table = fk.referenced_relation_name();
-                    let cols = fk.foreign_key_attributes().join(", ");
-
-                    let source_id = escape_dot_id(name);
-                    let target_id = escape_dot_id(ref_table);
-                    let label = escape_dot_string_content(&cols);
-
-                    dot.push_str(&format!(
-                        "    {} -> {} [label=\"({})\"];\n",
-                        source_id, target_id, label
-                    ));
-                }
-            }
+            self.generate_edges(&mut dot, name);
         }
 
         dot.push_str("}\n");
         dot
+    }
+
+    fn generate_node(&self, dot: &mut String, name: &str) {
+        let Ok(relation_type) = self.db.get_relvar_type(name) else {
+            return;
+        };
+
+        let tuple_type = relation_type.tuple_type();
+        let pk_attrs = self.get_primary_key_attributes(name);
+
+        let node_id = escape_dot_id(name);
+        let table_title = escape_html(name);
+
+        dot.push_str(&format!(
+            "    {} [label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\" cellpadding=\"4\">\n",
+            node_id
+        ));
+        dot.push_str(&format!(
+            "        <tr><td bgcolor=\"lightgrey\" colspan=\"2\"><b>{}</b></td></tr>\n",
+            table_title
+        ));
+
+        // Sort attributes for consistent output
+        let mut attributes: Vec<_> = tuple_type.attributes().iter().collect();
+        attributes.sort_by(|a, b| a.0.cmp(b.0));
+
+        for (attr_name, scalar_type) in attributes {
+            let is_pk = pk_attrs.contains(attr_name);
+            let safe_attr_name = escape_html(attr_name);
+
+            let display_name = if is_pk {
+                format!("<u>{}</u>", safe_attr_name)
+            } else {
+                safe_attr_name
+            };
+
+            // Note: scalar_type implements Debug, which might contain special chars.
+            // Ideally we'd escape that too, strictly speaking.
+            let safe_type = escape_html(&format!("{:?}", scalar_type));
+
+            dot.push_str(&format!(
+                "        <tr><td align=\"left\">{}</td><td align=\"left\">{}</td></tr>\n",
+                display_name, safe_type
+            ));
+        }
+        dot.push_str("    </table>>];\n\n");
+    }
+
+    fn get_primary_key_attributes(&self, name: &str) -> Vec<String> {
+        self.db
+            .get_key_constraints(name)
+            .and_then(|kc| kc.primary_key())
+            .map(|pk| pk.attributes().to_vec())
+            .unwrap_or_default()
+    }
+
+    fn generate_edges(&self, dot: &mut String, name: &str) {
+        let Some(fk_constraints) = self.db.get_foreign_key_constraints(name) else {
+            return;
+        };
+
+        for fk in fk_constraints.foreign_keys() {
+            let ref_table = fk.referenced_relation_name();
+            let cols = fk.foreign_key_attributes().join(", ");
+
+            let source_id = escape_dot_id(name);
+            let target_id = escape_dot_id(ref_table);
+            let label = escape_dot_string_content(&cols);
+
+            dot.push_str(&format!(
+                "    {} -> {} [label=\"({})\"];\n",
+                source_id, target_id, label
+            ));
+        }
     }
 }
 


### PR DESCRIPTION
🛁 Smell: `to_dot` in `relvar/src/tools/visualizer.rs` was a 90-line "God Function" with deep nesting and multiple responsibilities.
✨ Solution: Extracted logic into `generate_node`, `get_primary_key_attributes`, and `generate_edges` helper functions.
🧼 Benefit: Significantly flattens structure and improves readability, adhering to idiomatic Rust.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [11657761700710592163](https://jules.google.com/task/11657761700710592163) started by @madmax983*