### PR TITLE
⚒️ Forge: Refactor to_dot visualizer

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -627,3 +627,6 @@ Build it right, make it fast, keep it simple.
 ## 2026-05-01 - Extract God Function in CYK Parser
 **Learning:** `relvar/src/experimental/parser.rs` contained a "God Function" `parse` (over 65 lines) which combined initializing the parse table, generating new entries, and looping until fixpoint.
 **Action:** Applied the 'Three-Phase Operator' pattern by extracting `initialize_parse_table` and `compute_new_entries` into separate private helper functions to dramatically improve readability and modularity without changing behavior.
+## 2026-05-07 - Refactoring God Function to_dot
+**Learning:** The `to_dot` visualizer method had become extremely long (God Function) and deeply nested (Pyramid of Doom), making it hard to follow. Extracting generation logic into separate node and edge helper methods, and using an iterator chain (`.and_then().map().unwrap_or_default()`) over deeply nested `if let Some()` drastically improves clarity without altering functionality.
+**Action:** Proactively scan for God Functions with deep nesting during refactoring and use early returns/iterator combinators when extracting them into smaller focused methods.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,4 +1,0 @@
-💡 What: Optimized `compute_relation_after_update` in `relvar-core/src/database/dml.rs` to borrow `expected_type` as a reference rather than unnecessarily calling `.clone()` on the underlying `Arc<TupleType>`.
-🎯 Why: Avoiding an unnecessary clone call on `Arc<TupleType>` during data modifications. This `Arc` clone was happening repeatedly during setup of the update operations and could easily be avoided by borrowing a reference instead.
-📊 Impact: Minor speedup and removal of an unnecessary clone operation overhead, which could matter under heavy multi-threaded workloads where atomic refcounts are heavily contended. The `tuple_creation` bench showed a minor performance improvement.
-🔬 Measurement: Run bench `tuple_creation` / `group_bench`.

--- a/relvar/src/tools/visualizer.rs
+++ b/relvar/src/tools/visualizer.rs
@@ -106,82 +106,91 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
 
         // 1. Generate nodes (Tables)
         for name in &relvars {
-            // Note: We use get_relvar_type() to get the relation structure.
-            // This avoids loading the full relation data.
-            if let Ok(relation_type) = self.db.get_relvar_type(name) {
-                let tuple_type = relation_type.tuple_type();
-
-                // Determine primary key attributes
-                let pk_attrs = if let Some(key_constraints) = self.db.get_key_constraints(name) {
-                    if let Some(pk) = key_constraints.primary_key() {
-                        pk.attributes().to_vec()
-                    } else {
-                        Vec::new()
-                    }
-                } else {
-                    Vec::new()
-                };
-
-                let node_id = escape_dot_id(name);
-                let table_title = escape_html(name);
-
-                dot.push_str(&format!(
-                    "    {} [label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\" cellpadding=\"4\">\n",
-                    node_id
-                ));
-                dot.push_str(&format!(
-                    "        <tr><td bgcolor=\"lightgrey\" colspan=\"2\"><b>{}</b></td></tr>\n",
-                    table_title
-                ));
-
-                // Sort attributes for consistent output
-                let mut attributes: Vec<_> = tuple_type.attributes().iter().collect();
-                attributes.sort_by(|a, b| a.0.cmp(b.0));
-
-                for (attr_name, scalar_type) in attributes {
-                    let is_pk = pk_attrs.contains(attr_name);
-                    let safe_attr_name = escape_html(attr_name);
-
-                    let display_name = if is_pk {
-                        format!("<u>{}</u>", safe_attr_name)
-                    } else {
-                        safe_attr_name
-                    };
-
-                    // Note: scalar_type implements Debug, which might contain special chars.
-                    // Ideally we'd escape that too, strictly speaking.
-                    let safe_type = escape_html(&format!("{:?}", scalar_type));
-
-                    dot.push_str(&format!(
-                        "        <tr><td align=\"left\">{}</td><td align=\"left\">{}</td></tr>\n",
-                        display_name, safe_type
-                    ));
-                }
-                dot.push_str("    </table>>];\n\n");
-            }
+            self.append_node_for_relvar(&mut dot, name);
         }
 
         // 2. Generate edges (Foreign Keys)
         for name in &relvars {
-            if let Some(fk_constraints) = self.db.get_foreign_key_constraints(name) {
-                for fk in fk_constraints.foreign_keys() {
-                    let ref_table = fk.referenced_relation_name();
-                    let cols = fk.foreign_key_attributes().join(", ");
-
-                    let source_id = escape_dot_id(name);
-                    let target_id = escape_dot_id(ref_table);
-                    let label = escape_dot_string_content(&cols);
-
-                    dot.push_str(&format!(
-                        "    {} -> {} [label=\"({})\"];\n",
-                        source_id, target_id, label
-                    ));
-                }
-            }
+            self.append_edges_for_relvar(&mut dot, name);
         }
 
         dot.push_str("}\n");
         dot
+    }
+
+    fn append_node_for_relvar(&self, dot: &mut String, name: &str) {
+        // Note: We use get_relvar_type() to get the relation structure.
+        // This avoids loading the full relation data.
+        let Ok(relation_type) = self.db.get_relvar_type(name) else {
+            return;
+        };
+
+        let tuple_type = relation_type.tuple_type();
+
+        // Determine primary key attributes
+        let pk_attrs = self
+            .db
+            .get_key_constraints(name)
+            .and_then(|kc| kc.primary_key())
+            .map(|pk| pk.attributes().to_vec())
+            .unwrap_or_default();
+
+        let node_id = escape_dot_id(name);
+        let table_title = escape_html(name);
+
+        dot.push_str(&format!(
+            "    {} [label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\" cellpadding=\"4\">\n",
+            node_id
+        ));
+        dot.push_str(&format!(
+            "        <tr><td bgcolor=\"lightgrey\" colspan=\"2\"><b>{}</b></td></tr>\n",
+            table_title
+        ));
+
+        // Sort attributes for consistent output
+        let mut attributes: Vec<_> = tuple_type.attributes().iter().collect();
+        attributes.sort_by(|a, b| a.0.cmp(b.0));
+
+        for (attr_name, scalar_type) in attributes {
+            let is_pk = pk_attrs.contains(attr_name);
+            let safe_attr_name = escape_html(attr_name);
+
+            let display_name = if is_pk {
+                format!("<u>{}</u>", safe_attr_name)
+            } else {
+                safe_attr_name
+            };
+
+            // Note: scalar_type implements Debug, which might contain special chars.
+            // Ideally we'd escape that too, strictly speaking.
+            let safe_type = escape_html(&format!("{:?}", scalar_type));
+
+            dot.push_str(&format!(
+                "        <tr><td align=\"left\">{}</td><td align=\"left\">{}</td></tr>\n",
+                display_name, safe_type
+            ));
+        }
+        dot.push_str("    </table>>];\n\n");
+    }
+
+    fn append_edges_for_relvar(&self, dot: &mut String, name: &str) {
+        let Some(fk_constraints) = self.db.get_foreign_key_constraints(name) else {
+            return;
+        };
+
+        for fk in fk_constraints.foreign_keys() {
+            let ref_table = fk.referenced_relation_name();
+            let cols = fk.foreign_key_attributes().join(", ");
+
+            let source_id = escape_dot_id(name);
+            let target_id = escape_dot_id(ref_table);
+            let label = escape_dot_string_content(&cols);
+
+            dot.push_str(&format!(
+                "    {} -> {} [label=\"({})\"];\n",
+                source_id, target_id, label
+            ));
+        }
     }
 }
 


### PR DESCRIPTION
🚮 Smell: The `to_dot` function in `relvar/src/tools/visualizer.rs` was a "God Function" at 87 lines long. It suffered from the "Pyramid of Doom" pattern with deeply nested `if let Some` blocks used to calculate primary keys, mixing table and edge generation in a single monolithic method.
✨ Solution: Extracted the node and edge generation blocks into dedicated, private helper methods (`append_node_for_relvar` and `append_edges_for_relvar`). Flattened the deeply nested `if let` logic for primary keys using cleaner iterator combinators (`.and_then()`, `.map()`, `.unwrap_or_default()`) and employed guard clauses (`let Ok(...) = ... else { return; }`) for cleaner control flow.
🧼 Benefit: Significantly reduces cognitive load. The main `to_dot` function is now purely declarative, and individual generation steps are isolated and strictly typed without altering any runtime output.
🛡️ Verification: Tests passed. No logic changed. Checked with `cargo fmt`, `cargo clippy`, and `cargo test`.

---
*PR created automatically by Jules for task [16862718479168824103](https://jules.google.com/task/16862718479168824103) started by @madmax983*