### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,4 +1,0 @@
-💡 What: Optimized `compute_relation_after_update` in `relvar-core/src/database/dml.rs` to borrow `expected_type` as a reference rather than unnecessarily calling `.clone()` on the underlying `Arc<TupleType>`.
-🎯 Why: Avoiding an unnecessary clone call on `Arc<TupleType>` during data modifications. This `Arc` clone was happening repeatedly during setup of the update operations and could easily be avoided by borrowing a reference instead.
-📊 Impact: Minor speedup and removal of an unnecessary clone operation overhead, which could matter under heavy multi-threaded workloads where atomic refcounts are heavily contended. The `tuple_creation` bench showed a minor performance improvement.
-🔬 Measurement: Run bench `tuple_creation` / `group_bench`.

--- a/relvar-core/src/experimental/knowledge_graph.rs
+++ b/relvar-core/src/experimental/knowledge_graph.rs
@@ -3,6 +3,22 @@ use crate::types::{RelationType, ScalarType, TupleType};
 use crate::values::Relation;
 
 /// A Knowledge Graph modeled purely using relational algebra.
+///
+/// # Examples
+///
+/// ```
+/// use relvar_core::experimental::knowledge_graph::{KnowledgeGraph, TriplePattern};
+///
+/// let mut kg = KnowledgeGraph::new();
+/// kg.insert("Alice", "knows", "Bob").unwrap();
+/// kg.insert("Alice", "age", "30").unwrap();
+///
+/// let patterns = vec![
+///     TriplePattern::new("Alice", "?predicate", "?object"),
+/// ];
+/// let results = kg.query(&patterns).unwrap();
+/// assert_eq!(results.cardinality(), 2);
+/// ```
 pub struct KnowledgeGraph {
     /// A single relation storing triples (subject, predicate, object)
     pub triples: Relation,
@@ -10,6 +26,15 @@ pub struct KnowledgeGraph {
 
 impl KnowledgeGraph {
     /// Create a new empty Knowledge Graph.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::KnowledgeGraph;
+    ///
+    /// let kg = KnowledgeGraph::new();
+    /// assert_eq!(kg.triples.cardinality(), 0);
+    /// ```
     pub fn new() -> Self {
         let heading = TupleType::new()
             .with_attribute("subject", ScalarType::String)
@@ -22,6 +47,16 @@ impl KnowledgeGraph {
     }
 
     /// Insert a new triple into the Knowledge Graph.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::KnowledgeGraph;
+    ///
+    /// let mut kg = KnowledgeGraph::new();
+    /// kg.insert("Alice", "knows", "Bob").unwrap();
+    /// assert_eq!(kg.triples.cardinality(), 1);
+    /// ```
     pub fn insert(
         &mut self,
         subject: &str,
@@ -41,6 +76,29 @@ impl KnowledgeGraph {
 
     /// Query the graph using a basic graph pattern (BGP).
     /// A pattern is represented as a list of `TriplePattern` structs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::{KnowledgeGraph, TriplePattern};
+    ///
+    /// let mut kg = KnowledgeGraph::new();
+    /// kg.insert("Alice", "knows", "Bob").unwrap();
+    /// kg.insert("Bob", "knows", "Charlie").unwrap();
+    ///
+    /// let patterns = vec![
+    ///     TriplePattern::new("Alice", "knows", "?friend"),
+    ///     TriplePattern::new("?friend", "knows", "?friends_friend"),
+    /// ];
+    /// let results = kg.query(&patterns).unwrap();
+    /// assert_eq!(results.cardinality(), 1);
+    ///
+    /// let expected = relvar_core::tuple! {
+    ///     friend: "Bob",
+    ///     friends_friend: "Charlie"
+    /// };
+    /// assert!(results.contains(&expected));
+    /// ```
     pub fn query(&self, patterns: &[TriplePattern]) -> Result<Relation, DatabaseError> {
         if patterns.is_empty() {
             return Err(DatabaseError::AlgebraError("Empty BGP".to_string()));
@@ -119,6 +177,17 @@ pub struct TriplePattern {
 
 impl TriplePattern {
     /// Create a new TriplePattern
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::TriplePattern;
+    ///
+    /// let pattern = TriplePattern::new("?subject", "knows", "Bob");
+    /// assert_eq!(pattern.subject, "?subject");
+    /// assert_eq!(pattern.predicate, "knows");
+    /// assert_eq!(pattern.object, "Bob");
+    /// ```
     pub fn new(subject: &str, predicate: &str, object: &str) -> Self {
         Self {
             subject: subject.to_string(),


### PR DESCRIPTION
📖 Chapter: The `KnowledgeGraph` module in `relvar-core/src/experimental/`
🔦 Insight: Explained the relational representation of graph queries by providing concrete usage examples for constructing and querying a knowledge graph.
🧪 Example: Added 5 executable doctests for `KnowledgeGraph`, `new`, `insert`, `query`, and `TriplePattern::new`.

---
*PR created automatically by Jules for task [4019282330999866552](https://jules.google.com/task/4019282330999866552) started by @madmax983*