### PR TITLE
⚡ Bolt: Optimize query builder to use IntoIterator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,6 @@
 ## 2024-05-20 - String Allocations in Iterators
 **Learning:** `rename_into` previously consumed a tuple's BTreeMap entirely to scalar values by calling `.into_values()`. However, BTreeMaps also implement `into_iter()` which yields owned `(K, V)` pairs. We were discarding the `K` (the original String key) and creating a brand new String key for every column of every tuple, even if the rename mapping didn't touch it.
 **Action:** Always check if we can reuse the owned strings from an input collection instead of reflexively throwing them away and re-allocating them in an iterator pipeline.
+## 2023-10-25 - Query Builder IntoIterator Optimization
+**Learning:** Query builder APIs (`project`, `rename`, `summarize`) that accept `Vec<T>` force callers to allocate heap vectors even when they just want to pass stack-allocated arrays like `["a", "b"]`.
+**Action:** When designing query builders or chained APIs, accept `IntoIterator<Item = T>` instead of `Vec<T>`. This allows users to pass arrays directly, eliminating unnecessary heap allocations when building ASTs, while remaining completely backwards compatible with existing `Vec` calls.

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -369,9 +369,13 @@ impl Query {
     /// ```
     /// use relvar_core::query::Query;
     ///
-    /// let q = Query::scan("USERS").project(vec!["name", "email"]);
+    /// let q = Query::scan("USERS").project(["name", "email"]);
     /// ```
-    pub fn project<S: Into<String>>(self, attributes: Vec<S>) -> Self {
+    pub fn project<I, S>(self, attributes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
         Query::Project {
             input: Box::new(self),
             attributes: attributes.into_iter().map(|s| s.into()).collect(),
@@ -384,9 +388,14 @@ impl Query {
     /// ```
     /// use relvar_core::query::Query;
     ///
-    /// let q = Query::scan("USERS").rename(vec![("name", "full_name")]);
+    /// let q = Query::scan("USERS").rename([("name", "full_name")]);
     /// ```
-    pub fn rename<S1: Into<String>, S2: Into<String>>(self, mappings: Vec<(S1, S2)>) -> Self {
+    pub fn rename<I, S1, S2>(self, mappings: I) -> Self
+    where
+        I: IntoIterator<Item = (S1, S2)>,
+        S1: Into<String>,
+        S2: Into<String>,
+    {
         Query::Rename {
             input: Box::new(self),
             mappings: mappings
@@ -420,13 +429,13 @@ impl Query {
     /// use relvar_core::query::Query;
     /// use relvar_core::algebra::Aggregation;
     ///
-    /// let q = Query::scan("USERS").summarize(vec!["department"], vec![Aggregation::count("emp_count")]);
+    /// let q = Query::scan("USERS").summarize(["department"], vec![Aggregation::count("emp_count")]);
     /// ```
-    pub fn summarize<S: Into<String>>(
-        self,
-        group_by: Vec<S>,
-        aggregations: Vec<Aggregation>,
-    ) -> Self {
+    pub fn summarize<I, S>(self, group_by: I, aggregations: Vec<Aggregation>) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
         Query::Summarize {
             input: Box::new(self),
             group_by: group_by.into_iter().map(|s| s.into()).collect(),


### PR DESCRIPTION
💡 What: Optimized the query builder API (`project`, `rename`, `summarize`) in `relvar-core/src/query/mod.rs` to accept generic types implementing `IntoIterator` instead of explicitly requiring `Vec<T>`.

🎯 Why: The original signature forced callers to unnecessarily allocate heap vectors even when passing stack-allocated arrays (e.g. `["a", "b"]`), which is a common usage pattern when building static relational query ASTs. This changes avoids forcing users into those allocations while remaining fully backwards compatible since `Vec` implements `IntoIterator`.

📊 Impact: Eliminates an unnecessary `Vec` heap allocation per builder method call. This makes AST construction faster and more ergonomic by supporting stack-allocated fixed-size arrays zero-cost out-of-the-box.

🔬 Measurement: Run `cargo test` and `cargo check` to verify full compilation and behavior compatibility, particularly within the test suite that extensively exercises these query builder functions.

---
*PR created automatically by Jules for task [667267194052222399](https://jules.google.com/task/667267194052222399) started by @madmax983*