### PR TITLE
⚒️ Forge: Refactor God Function compute_pairwise_forces in Physics Engine

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,6 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+## 2024-05-30 - Extract God Function in Physics pairwise force computation
+**Learning:** `relvar/src/experimental/physics.rs` contained a "God Function" `compute_pairwise_forces` (81 lines) which combined preparing rename, joining relations, restricting self interactions, and the `fx` and `fy` force calculation closures. The large inline closures made the relational pipeline harder to follow and violated the Three-Phase Operator pattern.
+**Action:** Applied the "Three-Phase Operator" pattern by extracting the closures for calculating force components into strictly typed private helper functions `compute_fx` and `compute_fy`. This flattens the main method and significantly increases code readability without sacrificing logic or safety.

--- a/pr.py
+++ b/pr.py
@@ -4,4 +4,4 @@ import os
 with open("pr_description.md") as f:
     body = f.read()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+print(f"Submitting PR with title: ⚒️ Forge: Refactor God Function compute_pairwise_forces in Physics Engine\n\n{body}")

--- a/relvar/src/experimental/physics.rs
+++ b/relvar/src/experimental/physics.rs
@@ -91,52 +91,9 @@ impl PhysicsEngine {
         // 3. Compute forces for each pair
         let g = self.g;
         interactions
-            .extend("fx", ScalarType::Float, move |t| {
-                let x1 = t.get_typed::<f64>("x1").unwrap();
-                let y1 = t.get_typed::<f64>("y1").unwrap();
-                let x2 = t.get_typed::<f64>("x2").unwrap();
-                let y2 = t.get_typed::<f64>("y2").unwrap();
-                let m1 = t.get_typed::<f64>("m1").unwrap();
-                let m2 = t.get_typed::<f64>("m2").unwrap();
-
-                let dx = x2 - x1;
-                let dy = y2 - y1;
-                let dist_sq = dx * dx + dy * dy;
-
-                // Avoid division by zero
-                if dist_sq < 1e-10 {
-                    return ScalarValue::Float(0.0);
-                }
-
-                let dist = dist_sq.sqrt();
-                let f = g * m1 * m2 / dist_sq;
-                let fx = f * (dx / dist);
-
-                ScalarValue::Float(fx)
-            })
+            .extend("fx", ScalarType::Float, move |t| compute_fx(t, g))
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
-            .extend("fy", ScalarType::Float, move |t| {
-                let x1 = t.get_typed::<f64>("x1").unwrap();
-                let y1 = t.get_typed::<f64>("y1").unwrap();
-                let x2 = t.get_typed::<f64>("x2").unwrap();
-                let y2 = t.get_typed::<f64>("y2").unwrap();
-                let m1 = t.get_typed::<f64>("m1").unwrap();
-                let m2 = t.get_typed::<f64>("m2").unwrap();
-
-                let dx = x2 - x1;
-                let dy = y2 - y1;
-                let dist_sq = dx * dx + dy * dy;
-
-                if dist_sq < 1e-10 {
-                    return ScalarValue::Float(0.0);
-                }
-
-                let dist = dist_sq.sqrt();
-                let f = g * m1 * m2 / dist_sq;
-                let fy = f * (dy / dist);
-
-                ScalarValue::Float(fy)
-            })
+            .extend("fy", ScalarType::Float, move |t| compute_fy(t, g))
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
     }
 
@@ -230,6 +187,52 @@ impl PhysicsEngine {
 
         Ok(next_state)
     }
+}
+
+fn compute_fx(t: &relvar_core::values::Tuple, g: f64) -> ScalarValue {
+    let x1 = t.get_typed::<f64>("x1").unwrap();
+    let y1 = t.get_typed::<f64>("y1").unwrap();
+    let x2 = t.get_typed::<f64>("x2").unwrap();
+    let y2 = t.get_typed::<f64>("y2").unwrap();
+    let m1 = t.get_typed::<f64>("m1").unwrap();
+    let m2 = t.get_typed::<f64>("m2").unwrap();
+
+    let dx = x2 - x1;
+    let dy = y2 - y1;
+    let dist_sq = dx * dx + dy * dy;
+
+    if dist_sq < 1e-10 {
+        return ScalarValue::Float(0.0);
+    }
+
+    let dist = dist_sq.sqrt();
+    let f = g * m1 * m2 / dist_sq;
+    let fx = f * (dx / dist);
+
+    ScalarValue::Float(fx)
+}
+
+fn compute_fy(t: &relvar_core::values::Tuple, g: f64) -> ScalarValue {
+    let x1 = t.get_typed::<f64>("x1").unwrap();
+    let y1 = t.get_typed::<f64>("y1").unwrap();
+    let x2 = t.get_typed::<f64>("x2").unwrap();
+    let y2 = t.get_typed::<f64>("y2").unwrap();
+    let m1 = t.get_typed::<f64>("m1").unwrap();
+    let m2 = t.get_typed::<f64>("m2").unwrap();
+
+    let dx = x2 - x1;
+    let dy = y2 - y1;
+    let dist_sq = dx * dx + dy * dy;
+
+    if dist_sq < 1e-10 {
+        return ScalarValue::Float(0.0);
+    }
+
+    let dist = dist_sq.sqrt();
+    let f = g * m1 * m2 / dist_sq;
+    let fy = f * (dy / dist);
+
+    ScalarValue::Float(fy)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🚮 Smell: The `compute_pairwise_forces` method in `PhysicsEngine` was a God Function (81 lines) containing deeply nested inline closures for extending relations to calculate `fx` and `fy`. This violated the Three-Phase Operator pattern and reduced readability.
✨ Solution: Extracted the logic for computing forces into `compute_fx` and `compute_fy` standalone helper functions.
🧼 Benefit: Significantly flattens the relational pipeline, making it vastly easier to read, test, and understand. Strict typing is improved without changing any runtime evaluation logic.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [9375154991426892486](https://jules.google.com/task/9375154991426892486) started by @madmax983*