### PR TITLE
⚒️ Forge: refactor physics engine extend closures

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,7 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+
+## 2026-05-19 - Extract God Function Inline Closures in Physics Engine
+**Learning:** `relvar/src/experimental/physics.rs` contained "God Function" behaviors within `compute_pairwise_forces` and `update_kinematics_and_project`, where very large inline closures were used for `extend` operations (e.g., calculating forces and new kinematics). This deeply nested and duplicated logic hurt readability.
+**Action:** Extracted the inline closure logic into cleanly typed, private helper functions (`compute_force_x`, `compute_force_y`, `compute_new_vx`, etc.) on the `PhysicsEngine`. This flattens the relational algebra pipeline and makes the physical calculations easy to read independently.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,7 @@
+🚮 Smell: The `compute_pairwise_forces` and `update_kinematics_and_project` methods in `relvar/src/experimental/physics.rs` contained very large inline closures for their `extend` relational algebra operations. This created a "God Function" smell where complex mathematical logic was deeply nested and duplicated, making the relational pipeline hard to read.
+
+✨ Solution: Applied the "Three-Phase Operator" and extraction patterns. Extracted the mathematical calculation logic inside the `extend` closures into isolated, private, cleanly typed helper functions on `PhysicsEngine` (`compute_force_x`, `compute_force_y`, `compute_new_vx`, `compute_new_vy`, `compute_new_x`, `compute_new_y`).
+
+🧼 Benefit: Dramatically improves readability by flattening the nested closures. The physical calculation logic is now cleanly separated from the relational data flow pipeline. Reduces cognitive load.
+
+🛡️ Verification: Tests passed. No logic changed.

--- a/relvar/src/experimental/physics.rs
+++ b/relvar/src/experimental/physics.rs
@@ -92,50 +92,11 @@ impl PhysicsEngine {
         let g = self.g;
         interactions
             .extend("fx", ScalarType::Float, move |t| {
-                let x1 = t.get_typed::<f64>("x1").unwrap();
-                let y1 = t.get_typed::<f64>("y1").unwrap();
-                let x2 = t.get_typed::<f64>("x2").unwrap();
-                let y2 = t.get_typed::<f64>("y2").unwrap();
-                let m1 = t.get_typed::<f64>("m1").unwrap();
-                let m2 = t.get_typed::<f64>("m2").unwrap();
-
-                let dx = x2 - x1;
-                let dy = y2 - y1;
-                let dist_sq = dx * dx + dy * dy;
-
-                // Avoid division by zero
-                if dist_sq < 1e-10 {
-                    return ScalarValue::Float(0.0);
-                }
-
-                let dist = dist_sq.sqrt();
-                let f = g * m1 * m2 / dist_sq;
-                let fx = f * (dx / dist);
-
-                ScalarValue::Float(fx)
+                Self::compute_force_x(t, g)
             })
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
             .extend("fy", ScalarType::Float, move |t| {
-                let x1 = t.get_typed::<f64>("x1").unwrap();
-                let y1 = t.get_typed::<f64>("y1").unwrap();
-                let x2 = t.get_typed::<f64>("x2").unwrap();
-                let y2 = t.get_typed::<f64>("y2").unwrap();
-                let m1 = t.get_typed::<f64>("m1").unwrap();
-                let m2 = t.get_typed::<f64>("m2").unwrap();
-
-                let dx = x2 - x1;
-                let dy = y2 - y1;
-                let dist_sq = dx * dx + dy * dy;
-
-                if dist_sq < 1e-10 {
-                    return ScalarValue::Float(0.0);
-                }
-
-                let dist = dist_sq.sqrt();
-                let f = g * m1 * m2 / dist_sq;
-                let fy = f * (dy / dist);
-
-                ScalarValue::Float(fy)
+                Self::compute_force_y(t, g)
             })
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
     }
@@ -189,31 +150,19 @@ impl PhysicsEngine {
         let dt = self.dt;
         let updated = all_particles_with_forces
             .extend("new_vx", ScalarType::Float, move |t| {
-                let vx = t.get_typed::<f64>("vx").unwrap();
-                let m = t.get_typed::<f64>("mass").unwrap();
-                let fx = t.get_typed::<f64>("net_fx").unwrap();
-                let ax = fx / m;
-                ScalarValue::Float(vx + ax * dt)
+                Self::compute_new_vx(t, dt)
             })
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
             .extend("new_vy", ScalarType::Float, move |t| {
-                let vy = t.get_typed::<f64>("vy").unwrap();
-                let m = t.get_typed::<f64>("mass").unwrap();
-                let fy = t.get_typed::<f64>("net_fy").unwrap();
-                let ay = fy / m;
-                ScalarValue::Float(vy + ay * dt)
+                Self::compute_new_vy(t, dt)
             })
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
             .extend("new_x", ScalarType::Float, move |t| {
-                let x = t.get_typed::<f64>("x").unwrap();
-                let new_vx = t.get_typed::<f64>("new_vx").unwrap();
-                ScalarValue::Float(x + new_vx * dt)
+                Self::compute_new_x(t, dt)
             })
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
             .extend("new_y", ScalarType::Float, move |t| {
-                let y = t.get_typed::<f64>("y").unwrap();
-                let new_vy = t.get_typed::<f64>("new_vy").unwrap();
-                ScalarValue::Float(y + new_vy * dt)
+                Self::compute_new_y(t, dt)
             })
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
@@ -229,6 +178,80 @@ impl PhysicsEngine {
             ]);
 
         Ok(next_state)
+    }
+
+    fn compute_force_x(t: &relvar_core::values::Tuple, g: f64) -> ScalarValue {
+        let x1 = t.get_typed::<f64>("x1").unwrap();
+        let y1 = t.get_typed::<f64>("y1").unwrap();
+        let x2 = t.get_typed::<f64>("x2").unwrap();
+        let y2 = t.get_typed::<f64>("y2").unwrap();
+        let m1 = t.get_typed::<f64>("m1").unwrap();
+        let m2 = t.get_typed::<f64>("m2").unwrap();
+
+        let dx = x2 - x1;
+        let dy = y2 - y1;
+        let dist_sq = dx * dx + dy * dy;
+
+        if dist_sq < 1e-10 {
+            return ScalarValue::Float(0.0);
+        }
+
+        let dist = dist_sq.sqrt();
+        let f = g * m1 * m2 / dist_sq;
+        let fx = f * (dx / dist);
+
+        ScalarValue::Float(fx)
+    }
+
+    fn compute_force_y(t: &relvar_core::values::Tuple, g: f64) -> ScalarValue {
+        let x1 = t.get_typed::<f64>("x1").unwrap();
+        let y1 = t.get_typed::<f64>("y1").unwrap();
+        let x2 = t.get_typed::<f64>("x2").unwrap();
+        let y2 = t.get_typed::<f64>("y2").unwrap();
+        let m1 = t.get_typed::<f64>("m1").unwrap();
+        let m2 = t.get_typed::<f64>("m2").unwrap();
+
+        let dx = x2 - x1;
+        let dy = y2 - y1;
+        let dist_sq = dx * dx + dy * dy;
+
+        if dist_sq < 1e-10 {
+            return ScalarValue::Float(0.0);
+        }
+
+        let dist = dist_sq.sqrt();
+        let f = g * m1 * m2 / dist_sq;
+        let fy = f * (dy / dist);
+
+        ScalarValue::Float(fy)
+    }
+
+    fn compute_new_vx(t: &relvar_core::values::Tuple, dt: f64) -> ScalarValue {
+        let vx = t.get_typed::<f64>("vx").unwrap();
+        let m = t.get_typed::<f64>("mass").unwrap();
+        let fx = t.get_typed::<f64>("net_fx").unwrap();
+        let ax = fx / m;
+        ScalarValue::Float(vx + ax * dt)
+    }
+
+    fn compute_new_vy(t: &relvar_core::values::Tuple, dt: f64) -> ScalarValue {
+        let vy = t.get_typed::<f64>("vy").unwrap();
+        let m = t.get_typed::<f64>("mass").unwrap();
+        let fy = t.get_typed::<f64>("net_fy").unwrap();
+        let ay = fy / m;
+        ScalarValue::Float(vy + ay * dt)
+    }
+
+    fn compute_new_x(t: &relvar_core::values::Tuple, dt: f64) -> ScalarValue {
+        let x = t.get_typed::<f64>("x").unwrap();
+        let new_vx = t.get_typed::<f64>("new_vx").unwrap();
+        ScalarValue::Float(x + new_vx * dt)
+    }
+
+    fn compute_new_y(t: &relvar_core::values::Tuple, dt: f64) -> ScalarValue {
+        let y = t.get_typed::<f64>("y").unwrap();
+        let new_vy = t.get_typed::<f64>("new_vy").unwrap();
+        ScalarValue::Float(y + new_vy * dt)
     }
 }
 


### PR DESCRIPTION
🚮 Smell: The `compute_pairwise_forces` and `update_kinematics_and_project` methods in `relvar/src/experimental/physics.rs` contained very large inline closures for their `extend` relational algebra operations. This created a "God Function" smell where complex mathematical logic was deeply nested and duplicated, making the relational pipeline hard to read.

✨ Solution: Applied the "Three-Phase Operator" and extraction patterns. Extracted the mathematical calculation logic inside the `extend` closures into isolated, private, cleanly typed helper functions on `PhysicsEngine` (`compute_force_x`, `compute_force_y`, `compute_new_vx`, `compute_new_vy`, `compute_new_x`, `compute_new_y`).

🧼 Benefit: Dramatically improves readability by flattening the nested closures. The physical calculation logic is now cleanly separated from the relational data flow pipeline. Reduces cognitive load.

🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [15289703665069865743](https://jules.google.com/task/15289703665069865743) started by @madmax983*