### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/pr.py
+++ b/pr.py
@@ -4,4 +4,4 @@ import os
 with open("pr_description.md") as f:
     body = f.read()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+print(f"Submitting PR with title: 🎻 Bard: [documentation update]\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,3 @@
+📖 Chapter: The `Spreadsheet` module
+🔦 Insight: Explained the concept of the Relational Spreadsheet and how it models cells and formulas purely using relational algebra.
+🧪 Example: Replaced placeholder documentation with executable doc-tests for `Spreadsheet::new` and `Spreadsheet::evaluate`.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -1,3 +1,13 @@
+//! The Relational Spreadsheet Engine.
+//!
+//! This module provides a functional, purely relational approach to evaluating a spreadsheet.
+//! Rather than using a traditional mutable object graph, the spreadsheet state is represented
+//! as relations: a `values` relation containing the resolved cells, and a `formulas`
+//! relation containing the un-evaluated formulas.
+//!
+//! Evaluating the spreadsheet is performed purely through relational algebra: joins,
+//! restrictions, differences, and extensions until a fixpoint is reached (all cells are evaluated).
+
 use relvar_core::{
     error::DatabaseError,
     types::ScalarType,
@@ -23,9 +33,24 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{tuple, Relation, RelationType, ScalarType, TupleType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_heading));
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// assert_eq!(spreadsheet.values.cardinality(), 0);
+    /// assert_eq!(spreadsheet.formulas.cardinality(), 0);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -36,9 +61,31 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{tuple, Relation, RelationType, ScalarType, TupleType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_heading));
+    /// // B1 = A1 + A2
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    ///
+    /// assert_eq!(result.cardinality(), 3); // A1, A2, and B1 (which is 30.0)
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
📖 Chapter: The `Spreadsheet` module
🔦 Insight: Explained the concept of the Relational Spreadsheet and how it models cells and formulas purely using relational algebra.
🧪 Example: Replaced placeholder documentation with executable doc-tests for `Spreadsheet::new` and `Spreadsheet::evaluate`.

---
*PR created automatically by Jules for task [5544904127865557065](https://jules.google.com/task/5544904127865557065) started by @madmax983*