### PR TITLE
🗺️ Atlas: [architectural change] Encapsulate query test modules

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -27,3 +27,6 @@
 ## 2024-05-19 - Fixing Public Module Leaks
 **Tangle:** Broad visibility (`pub mod`) across many test and internal modules leaked implementation details and complicated the dependency graph.
 **Blueprint:** Converted most top-level internal module definitions in `relvar-core` and `relvar-storage` and `relvar` to `pub(crate) mod` where appropriate, and fixed some lingering pub use statements.
+## 2024-05-19 - Sub-modularizing the Query Tests Blob Visibility
+**Tangle:** Broad visibility (`pub mod`) across test modules like `relvar-core/src/query/tests/mod.rs` (which contained `pub mod basic;` and `pub mod common;`) leaked implementation details of testing setups and complicated the dependency graph.
+**Blueprint:** Converted internal module definitions in `relvar-core/src/query/tests/mod.rs` from `pub mod` to `pub(crate) mod`. This ensures clear, intention-revealing module boundaries while preventing leaky test module abstractions, fully adhering to the structural design without breaking the external APIs or triggering unused code warnings.

--- a/pr.py
+++ b/pr.py
@@ -1,7 +1,0 @@
-import sys
-import os
-
-with open("pr_description.md") as f:
-    body = f.read()
-
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")

--- a/relvar-core/src/query/tests/mod.rs
+++ b/relvar-core/src/query/tests/mod.rs
@@ -1,2 +1,2 @@
-pub mod basic;
-pub mod common;
+pub(crate) mod basic;
+pub(crate) mod common;


### PR DESCRIPTION
🕸️ Tangle: Broad visibility (`pub mod`) across test modules like `relvar-core/src/query/tests/mod.rs` (which contained `pub mod basic;` and `pub mod common;`) leaked implementation details of testing setups and complicated the dependency graph.

📐 Blueprint: Converted internal module definitions in `relvar-core/src/query/tests/mod.rs` from `pub mod` to `pub(crate) mod`. This ensures clear, intention-revealing module boundaries while preventing leaky test module abstractions, fully adhering to the structural design without breaking the external APIs or triggering unused code warnings.

🧱 Stability: Reduced potential for tight coupling between the public API and test code; no changes in public interface or logical processing.

🔬 Verification: Code compiles successfully. `cargo test`, `cargo clippy`, and `cargo check` all run and pass locally. Verified that tests execute seamlessly.

---
*PR created automatically by Jules for task [14229501155631293795](https://jules.google.com/task/14229501155631293795) started by @madmax983*