### PR TITLE
⚒️ Forge: Refactor to_dot god function in visualizer.rs

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -627,3 +627,7 @@ Build it right, make it fast, keep it simple.
 ## 2026-05-01 - Extract God Function in CYK Parser
 **Learning:** `relvar/src/experimental/parser.rs` contained a "God Function" `parse` (over 65 lines) which combined initializing the parse table, generating new entries, and looping until fixpoint.
 **Action:** Applied the 'Three-Phase Operator' pattern by extracting `initialize_parse_table` and `compute_new_entries` into separate private helper functions to dramatically improve readability and modularity without changing behavior.
+
+## 2024-05-30 - Extract God Function in Visualizer to_dot
+**Learning:** `relvar/src/tools/visualizer.rs` contained a long function `to_dot` that combined generating nodes (tables) and edges (foreign keys) into a single function block.
+**Action:** Extract specific generation logic into `generate_nodes` and `generate_edges` helpers to improve code clarity without altering runtime behavior.

--- a/relvar/src/tools/visualizer.rs
+++ b/relvar/src/tools/visualizer.rs
@@ -104,8 +104,16 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
 
         let relvars = self.db.list_relvars();
 
+        self.generate_nodes(&relvars, &mut dot);
+        self.generate_edges(&relvars, &mut dot);
+
+        dot.push_str("}\n");
+        dot
+    }
+
+    fn generate_nodes(&self, relvars: &[String], dot: &mut String) {
         // 1. Generate nodes (Tables)
-        for name in &relvars {
+        for name in relvars {
             // Note: We use get_relvar_type() to get the relation structure.
             // This avoids loading the full relation data.
             if let Ok(relation_type) = self.db.get_relvar_type(name) {
@@ -160,9 +168,11 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
                 dot.push_str("    </table>>];\n\n");
             }
         }
+    }
 
+    fn generate_edges(&self, relvars: &[String], dot: &mut String) {
         // 2. Generate edges (Foreign Keys)
-        for name in &relvars {
+        for name in relvars {
             if let Some(fk_constraints) = self.db.get_foreign_key_constraints(name) {
                 for fk in fk_constraints.foreign_keys() {
                     let ref_table = fk.referenced_relation_name();
@@ -179,9 +189,6 @@ impl<'a, E: StorageEngine> SchemaVisualizer<'a, E> {
                 }
             }
         }
-
-        dot.push_str("}\n");
-        dot
     }
 }
 


### PR DESCRIPTION
🚮 Smell: The `to_dot` function in `visualizer.rs` was a 'God Function' (87 lines long) that mixed the logic for generating DOT code for nodes (tables) and edges (foreign keys) into a single monolithic block. This made the function difficult to read and maintain.

✨ Solution: Applied the 'Three-Phase Operator' pattern by extracting the node generation logic into a new `generate_nodes` private helper function, and the edge generation logic into a new `generate_edges` private helper function.

🧼 Benefit: The `to_dot` function is now vastly simplified, serving as a clean coordinator that delegates to clearly named helper functions. This flattens the structure and greatly improves readability.

🛡️ Verification: Tests passed. No logic changed. Visually verified the diff, ran `cargo fmt`, `cargo clippy`, and `cargo test`.

---
*PR created automatically by Jules for task [14786010153562361763](https://jules.google.com/task/14786010153562361763) started by @madmax983*