### PR TITLE
🗺️ Atlas: [architectural change] Encapsulate relvar-storage internal modules

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -27,3 +27,6 @@
 ## 2024-05-19 - Fixing Public Module Leaks
 **Tangle:** Broad visibility (`pub mod`) across many test and internal modules leaked implementation details and complicated the dependency graph.
 **Blueprint:** Converted most top-level internal module definitions in `relvar-core` and `relvar-storage` and `relvar` to `pub(crate) mod` where appropriate, and fixed some lingering pub use statements.
+## 2026-05-11 - Module Encapsulation Cleanup
+**Tangle:** Broad visibility (`pub mod`) across many internal modules in `relvar-storage` leaked implementation details and complicated the dependency graph.
+**Blueprint:** Converted most top-level internal module definitions in `relvar-storage` to `pub(crate) mod`. Re-exported necessary types via their respective `mod.rs` files, ensuring clean, intention-revealing public APIs while maintaining low coupling between internal components.

--- a/relvar-storage/benches/mvcc.rs
+++ b/relvar-storage/benches/mvcc.rs
@@ -9,7 +9,7 @@ use relvar_core::StorageEngine;
 use relvar_core::tuple;
 use relvar_core::types::{RelationType, ScalarType, TupleType};
 use relvar_core::values::Relation;
-use relvar_storage::persistent_engine::PersistentEngine;
+use relvar_storage::PersistentEngine;
 use tempfile::TempDir;
 
 fn create_test_relation_type() -> RelationType {

--- a/relvar-storage/benches/storage.rs
+++ b/relvar-storage/benches/storage.rs
@@ -4,7 +4,7 @@ use criterion::{
 use relvar_core::tuple;
 use relvar_core::types::{RelationType, ScalarType, TupleType};
 use relvar_core::values::Tuple;
-use relvar_storage::storage::{HeapFile, Page, PageFile};
+use relvar_storage::{HeapFile, Page, PageFile};
 use tempfile::NamedTempFile;
 
 fn create_test_relation_type() -> RelationType {

--- a/relvar-storage/src/lib.rs
+++ b/relvar-storage/src/lib.rs
@@ -104,7 +104,7 @@
 //! ### Using `HeapFile` (Low-level)
 //!
 //! ```no_run
-//! use relvar_storage::storage::HeapFile;
+//! use relvar_storage::HeapFile;
 //! use relvar_core::types::{RelationType, TupleType, ScalarType};
 //! use relvar_core::tuple;
 //!
@@ -128,8 +128,8 @@
 
 #![warn(missing_docs)]
 
-pub mod persistent_engine;
-pub mod storage;
+pub(crate) mod persistent_engine;
+pub(crate) mod storage;
 
 // WAL module is pub(crate) - not exposed to logical layer (TTM compliance)
 pub(crate) mod wal;
@@ -140,4 +140,4 @@ pub(crate) mod mvcc;
 pub use persistent_engine::PersistentEngine;
 
 // Re-export key storage types
-pub use storage::{Catalog, CatalogError, HeapError, HeapFile, Page, PageError, PageFile};
+pub use storage::{Catalog, CatalogError, HeapError, HeapFile, Page, PageError, PageFile, PAGE_SIZE, RelationMetadata, PageId};

--- a/relvar-storage/src/storage/catalog.rs
+++ b/relvar-storage/src/storage/catalog.rs
@@ -14,7 +14,7 @@
 //! # Example
 //!
 //! ```no_run
-//! use relvar_storage::storage::Catalog;
+//! use relvar_storage::Catalog;
 //! use relvar_core::types::{RelationType, TupleType, ScalarType};
 //! use std::path::PathBuf;
 //!
@@ -98,7 +98,7 @@ pub struct RelationMetadata {
 /// # Examples
 ///
 /// ```no_run
-/// use relvar_storage::storage::Catalog;
+/// use relvar_storage::Catalog;
 /// use relvar_core::types::{RelationType, TupleType, ScalarType};
 /// use std::path::PathBuf;
 ///
@@ -136,7 +136,7 @@ impl Catalog {
     /// # Examples
     ///
     /// ```
-    /// use relvar_storage::storage::Catalog;
+    /// use relvar_storage::Catalog;
     ///
     /// let catalog = Catalog::new();
     /// assert_eq!(catalog.relation_count(), 0);
@@ -158,7 +158,7 @@ impl Catalog {
     ///
     /// # Examples
     /// ```
-    /// use relvar_storage::storage::Catalog;
+    /// use relvar_storage::Catalog;
     /// use tempfile::tempdir;
     /// let dir = tempdir().unwrap();
     /// let path = dir.path().join("catalog.json");
@@ -210,7 +210,7 @@ impl Catalog {
     ///
     /// # Examples
     /// ```
-    /// use relvar_storage::storage::Catalog;
+    /// use relvar_storage::Catalog;
     /// use tempfile::tempdir;
     /// let dir = tempdir().unwrap();
     /// let path = dir.path().join("catalog.json");
@@ -276,7 +276,7 @@ impl Catalog {
     ///
     /// # Examples
     /// ```
-    /// use relvar_storage::storage::Catalog;
+    /// use relvar_storage::Catalog;
     /// use relvar_core::types::{RelationType, TupleType};
     /// use std::path::PathBuf;
     /// let mut catalog = Catalog::new();
@@ -295,7 +295,7 @@ impl Catalog {
     ///
     /// # Examples
     /// ```
-    /// use relvar_storage::storage::Catalog;
+    /// use relvar_storage::Catalog;
     /// let catalog = Catalog::new();
     /// assert!(!catalog.relation_exists("my_table"));
     /// ```
@@ -337,7 +337,7 @@ impl Catalog {
     /// # Examples
     ///
     /// ```
-    /// use relvar_storage::storage::Catalog;
+    /// use relvar_storage::Catalog;
     ///
     /// let catalog = Catalog::new();
     /// assert_eq!(catalog.relation_count(), 0);

--- a/relvar-storage/src/storage/mod.rs
+++ b/relvar-storage/src/storage/mod.rs
@@ -39,7 +39,7 @@
 //! # Example
 //!
 //! ```no_run
-//! use relvar_storage::storage::{HeapFile, Catalog};
+//! use relvar_storage::{HeapFile, Catalog};
 //! use relvar_core::types::{RelationType, TupleType, ScalarType};
 //! use relvar_core::tuple;
 //! use std::path::PathBuf;

--- a/relvar-storage/src/storage/page.rs
+++ b/relvar-storage/src/storage/page.rs
@@ -21,7 +21,7 @@
 //! # Example
 //!
 //! ```no_run
-//! use relvar_storage::storage::{Page, PageFile, PAGE_SIZE};
+//! use relvar_storage::{Page, PageFile, PAGE_SIZE};
 //!
 //! // Create a page file
 //! let mut pf = PageFile::create("data.pages").unwrap();
@@ -84,7 +84,7 @@ pub enum PageError {
 /// # Examples
 ///
 /// ```
-/// use relvar_storage::storage::{Page, PAGE_SIZE};
+/// use relvar_storage::{Page, PAGE_SIZE};
 ///
 /// // Create an empty page
 /// let mut page = Page::new(0);
@@ -113,7 +113,7 @@ impl Page {
     /// # Examples
     ///
     /// ```
-    /// use relvar_storage::storage::Page;
+    /// use relvar_storage::Page;
     ///
     /// let page = Page::new(0);
     /// assert_eq!(page.id(), 0);
@@ -140,7 +140,7 @@ impl Page {
     /// # Examples
     ///
     /// ```
-    /// use relvar_storage::storage::Page;
+    /// use relvar_storage::Page;
     ///
     /// let page = Page::from_data(42, vec![1, 2, 3]).unwrap();
     /// assert_eq!(page.id(), 42);
@@ -164,7 +164,7 @@ impl Page {
     /// # Examples
     ///
     /// ```
-    /// use relvar_storage::storage::Page;
+    /// use relvar_storage::Page;
     ///
     /// let page = Page::new(42);
     /// assert_eq!(page.id(), 42);
@@ -200,7 +200,7 @@ impl Page {
     /// # Examples
     ///
     /// ```
-    /// use relvar_storage::storage::{Page, PAGE_SIZE};
+    /// use relvar_storage::{Page, PAGE_SIZE};
     ///
     /// let page = Page::new(1);
     /// // A new page starts completely empty (data length is 0).
@@ -238,7 +238,7 @@ impl Page {
 /// # Examples
 ///
 /// ```no_run
-/// use relvar_storage::storage::{Page, PageFile};
+/// use relvar_storage::{Page, PageFile};
 ///
 /// // Create a new page file
 /// let mut pf = PageFile::create("data.pages").unwrap();


### PR DESCRIPTION
🕸️ Tangle: Broad visibility (`pub mod`) across many internal modules in `relvar-storage` leaked implementation details and complicated the dependency graph.
📐 Blueprint: Converted top-level internal module definitions in `relvar-storage/src/lib.rs` to `pub(crate) mod`. Re-exported necessary types (`Catalog`, `CatalogError`, `HeapError`, `HeapFile`, `Page`, `PageError`, `PageFile`, `PAGE_SIZE`, `RelationMetadata`, `PageId`) via `pub use` in `relvar-storage/src/lib.rs` and `relvar-storage/src/storage/mod.rs`, ensuring clean, intention-revealing public APIs while maintaining low coupling between internal components.
🧱 Stability: Reduced coupling, cleaner public API.
🔬 Verification: Builds successfully, strict separation enforced. Evaluated locally with `cargo check` and `cargo test`.

---
*PR created automatically by Jules for task [10313940365921995214](https://jules.google.com/task/10313940365921995214) started by @madmax983*