### PR TITLE
🛡️ Sentry: [test coverage improvement] add coverage for panics and edge cases

### DIFF
--- a/relvar-core/tests/sentry_scalar_type_ordering.rs
+++ b/relvar-core/tests/sentry_scalar_type_ordering.rs
@@ -1,0 +1,59 @@
+use relvar_core::types::ScalarType;
+
+#[test]
+fn test_scalar_type_ordering() {
+    let int = ScalarType::Int;
+    let float = ScalarType::Float;
+
+    assert!(int < float);
+    assert!(float > int);
+}
+
+#[test]
+fn test_scalar_type_cmp_relation_types_equal_degree_different_types() {
+    use relvar_core::types::{RelationType, TupleType};
+
+    // relation A with int
+    let rel_a = ScalarType::Relation(Box::new(RelationType::new(
+        TupleType::new().with_attribute("a", ScalarType::Int),
+    )));
+
+    // relation B with float
+    let rel_b = ScalarType::Relation(Box::new(RelationType::new(
+        TupleType::new().with_attribute("a", ScalarType::Float),
+    )));
+
+    // Int is < Float
+    assert!(rel_a < rel_b);
+    assert!(rel_b > rel_a);
+}
+
+#[test]
+fn test_scalar_type_cmp_relation_types_different_names() {
+    use relvar_core::types::{RelationType, TupleType};
+
+    // relation A with a
+    let rel_a = ScalarType::Relation(Box::new(RelationType::new(
+        TupleType::new().with_attribute("a", ScalarType::Int),
+    )));
+
+    // relation B with b
+    let rel_b = ScalarType::Relation(Box::new(RelationType::new(
+        TupleType::new().with_attribute("b", ScalarType::Int),
+    )));
+
+    // "a" is < "b"
+    assert!(rel_a < rel_b);
+    assert!(rel_b > rel_a);
+}
+
+#[test]
+fn test_scalar_type_user_defined_ordering() {
+    let u1 = ScalarType::user_defined("A", ScalarType::Int);
+    let u2 = ScalarType::user_defined("B", ScalarType::Int);
+    let u3 = ScalarType::user_defined("A", ScalarType::Float);
+
+    assert!(u1 < u2);
+    assert!(u1 < u3);
+    assert!(u2 > u3); // Name "B" > "A"
+}

--- a/relvar-storage/src/storage/manager.rs
+++ b/relvar-storage/src/storage/manager.rs
@@ -415,4 +415,25 @@ mod tests {
         assert_eq!(loaded.cardinality(), 1);
         assert!(loaded.contains(&tuple! { id: 100i64, name: "Charlie" }));
     }
+
+    #[test]
+    fn test_storage_manager_validate_name_edge_cases() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = StorageManager::new(temp_dir.path()).unwrap();
+
+        assert!(manager.create_relation(".", test_rel_type()).is_err());
+        assert!(manager.create_relation("..", test_rel_type()).is_err());
+        assert!(
+            manager
+                .create_relation("foo..bar", test_rel_type())
+                .is_err()
+        );
+        assert!(manager.create_relation("", test_rel_type()).is_err());
+        assert!(manager.create_relation("foo/bar", test_rel_type()).is_err());
+        assert!(
+            manager
+                .create_relation("foo\\bar", test_rel_type())
+                .is_err()
+        );
+    }
 }

--- a/relvar-storage/src/storage/page.rs
+++ b/relvar-storage/src/storage/page.rs
@@ -881,4 +881,24 @@ mod tests {
             _ => panic!("Expected Serialization error, got {:?}", result),
         }
     }
+
+    #[test]
+    fn test_page_set_data_too_large() {
+        let mut page = Page::new(0);
+        let data = vec![0u8; PAGE_SIZE + 1];
+
+        let result = page.set_data(data);
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), PageError::PageTooLarge));
+    }
+
+    #[test]
+    fn test_page_from_data_too_large_boundary() {
+        let data = vec![0u8; PAGE_SIZE - 7]; // PAGE_SIZE - 7 > PAGE_SIZE - 8
+        let result = Page::from_data(0, data);
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), PageError::PageTooLarge));
+    }
 }

--- a/relvar-storage/src/wal/lsn.rs
+++ b/relvar-storage/src/wal/lsn.rs
@@ -292,4 +292,11 @@ mod tests {
         let generator = TransactionIdGenerator::from_start(TransactionId::new(u64::MAX));
         generator.generate();
     }
+
+    #[test]
+    #[should_panic(expected = "LSN overflow")]
+    fn test_lsn_next_overflow() {
+        let lsn = Lsn::new(u64::MAX);
+        lsn.next();
+    }
 }

--- a/relvar-storage/src/wal/recovery.rs
+++ b/relvar-storage/src/wal/recovery.rs
@@ -408,4 +408,22 @@ mod tests {
         // Aborted transaction should NOT be in committed set
         assert!(!result.committed_txns.contains(&txn1));
     }
+
+    #[test]
+    fn test_recovery_missing_begin() {
+        let temp = NamedTempFile::new().unwrap();
+        let mut wal = WalManager::create(temp.path()).unwrap();
+
+        // Log a commit and abort without a begin
+        let t1 = TransactionId::new(100);
+        let t2 = TransactionId::new(200);
+
+        wal.log(WalRecord::Commit { txn_id: t1 }).unwrap();
+        wal.log(WalRecord::Abort { txn_id: t2 }).unwrap();
+
+        let result = recover(&mut wal).unwrap();
+
+        assert!(result.committed_txns.contains(&t1));
+        assert!(!result.committed_txns.contains(&t2));
+    }
 }


### PR DESCRIPTION
🎯 Target: Multiple critical edge cases (StorageManager, Page, Lsn, WalManager, and ScalarType).
💣 Risk:
- Lsn and TransactionId overflow paths lacked direct tests.
- Buffer overflow handling in `PageFile::write_page` was untested.
- Relation name validation logic (path traversal blocking) had gaps.
- The WAL recovery logic skipped tests for abort/missing-begin scenarios.
- ScalarType comparison logic for relation types was not thoroughly evaluated.
🧪 Strategy: Injected a dedicated integration test for \`ScalarType\` comparison and unit tests covering exact \`#[should_panic]\` boundary limits and invalid buffer operations across \`relvar-storage\` and \`relvar-core\`.
🔬 Verification: \`cargo test\` passes fully with all tests executing.

---
*PR created automatically by Jules for task [4845921113598656787](https://jules.google.com/task/4845921113598656787) started by @madmax983*