### PR TITLE
⚒️ Forge: Refactor compute_pairwise_forces and compute_kernel_contributions God Functions

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,7 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+
+## 2024-05-31 - Refactor `compute_kernel_contributions` and `compute_pairwise_forces` God Functions
+**Learning:** Functions that combine complex relational iteration structures (like looping over kernel taps or calculating distances between Cartesian pairs) with deeply nested, inline relational logic (like `extend` and `project`) quickly become "God Functions". This pattern hurts readability and makes the relation construction flow difficult to trace.
+**Action:** Applied the "Three-Phase Operator" pattern to extract the inner relational logic into distinct, tightly-scoped private helper functions (`compute_single_contribution` and `calculate_force_components`). This flattened the primary algorithms into highly readable coordination blocks without sacrificing execution context or behavior.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,7 @@
+Title: ⚒️ Forge: Refactor compute_pairwise_forces and compute_kernel_contributions God Functions
+
+Description:
+🚮 Smell: The `compute_pairwise_forces` method in `relvar/src/experimental/physics.rs` and the `compute_kernel_contributions` method in `relvar/src/experimental/image.rs` were long, complex "God Functions". They contained deeply nested relational `extend` logic directly in their core iterative structures, increasing cognitive load and making the flow of relation construction hard to read.
+✨ Solution: Applied the "Three-Phase Operator" pattern. In `physics.rs`, extracted the massive `extend` logic calculating vector forces into `calculate_force_components`. In `image.rs`, extracted the inner kernel-tap processing loop (shifting, scaling, renaming, projecting) into a focused `compute_single_contribution` helper function.
+🧼 Benefit: Flattened the core algorithms into readable coordination blocks, moving detailed relational arithmetic into clearly named, tightly scoped, private helper functions. Dramatically improves readability without altering behavior.
+🛡️ Verification: Tests passed. No logic changed.

--- a/relvar/src/experimental/image.rs
+++ b/relvar/src/experimental/image.rs
@@ -197,75 +197,80 @@ fn compute_kernel_contributions(relation: &Relation, kernel: &[KernelTap]) -> Ve
     let mut contributions = Vec::with_capacity(kernel.len());
 
     for (i, tap) in kernel.iter().enumerate() {
-        let dx = tap.dx;
-        let dy = tap.dy;
-        let weight = tap.weight;
-        let k_idx = i as i64;
-
-        // Step 1: Shift and Scale
-        // We use extend to compute new coordinates and weighted values
-        // We project to keep only relevant columns + k_idx
-        // Logic: A pixel at (x,y) contributes to (x+dx, y+dy) with weight w.
-        // So for a target pixel (tx, ty), the source is (tx-dx, ty-dy).
-        // But here we are iterating source pixels.
-        // Source (x,y) contributes to Target (x+dx, y+dy).
-        // So let's name the new coordinates `tx` and `ty`.
-
-        // Extend 1: Calculate target coordinates
-        let with_coords = relation
-            .extend("tx", ScalarType::Int, move |t| {
-                let x = t.get_typed::<i64>("x").unwrap();
-                ScalarValue::Int(x + dx)
-            })
-            .unwrap()
-            .extend("ty", ScalarType::Int, move |t| {
-                let y = t.get_typed::<i64>("y").unwrap();
-                ScalarValue::Int(y + dy)
-            })
-            .unwrap();
-
-        // Extend 2: Calculate weighted color components
-        let with_weights = with_coords
-            .extend("wr", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("r").unwrap();
-                ScalarValue::Int(v * weight)
-            })
-            .unwrap()
-            .extend("wg", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("g").unwrap();
-                ScalarValue::Int(v * weight)
-            })
-            .unwrap()
-            .extend("wb", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("b").unwrap();
-                ScalarValue::Int(v * weight)
-            })
-            .unwrap();
-
-        // Extend 3: Add kernel index (to prevent set deduplication of values)
-        let with_idx = with_weights
-            .extend("k_idx", ScalarType::Int, move |_| ScalarValue::Int(k_idx))
-            .unwrap();
-
-        // Project: Keep (tx, ty, wr, wg, wb, k_idx)
-        // But we rename them to a standard schema for Union
-        // Standard: (x, y, r, g, b, k_idx)
-        // Rename mapping: tx->x, ty->y, wr->r, wg->g, wb->b
-        let rename_map = vec![
-            ("tx", "x"),
-            ("ty", "y"),
-            ("wr", "r"),
-            ("wg", "g"),
-            ("wb", "b"),
-        ];
-
-        let projected = with_idx.project(&["tx", "ty", "wr", "wg", "wb", "k_idx"]);
-        let renamed = projected.rename(&rename_map);
-
-        contributions.push(renamed);
+        contributions.push(compute_single_contribution(
+            relation, tap.dx, tap.dy, tap.weight, i as i64,
+        ));
     }
 
     contributions
+}
+
+fn compute_single_contribution(
+    relation: &Relation,
+    dx: i64,
+    dy: i64,
+    weight: i64,
+    k_idx: i64,
+) -> Relation {
+    // Step 1: Shift and Scale
+    // We use extend to compute new coordinates and weighted values
+    // We project to keep only relevant columns + k_idx
+    // Logic: A pixel at (x,y) contributes to (x+dx, y+dy) with weight w.
+    // So for a target pixel (tx, ty), the source is (tx-dx, ty-dy).
+    // But here we are iterating source pixels.
+    // Source (x,y) contributes to Target (x+dx, y+dy).
+    // So let's name the new coordinates `tx` and `ty`.
+
+    // Extend 1: Calculate target coordinates
+    let with_coords = relation
+        .extend("tx", ScalarType::Int, move |t| {
+            let x = t.get_typed::<i64>("x").unwrap();
+            ScalarValue::Int(x + dx)
+        })
+        .unwrap()
+        .extend("ty", ScalarType::Int, move |t| {
+            let y = t.get_typed::<i64>("y").unwrap();
+            ScalarValue::Int(y + dy)
+        })
+        .unwrap();
+
+    // Extend 2: Calculate weighted color components
+    let with_weights = with_coords
+        .extend("wr", ScalarType::Int, move |t| {
+            let v = t.get_typed::<i64>("r").unwrap();
+            ScalarValue::Int(v * weight)
+        })
+        .unwrap()
+        .extend("wg", ScalarType::Int, move |t| {
+            let v = t.get_typed::<i64>("g").unwrap();
+            ScalarValue::Int(v * weight)
+        })
+        .unwrap()
+        .extend("wb", ScalarType::Int, move |t| {
+            let v = t.get_typed::<i64>("b").unwrap();
+            ScalarValue::Int(v * weight)
+        })
+        .unwrap();
+
+    // Extend 3: Add kernel index (to prevent set deduplication of values)
+    let with_idx = with_weights
+        .extend("k_idx", ScalarType::Int, move |_| ScalarValue::Int(k_idx))
+        .unwrap();
+
+    // Project: Keep (tx, ty, wr, wg, wb, k_idx)
+    // But we rename them to a standard schema for Union
+    // Standard: (x, y, r, g, b, k_idx)
+    // Rename mapping: tx->x, ty->y, wr->r, wg->g, wb->b
+    let rename_map = vec![
+        ("tx", "x"),
+        ("ty", "y"),
+        ("wr", "r"),
+        ("wg", "g"),
+        ("wb", "b"),
+    ];
+
+    let projected = with_idx.project(&["tx", "ty", "wr", "wg", "wb", "k_idx"]);
+    projected.rename(&rename_map)
 }
 
 fn union_contributions(contributions: &[Relation]) -> Relation {

--- a/relvar/src/experimental/physics.rs
+++ b/relvar/src/experimental/physics.rs
@@ -89,7 +89,13 @@ impl PhysicsEngine {
         });
 
         // 3. Compute forces for each pair
-        let g = self.g;
+        Self::calculate_force_components(interactions, self.g)
+    }
+
+    fn calculate_force_components(
+        interactions: Relation,
+        g: f64,
+    ) -> Result<Relation, DatabaseError> {
         interactions
             .extend("fx", ScalarType::Float, move |t| {
                 let x1 = t.get_typed::<f64>("x1").unwrap();


### PR DESCRIPTION
🚮 Smell: The `compute_pairwise_forces` method in `relvar/src/experimental/physics.rs` and the `compute_kernel_contributions` method in `relvar/src/experimental/image.rs` were long, complex "God Functions". They contained deeply nested relational `extend` logic directly in their core iterative structures, increasing cognitive load and making the flow of relation construction hard to read.
✨ Solution: Applied the "Three-Phase Operator" pattern. In `physics.rs`, extracted the massive `extend` logic calculating vector forces into `calculate_force_components`. In `image.rs`, extracted the inner kernel-tap processing loop (shifting, scaling, renaming, projecting) into a focused `compute_single_contribution` helper function.
🧼 Benefit: Flattened the core algorithms into readable coordination blocks, moving detailed relational arithmetic into clearly named, tightly scoped, private helper functions. Dramatically improves readability without altering behavior.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [11624750353739736036](https://jules.google.com/task/11624750353739736036) started by @madmax983*