### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -30,3 +30,4 @@
 ## 2024-05-18 - [Error Documentation]
 **Confusion:** Error enums were documented with simple `.to_string()` assertions, which was "Dead End" noise failing to explain how to recover.
 **Clarification:** Rewrote doc-tests to include rich `/// # Recovery` sections mapped to each variant, explaining exactly what the error means in the Relational context and how to fix it, using story-driven lore as per Bard's philosophy.
+## 2025-05-20 - The "KnowledgeGraph" Examples\n**Confusion:** The experimental `KnowledgeGraph` module had no executable doc-tests for the main struct or its methods (`new`, `insert`, `query`, and `TriplePattern::new`). This lack of examples made it confusing to understand how to initialize the graph, insert triples, and execute Basic Graph Pattern queries.\n**Clarification:** Added executable `/// # Examples` doc-tests for `KnowledgeGraph` and all its core methods, demonstrating how to construct the graph and query variables successfully.

--- a/pr.py
+++ b/pr.py
@@ -4,4 +4,4 @@ import os
 with open("pr_description.md") as f:
     body = f.read()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+print(f"Submitting PR with title: 🎻 Bard: [documentation update]\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,4 +1,4 @@
-💡 What: Optimized `compute_relation_after_update` in `relvar-core/src/database/dml.rs` to borrow `expected_type` as a reference rather than unnecessarily calling `.clone()` on the underlying `Arc<TupleType>`.
-🎯 Why: Avoiding an unnecessary clone call on `Arc<TupleType>` during data modifications. This `Arc` clone was happening repeatedly during setup of the update operations and could easily be avoided by borrowing a reference instead.
-📊 Impact: Minor speedup and removal of an unnecessary clone operation overhead, which could matter under heavy multi-threaded workloads where atomic refcounts are heavily contended. The `tuple_creation` bench showed a minor performance improvement.
-🔬 Measurement: Run bench `tuple_creation` / `group_bench`.
+📖 Chapter: The `knowledge_graph` module
+🔦 Insight: Explained how to initialize a `KnowledgeGraph`, insert triples, and evaluate Basic Graph Patterns using relational operators.
+🧪 Example: Added 5 executable doctests to `KnowledgeGraph`, `new`, `insert`, `query`, and `TriplePattern::new`.
+🖼️ Preview: Docs successfully rendered and examples verify via `cargo test`.

--- a/relvar-core/src/experimental/knowledge_graph.rs
+++ b/relvar-core/src/experimental/knowledge_graph.rs
@@ -3,6 +3,16 @@ use crate::types::{RelationType, ScalarType, TupleType};
 use crate::values::Relation;
 
 /// A Knowledge Graph modeled purely using relational algebra.
+///
+/// # Examples
+/// ```
+/// use relvar_core::experimental::knowledge_graph::KnowledgeGraph;
+///
+/// let mut kg = KnowledgeGraph::new();
+/// kg.insert("Alice", "knows", "Bob").unwrap();
+///
+/// assert_eq!(kg.triples.cardinality(), 1);
+/// ```
 pub struct KnowledgeGraph {
     /// A single relation storing triples (subject, predicate, object)
     pub triples: Relation,
@@ -10,6 +20,14 @@ pub struct KnowledgeGraph {
 
 impl KnowledgeGraph {
     /// Create a new empty Knowledge Graph.
+    ///
+    /// # Examples
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::KnowledgeGraph;
+    ///
+    /// let kg = KnowledgeGraph::new();
+    /// assert_eq!(kg.triples.cardinality(), 0);
+    /// ```
     pub fn new() -> Self {
         let heading = TupleType::new()
             .with_attribute("subject", ScalarType::String)
@@ -22,6 +40,16 @@ impl KnowledgeGraph {
     }
 
     /// Insert a new triple into the Knowledge Graph.
+    ///
+    /// # Examples
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::KnowledgeGraph;
+    ///
+    /// let mut kg = KnowledgeGraph::new();
+    /// kg.insert("Alice", "knows", "Bob").unwrap();
+    ///
+    /// assert_eq!(kg.triples.cardinality(), 1);
+    /// ```
     pub fn insert(
         &mut self,
         subject: &str,
@@ -41,6 +69,25 @@ impl KnowledgeGraph {
 
     /// Query the graph using a basic graph pattern (BGP).
     /// A pattern is represented as a list of `TriplePattern` structs.
+    ///
+    /// # Examples
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::{KnowledgeGraph, TriplePattern};
+    ///
+    /// let mut kg = KnowledgeGraph::new();
+    /// kg.insert("Alice", "knows", "Bob").unwrap();
+    /// kg.insert("Bob", "knows", "Charlie").unwrap();
+    /// kg.insert("Bob", "age", "30").unwrap();
+    ///
+    /// // Query: Who does Alice know that also has an age?
+    /// let patterns = vec![
+    ///     TriplePattern::new("Alice", "knows", "?friend"),
+    ///     TriplePattern::new("?friend", "age", "?age"),
+    /// ];
+    ///
+    /// let result = kg.query(&patterns).unwrap();
+    /// assert_eq!(result.cardinality(), 1);
+    /// ```
     pub fn query(&self, patterns: &[TriplePattern]) -> Result<Relation, DatabaseError> {
         if patterns.is_empty() {
             return Err(DatabaseError::AlgebraError("Empty BGP".to_string()));
@@ -119,6 +166,17 @@ pub struct TriplePattern {
 
 impl TriplePattern {
     /// Create a new TriplePattern
+    ///
+    /// # Examples
+    /// ```
+    /// use relvar_core::experimental::knowledge_graph::TriplePattern;
+    ///
+    /// // A pattern with concrete values
+    /// let p1 = TriplePattern::new("Alice", "knows", "Bob");
+    ///
+    /// // A pattern with variables
+    /// let p2 = TriplePattern::new("?person", "knows", "?friend");
+    /// ```
     pub fn new(subject: &str, predicate: &str, object: &str) -> Self {
         Self {
             subject: subject.to_string(),


### PR DESCRIPTION
📖 Chapter: The `knowledge_graph` module
🔦 Insight: Explained how to initialize a `KnowledgeGraph`, insert triples, and evaluate Basic Graph Patterns using relational operators.
🧪 Example: Added 5 executable doctests to `KnowledgeGraph`, `new`, `insert`, `query`, and `TriplePattern::new`.
🖼️ Preview: Docs successfully rendered and examples verify via `cargo test`.

---
*PR created automatically by Jules for task [11233753472393142401](https://jules.google.com/task/11233753472393142401) started by @madmax983*