### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -30,3 +30,6 @@
 ## 2024-05-18 - [Error Documentation]
 **Confusion:** Error enums were documented with simple `.to_string()` assertions, which was "Dead End" noise failing to explain how to recover.
 **Clarification:** Rewrote doc-tests to include rich `/// # Recovery` sections mapped to each variant, explaining exactly what the error means in the Relational context and how to fix it, using story-driven lore as per Bard's philosophy.
+## 2025-05-20 - The "KnowledgeGraph" Examples
+**Confusion:** The experimental `KnowledgeGraph` module was flagged by `find_undoc.py` for missing module-level documentation (`//!`) and lacking executable doc-tests (`/// # Examples` blocks) for its main struct, `TriplePattern`, and methods (`new`, `insert`, `query`). This lack of storytelling made it hard to understand how basic graph patterns are modeled relationally.
+**Clarification:** Added module-level documentation explaining the purpose of the experimental Knowledge Graph. Systematically added executable `/// # Examples` blocks demonstrating how to initialize the graph, insert triples, construct `TriplePattern` instances, and execute queries, fulfilling Bard's philosophy.

--- a/plan.md
+++ b/plan.md
@@ -1,2 +1,0 @@
-1. **Submit the clean audit report.**
-   - Since no active vulnerabilities were found during the investigation of `unsafe` blocks, bounds checking, buffer limits, and data serialization (verifying that they either safely bounded or properly capped), I will submit the PR to confirm the codebase is secure under the given scope.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,4 +1,0 @@
-💡 What: Optimized `compute_relation_after_update` in `relvar-core/src/database/dml.rs` to borrow `expected_type` as a reference rather than unnecessarily calling `.clone()` on the underlying `Arc<TupleType>`.
-🎯 Why: Avoiding an unnecessary clone call on `Arc<TupleType>` during data modifications. This `Arc` clone was happening repeatedly during setup of the update operations and could easily be avoided by borrowing a reference instead.
-📊 Impact: Minor speedup and removal of an unnecessary clone operation overhead, which could matter under heavy multi-threaded workloads where atomic refcounts are heavily contended. The `tuple_creation` bench showed a minor performance improvement.
-🔬 Measurement: Run bench `tuple_creation` / `group_bench`.

--- a/relvar-core/src/experimental/knowledge_graph.rs
+++ b/relvar-core/src/experimental/knowledge_graph.rs
@@ -1,8 +1,31 @@
+//! A Knowledge Graph built on top of the relational algebra.
+//!
+//! This module provides a basic experimental implementation of a Knowledge Graph
+//! where facts are stored as subject-predicate-object triples in a single relation.
+//! It supports querying the graph using Basic Graph Patterns (BGPs).
+
 use crate::error::DatabaseError;
 use crate::types::{RelationType, ScalarType, TupleType};
 use crate::values::Relation;
 
 /// A Knowledge Graph modeled purely using relational algebra.
+/// # Examples
+///
+/// ```
+/// use relvar_core::experimental::knowledge_graph::{KnowledgeGraph, TriplePattern};
+///
+/// let mut kg = KnowledgeGraph::new();
+/// kg.insert("Alice", "knows", "Bob").unwrap();
+/// kg.insert("Bob", "knows", "Charlie").unwrap();
+///
+/// let patterns = vec![
+///     TriplePattern::new("Alice", "knows", "?friend"),
+///     TriplePattern::new("?friend", "knows", "?friend_of_friend"),
+/// ];
+///
+/// let results = kg.query(&patterns).unwrap();
+/// assert_eq!(results.cardinality(), 1);
+/// ```
 pub struct KnowledgeGraph {
     /// A single relation storing triples (subject, predicate, object)
     pub triples: Relation,
@@ -10,6 +33,14 @@ pub struct KnowledgeGraph {
 
 impl KnowledgeGraph {
     /// Create a new empty Knowledge Graph.
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::KnowledgeGraph;
+    ///
+    /// let kg = KnowledgeGraph::new();
+    /// assert_eq!(kg.triples.cardinality(), 0);
+    /// ```
     pub fn new() -> Self {
         let heading = TupleType::new()
             .with_attribute("subject", ScalarType::String)
@@ -22,6 +53,15 @@ impl KnowledgeGraph {
     }
 
     /// Insert a new triple into the Knowledge Graph.
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::KnowledgeGraph;
+    ///
+    /// let mut kg = KnowledgeGraph::new();
+    /// kg.insert("Alice", "knows", "Bob").unwrap();
+    /// assert_eq!(kg.triples.cardinality(), 1);
+    /// ```
     pub fn insert(
         &mut self,
         subject: &str,
@@ -41,6 +81,21 @@ impl KnowledgeGraph {
 
     /// Query the graph using a basic graph pattern (BGP).
     /// A pattern is represented as a list of `TriplePattern` structs.
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::{KnowledgeGraph, TriplePattern};
+    ///
+    /// let mut kg = KnowledgeGraph::new();
+    /// kg.insert("Alice", "likes", "Apples").unwrap();
+    ///
+    /// let patterns = vec![
+    ///     TriplePattern::new("Alice", "likes", "?fruit"),
+    /// ];
+    ///
+    /// let result = kg.query(&patterns).unwrap();
+    /// assert_eq!(result.cardinality(), 1);
+    /// ```
     pub fn query(&self, patterns: &[TriplePattern]) -> Result<Relation, DatabaseError> {
         if patterns.is_empty() {
             return Err(DatabaseError::AlgebraError("Empty BGP".to_string()));
@@ -107,6 +162,15 @@ impl KnowledgeGraph {
 
 /// Represents a single pattern to match in the graph.
 /// A node can be either a variable (starts with '?') or a concrete value.
+/// # Examples
+///
+/// ```
+/// use relvar_core::experimental::knowledge_graph::TriplePattern;
+///
+/// let pattern = TriplePattern::new("Alice", "knows", "?friend");
+/// assert_eq!(pattern.subject, "Alice");
+/// assert_eq!(pattern.object, "?friend");
+/// ```
 #[derive(Debug, Clone)]
 pub struct TriplePattern {
     /// Subject
@@ -119,6 +183,14 @@ pub struct TriplePattern {
 
 impl TriplePattern {
     /// Create a new TriplePattern
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::TriplePattern;
+    ///
+    /// // A pattern matching any subject that 'knows' Bob.
+    /// let pattern = TriplePattern::new("?subject", "knows", "Bob");
+    /// ```
     pub fn new(subject: &str, predicate: &str, object: &str) -> Self {
         Self {
             subject: subject.to_string(),


### PR DESCRIPTION
📖 Chapter: The `KnowledgeGraph` module in `relvar-core`

🔦 Insight: The experimental `KnowledgeGraph` lacked both module-level documentation and executable examples. It was entirely unclear how users were expected to use `TriplePattern` to match subjects, predicates, and objects within the relational store.

🧪 Example: Added comprehensive executable doctests demonstrating how to instantiate the graph, insert triples, formulate queries with variables (`?friend`), and traverse the relations securely.

🖼️ Preview: Documentation is now visible and passes `cargo doc`.

---
*PR created automatically by Jules for task [3611978991666623440](https://jules.google.com/task/3611978991666623440) started by @madmax983*