### PR TITLE
⚡ Bolt: Avoid Vec allocation in query AST builder methods

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -51,3 +51,7 @@
 ## 2026-05-01 - Avoided Arc clone in DML loop
 **Learning:** `Arc<TupleType>::clone()` incurs reference counting overhead and potential allocation overhead, taking around 14ms per 10k tuple creations as shown in `tuple_creation` bench.
 **Action:** Always borrow reference from wrapper container types instead of cloning Arc explicitly if the borrow lifetime spans the whole needed lifetime block, like `tuple.conforms_to(relation_type.tuple_type())` instead of `.clone()`ing `expected_type`.
+
+## 2024-05-15 - [Avoid `Vec` allocation in query AST builder methods]
+**Learning:** `IntoIterator` can be used to accept both arrays (`["a", "b"]`) and Vec (`vec!["a", "b"]`) to avoid intermediate heap allocation from using `.collect()` when calling API methods.
+**Action:** Replace `Vec<T>` inputs with `IntoIterator<Item = T>` in API builders where intermediate conversions or slices are common.

--- a/fix_query_docs.py
+++ b/fix_query_docs.py
@@ -1,0 +1,11 @@
+with open("relvar-core/src/query/mod.rs", "r") as f:
+    content = f.read()
+
+content = content.replace("    pub fn project<S: Into<String>, I: IntoIterator<Item = S>>(self, attributes: I) -> Self {", "    /// **Optimization**: Accepts `IntoIterator` to allow passing stack-allocated arrays\n    /// (e.g., `[\"a\", \"b\"]`) instead of requiring heap-allocated vectors (`vec![\"a\", \"b\"]`).\n    pub fn project<S: Into<String>, I: IntoIterator<Item = S>>(self, attributes: I) -> Self {")
+
+content = content.replace("    pub fn rename<S1: Into<String>, S2: Into<String>, I: IntoIterator<Item = (S1, S2)>>(\n        self,\n        mappings: I,\n    ) -> Self {", "    /// **Optimization**: Accepts `IntoIterator` to allow passing stack-allocated arrays\n    /// (e.g., `[(\"old\", \"new\")]`) instead of requiring heap-allocated vectors.\n    pub fn rename<S1: Into<String>, S2: Into<String>, I: IntoIterator<Item = (S1, S2)>>(\n        self,\n        mappings: I,\n    ) -> Self {")
+
+content = content.replace("    pub fn summarize<\n        S: Into<String>,\n        I: IntoIterator<Item = S>,\n        A: IntoIterator<Item = Aggregation>,\n    >(\n        self,\n        group_by: I,\n        aggregations: A,\n    ) -> Self {", "    /// **Optimization**: Accepts `IntoIterator` for both `group_by` and `aggregations`\n    /// to allow passing stack-allocated arrays instead of requiring heap-allocated vectors.\n    pub fn summarize<\n        S: Into<String>,\n        I: IntoIterator<Item = S>,\n        A: IntoIterator<Item = Aggregation>,\n    >(\n        self,\n        group_by: I,\n        aggregations: A,\n    ) -> Self {")
+
+with open("relvar-core/src/query/mod.rs", "w") as f:
+    f.write(content)

--- a/fix_query_tests.py
+++ b/fix_query_tests.py
@@ -1,0 +1,16 @@
+with open("relvar-core/src/query/mod.rs", "r") as f:
+    content = f.read()
+
+content = content.replace('.project(vec!["name", "email"]);', '.project(["name", "email"]);')
+content = content.replace('.rename(vec![("name", "full_name")]);', '.rename([("name", "full_name")]);')
+content = content.replace('.summarize(vec!["department"], vec![Aggregation::count("emp_count")]);', '.summarize(["department"], [Aggregation::count("emp_count")]);')
+
+content = content.replace('.project(vec!["name"]);', '.project(["name"]);')
+content = content.replace('.rename(vec![("name", "full_name")]);', '.rename([("name", "full_name")]);')
+content = content.replace('.summarize(vec!["age"], vec![Aggregation::count("count")]);', '.summarize(["age"], [Aggregation::count("count")]);')
+content = content.replace('.rename(vec![("old", "new")]);', '.rename([("old", "new")]);')
+content = content.replace('.summarize(vec!["a"], vec![Aggregation::count("cnt")]);', '.summarize(["a"], [Aggregation::count("cnt")]);')
+content = content.replace('.summarize(vec!["nonexistent_col"], vec![]);', '.summarize(["nonexistent_col"], []);')
+
+with open("relvar-core/src/query/mod.rs", "w") as f:
+    f.write(content)

--- a/pr.py
+++ b/pr.py
@@ -4,4 +4,4 @@ import os
 with open("pr_description.md") as f:
     body = f.read()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+print(f"Submitting PR with title: ⚡ Bolt: Avoid Vec allocation in query AST builder methods\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,4 +1,0 @@
-💡 What: Optimized `compute_relation_after_update` in `relvar-core/src/database/dml.rs` to borrow `expected_type` as a reference rather than unnecessarily calling `.clone()` on the underlying `Arc<TupleType>`.
-🎯 Why: Avoiding an unnecessary clone call on `Arc<TupleType>` during data modifications. This `Arc` clone was happening repeatedly during setup of the update operations and could easily be avoided by borrowing a reference instead.
-📊 Impact: Minor speedup and removal of an unnecessary clone operation overhead, which could matter under heavy multi-threaded workloads where atomic refcounts are heavily contended. The `tuple_creation` bench showed a minor performance improvement.
-🔬 Measurement: Run bench `tuple_creation` / `group_bench`.

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -30,7 +30,7 @@
 //!         op: CmpOp::Eq,
 //!         right: ValueOrRef::Value(ScalarValue::Int(1)),
 //!     })
-//!     .project(vec!["name"]);
+//!     .project(["name"]);
 //!
 //! // Execute
 //! let result = query.execute(&db).unwrap();
@@ -369,9 +369,11 @@ impl Query {
     /// ```
     /// use relvar_core::query::Query;
     ///
-    /// let q = Query::scan("USERS").project(vec!["name", "email"]);
+    /// let q = Query::scan("USERS").project(["name", "email"]);
     /// ```
-    pub fn project<S: Into<String>>(self, attributes: Vec<S>) -> Self {
+    /// **Optimization**: Accepts `IntoIterator` to allow passing stack-allocated arrays
+    /// (e.g., `["a", "b"]`) instead of requiring heap-allocated vectors (`vec!["a", "b"]`).
+    pub fn project<S: Into<String>, I: IntoIterator<Item = S>>(self, attributes: I) -> Self {
         Query::Project {
             input: Box::new(self),
             attributes: attributes.into_iter().map(|s| s.into()).collect(),
@@ -384,9 +386,14 @@ impl Query {
     /// ```
     /// use relvar_core::query::Query;
     ///
-    /// let q = Query::scan("USERS").rename(vec![("name", "full_name")]);
+    /// let q = Query::scan("USERS").rename([("name", "full_name")]);
     /// ```
-    pub fn rename<S1: Into<String>, S2: Into<String>>(self, mappings: Vec<(S1, S2)>) -> Self {
+    /// **Optimization**: Accepts `IntoIterator` to allow passing stack-allocated arrays
+    /// (e.g., `[("old", "new")]`) instead of requiring heap-allocated vectors.
+    pub fn rename<S1: Into<String>, S2: Into<String>, I: IntoIterator<Item = (S1, S2)>>(
+        self,
+        mappings: I,
+    ) -> Self {
         Query::Rename {
             input: Box::new(self),
             mappings: mappings
@@ -420,17 +427,23 @@ impl Query {
     /// use relvar_core::query::Query;
     /// use relvar_core::algebra::Aggregation;
     ///
-    /// let q = Query::scan("USERS").summarize(vec!["department"], vec![Aggregation::count("emp_count")]);
+    /// let q = Query::scan("USERS").summarize(["department"], [Aggregation::count("emp_count")]);
     /// ```
-    pub fn summarize<S: Into<String>>(
+    /// **Optimization**: Accepts `IntoIterator` for both `group_by` and `aggregations`
+    /// to allow passing stack-allocated arrays instead of requiring heap-allocated vectors.
+    pub fn summarize<
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+        A: IntoIterator<Item = Aggregation>,
+    >(
         self,
-        group_by: Vec<S>,
-        aggregations: Vec<Aggregation>,
+        group_by: I,
+        aggregations: A,
     ) -> Self {
         Query::Summarize {
             input: Box::new(self),
             group_by: group_by.into_iter().map(|s| s.into()).collect(),
-            aggregations,
+            aggregations: aggregations.into_iter().collect(),
         }
     }
 }
@@ -529,7 +542,7 @@ mod tests {
     #[test]
     fn test_project() {
         let db = setup_db();
-        let query = Query::scan("USERS").project(vec!["name"]);
+        let query = Query::scan("USERS").project(["name"]);
 
         let result = query.execute(&db).unwrap();
         assert_eq!(result.degree(), 1);
@@ -539,7 +552,7 @@ mod tests {
     #[test]
     fn test_rename() {
         let db = setup_db();
-        let query = Query::scan("USERS").rename(vec![("name", "full_name")]);
+        let query = Query::scan("USERS").rename([("name", "full_name")]);
 
         let result = query.execute(&db).unwrap();
         assert!(result.relation_type().heading().has_attribute("full_name"));
@@ -562,7 +575,7 @@ mod tests {
     #[test]
     fn test_summarize() {
         let db = setup_db();
-        let query = Query::scan("USERS").summarize(vec!["age"], vec![Aggregation::count("count")]);
+        let query = Query::scan("USERS").summarize(["age"], [Aggregation::count("count")]);
         let result = query.execute(&db).unwrap();
 
         // One person with age 25, one with age 30
@@ -577,7 +590,7 @@ mod tests {
                 op: CmpOp::Eq,
                 right: ValueOrRef::Value(ScalarValue::Int(1)),
             })
-            .project(vec!["name"]);
+            .project(["name"]);
 
         let explain_str = query.explain();
         assert!(explain_str.contains("Project([\"name\"])"));
@@ -587,10 +600,10 @@ mod tests {
         let q_join = Query::scan("A").join(Query::scan("B"));
         assert!(q_join.explain().contains("Join"));
 
-        let q_rename = Query::scan("A").rename(vec![("old", "new")]);
+        let q_rename = Query::scan("A").rename([("old", "new")]);
         assert!(q_rename.explain().contains("Rename([(\"old\", \"new\")])"));
 
-        let q_summarize = Query::scan("A").summarize(vec!["a"], vec![Aggregation::count("cnt")]);
+        let q_summarize = Query::scan("A").summarize(["a"], [Aggregation::count("cnt")]);
         assert!(q_summarize.explain().contains("Summarize"));
     }
 
@@ -599,7 +612,7 @@ mod tests {
         let db = setup_db();
 
         // Algebra error in Summarize (grouping by missing attribute)
-        let q_bad_sum = Query::scan("USERS").summarize(vec!["nonexistent_col"], vec![]);
+        let q_bad_sum = Query::scan("USERS").summarize(["nonexistent_col"], []);
         let err = q_bad_sum.execute(&db);
         assert!(matches!(err, Err(QueryError::Algebra(_))));
     }


### PR DESCRIPTION
💡 What: Optimized query AST builder methods (`project`, `rename`, `summarize`) to accept `IntoIterator` instead of explicitly requiring `Vec`.
🎯 Why: Avoiding intermediate `Vec` allocations (e.g. `vec!["a", "b"]`) when using arrays or other iterators during query AST construction.
📊 Impact: Minor optimization that prevents one or more heap allocations per AST builder method invocation.
🔬 Measurement: Run `cargo test -p relvar-core` to verify correctly resolving array lengths.

---
*PR created automatically by Jules for task [2081601655027764554](https://jules.google.com/task/2081601655027764554) started by @madmax983*