### PR TITLE
⚡ Bolt: [Zero-cost Query iterators]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,9 @@
 ## 2024-05-20 - String Allocations in Iterators
 **Learning:** `rename_into` previously consumed a tuple's BTreeMap entirely to scalar values by calling `.into_values()`. However, BTreeMaps also implement `into_iter()` which yields owned `(K, V)` pairs. We were discarding the `K` (the original String key) and creating a brand new String key for every column of every tuple, even if the rename mapping didn't touch it.
 **Action:** Always check if we can reuse the owned strings from an input collection instead of reflexively throwing them away and re-allocating them in an iterator pipeline.
+## 2026-05-12 - [Zero-Cost Query Builder Iterators]
+**Learning:** Replaced  with  in  builder methods (, , ). This allows users to pass stack-allocated arrays like  without forcing a heap allocation for a , while still supporting standard  or  usage via implicit trait resolution.
+**Action:** Always prefer  for public API functions that consume collections to provide zero-cost abstractions to callers.
+## $(date +%Y-%m-%d) - [Zero-Cost Query Builder Iterators]
+**Learning:** Replaced `Vec<T>` with `IntoIterator<Item = T>` in `Query` builder methods (`project`, `rename`, `summarize`). This allows users to pass stack-allocated arrays like `["a", "b"]` without forcing a heap allocation for a `Vec`, while still supporting standard `.collect()` or `vec![]` usage via implicit trait resolution.
+**Action:** Always prefer `IntoIterator` for public API functions that consume collections to provide zero-cost abstractions to callers.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,11 @@
+💡 What: The optimization implemented
+Replaced `Vec<T>` arguments in `Query::project`, `Query::rename`, and `Query::summarize` with generic `IntoIterator<Item = T>` traits.
+
+🎯 Why: The bottleneck
+Forcing a `Vec` for small, statically known argument lists (like projection attributes) requires a heap allocation at the call site (e.g., `vec!["name", "email"]`).
+
+📊 Impact: Expected gain
+Eliminates intermediate heap allocations when users pass stack-allocated arrays like `["name", "email"]`. Zero runtime cost for existing `vec!` callers.
+
+🔬 Measurement: How to verify
+Run `cargo bench` on query builder usage, and check `cargo run` examples to see that array syntax is supported.

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -371,7 +371,12 @@ impl Query {
     ///
     /// let q = Query::scan("USERS").project(vec!["name", "email"]);
     /// ```
-    pub fn project<S: Into<String>>(self, attributes: Vec<S>) -> Self {
+    /// ⚡ Bolt Optimization: Uses `IntoIterator` to avoid forcing heap allocation for attributes.
+    pub fn project<I, S>(self, attributes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
         Query::Project {
             input: Box::new(self),
             attributes: attributes.into_iter().map(|s| s.into()).collect(),
@@ -386,7 +391,13 @@ impl Query {
     ///
     /// let q = Query::scan("USERS").rename(vec![("name", "full_name")]);
     /// ```
-    pub fn rename<S1: Into<String>, S2: Into<String>>(self, mappings: Vec<(S1, S2)>) -> Self {
+    /// ⚡ Bolt Optimization: Uses `IntoIterator` to avoid forcing heap allocation for mappings.
+    pub fn rename<I, S1, S2>(self, mappings: I) -> Self
+    where
+        I: IntoIterator<Item = (S1, S2)>,
+        S1: Into<String>,
+        S2: Into<String>,
+    {
         Query::Rename {
             input: Box::new(self),
             mappings: mappings
@@ -422,15 +433,17 @@ impl Query {
     ///
     /// let q = Query::scan("USERS").summarize(vec!["department"], vec![Aggregation::count("emp_count")]);
     /// ```
-    pub fn summarize<S: Into<String>>(
-        self,
-        group_by: Vec<S>,
-        aggregations: Vec<Aggregation>,
-    ) -> Self {
+    /// ⚡ Bolt Optimization: Uses `IntoIterator` to avoid forcing heap allocation for group_by and aggregations.
+    pub fn summarize<I1, S, I2>(self, group_by: I1, aggregations: I2) -> Self
+    where
+        I1: IntoIterator<Item = S>,
+        S: Into<String>,
+        I2: IntoIterator<Item = Aggregation>,
+    {
         Query::Summarize {
             input: Box::new(self),
             group_by: group_by.into_iter().map(|s| s.into()).collect(),
-            aggregations,
+            aggregations: aggregations.into_iter().collect(),
         }
     }
 }


### PR DESCRIPTION
💡 What: The optimization implemented
Replaced `Vec<T>` arguments in `Query::project`, `Query::rename`, and `Query::summarize` with generic `IntoIterator<Item = T>` traits.

🎯 Why: The bottleneck
Forcing a `Vec` for small, statically known argument lists (like projection attributes) requires a heap allocation at the call site (e.g., `vec!["name", "email"]`).

📊 Impact: Expected gain
Eliminates intermediate heap allocations when users pass stack-allocated arrays like `["name", "email"]`. Zero runtime cost for existing `vec!` callers.

🔬 Measurement: How to verify
Run `cargo bench` on query builder usage, and check `cargo run` examples to see that array syntax is supported.

---
*PR created automatically by Jules for task [6287705301790339525](https://jules.google.com/task/6287705301790339525) started by @madmax983*