### PR TITLE
⚡ Bolt: [performance improvement] Avoid string allocations in divide operator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -51,3 +51,6 @@
 ## 2026-05-01 - Avoided Arc clone in DML loop
 **Learning:** `Arc<TupleType>::clone()` incurs reference counting overhead and potential allocation overhead, taking around 14ms per 10k tuple creations as shown in `tuple_creation` bench.
 **Action:** Always borrow reference from wrapper container types instead of cloning Arc explicitly if the borrow lifetime spans the whole needed lifetime block, like `tuple.conforms_to(relation_type.tuple_type())` instead of `.clone()`ing `expected_type`.
+## 2026-05-21 - [Vec<&str> String Allocation Avoidance]
+**Learning:** Returning `Vec<String>` from internal pre-calculation helpers like `compute_remainder_attributes` or `common_attributes` causes operations (like projecting in `divide`) to map and collect those strings unnecessarily. This adds significant heap allocations inside loops or filter chains.
+**Action:** By explicitly changing the return type to `Vec<&str>` where lifetimes allow (e.g. slicing references tied to the original headers), the operations can slice and pass atomic references rather than allocating and pushing full `String`s. This drops time and space complexity during mapped iterations from O(N * C) (C being attribute string length) to essentially O(N).

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,4 +1,0 @@
-💡 What: Optimized `compute_relation_after_update` in `relvar-core/src/database/dml.rs` to borrow `expected_type` as a reference rather than unnecessarily calling `.clone()` on the underlying `Arc<TupleType>`.
-🎯 Why: Avoiding an unnecessary clone call on `Arc<TupleType>` during data modifications. This `Arc` clone was happening repeatedly during setup of the update operations and could easily be avoided by borrowing a reference instead.
-📊 Impact: Minor speedup and removal of an unnecessary clone operation overhead, which could matter under heavy multi-threaded workloads where atomic refcounts are heavily contended. The `tuple_creation` bench showed a minor performance improvement.
-🔬 Measurement: Run bench `tuple_creation` / `group_bench`.

--- a/relvar-core/src/algebra/divide.rs
+++ b/relvar-core/src/algebra/divide.rs
@@ -174,14 +174,14 @@ fn validate_division_compatibility(
 
 /// Compute remainder attributes (dividend - divisor).
 /// Returns error if remainder is empty.
-fn compute_remainder_attributes(
-    dividend_heading: &crate::types::TupleType,
+fn compute_remainder_attributes<'a>(
+    dividend_heading: &'a crate::types::TupleType,
     divisor_heading: &crate::types::TupleType,
-) -> Result<Vec<String>, DivideError> {
-    let remainder_attrs: Vec<String> = dividend_heading
+) -> Result<Vec<&'a str>, DivideError> {
+    let remainder_attrs: Vec<&'a str> = dividend_heading
         .attribute_names()
         .filter(|attr| !divisor_heading.has_attribute(attr))
-        .cloned()
+        .map(|s| s.as_str())
         .collect();
 
     if remainder_attrs.is_empty() {
@@ -192,9 +192,8 @@ fn compute_remainder_attributes(
 }
 
 /// Project relation onto specified attributes.
-fn project_onto_attrs(relation: &Relation, attrs: &[String]) -> Relation {
-    let attr_refs: Vec<&str> = attrs.iter().map(|s| s.as_str()).collect();
-    relation.project(&attr_refs)
+fn project_onto_attrs(relation: &Relation, attrs: &[&str]) -> Relation {
+    relation.project(attrs)
 }
 
 /// Filter candidate tuples, keeping only those where ALL divisor tuples


### PR DESCRIPTION
💡 What: Optimized the `divide` operator by avoiding unnecessary `String` allocations during projection. Replaced `Vec<String>` with `Vec<&str>` in the return type of `compute_remainder_attributes`.
🎯 Why: Because `project_onto_attrs` only requires string references, mapping and cloning strings into a `Vec<String>` inside `compute_remainder_attributes` resulted in an unneeded heap allocation and copy for every attribute string. Returning sliced references tied to the original header (`dividend_heading`) eliminates this completely.
📊 Impact: Removes the dynamic string allocation overhead (which drops operations from O(C) length bounds to pure O(1) reference collections) directly inside the relation evaluation pipeline.
🔬 Measurement: Run `cargo test -p relvar-core` to verify all mathematical tests pass securely.

---
*PR created automatically by Jules for task [14223104609362594692](https://jules.google.com/task/14223104609362594692) started by @madmax983*