### PR TITLE
🪒 Razor: [API Simplification] Query Builder APIs into_iter

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -21,3 +21,8 @@
 **Bloat:** Single-variant enum `RelationError` in `relvar-core/src/values/relation.rs` acting as a unit struct, with an unused variant `DuplicateTuple` and only one used variant `TypeMismatch`.
 **Cut:** Converted to unit struct `pub struct RelationError;` with `#[error("Tuple does not conform to relation type")]` directly. Removed the unused `DuplicateTuple` variant.
 **Saved:** Unnecessary enum matching, simplified error handling code significantly.
+
+## [Reduction]
+**Bloat:** Query builder APIs (`Query::project`, `Query::rename`, `Query::summarize`) required passing owned `Vec<T>`, forcing callers to allocate intermediate vectors (`vec!["a", "b"]`) when they could just pass stack-allocated arrays (`["a", "b"]`).
+**Cut:** Refactored the signatures of `project`, `rename`, and `summarize` in `relvar-core/src/query/mod.rs` to accept generic `IntoIterator<Item = T>` bounds instead. Replaced `vec![]` invocations with standard array literals `[]` across `Query` tests to prove out the simplified calling convention.
+**Saved:** Heap allocation overhead for query builder operations, plus simplification and reduction of cognitive load across caller code, aligning perfectly with the KISS principle.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,5 @@
+**Bloat:** Query builder APIs (`Query::project`, `Query::rename`, `Query::summarize`) required passing owned `Vec<T>`, forcing callers to allocate intermediate vectors (`vec!["a", "b"]`) when they could just pass stack-allocated arrays (`["a", "b"]`).
+
+**Cut:** Refactored the signatures of `project`, `rename`, and `summarize` in `relvar-core/src/query/mod.rs` to accept generic `IntoIterator<Item = T>` bounds instead. Replaced `vec![]` invocations with standard array literals `[]` across `Query` tests to prove out the simplified calling convention.
+
+**Saved:** Heap allocation overhead for query builder operations, plus simplification and reduction of cognitive load across caller code, aligning perfectly with the KISS principle.

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -30,7 +30,7 @@
 //!         op: CmpOp::Eq,
 //!         right: ValueOrRef::Value(ScalarValue::Int(1)),
 //!     })
-//!     .project(vec!["name"]);
+//!     .project(["name"]);
 //!
 //! // Execute
 //! let result = query.execute(&db).unwrap();
@@ -263,7 +263,7 @@ impl Query {
     /// ```
     /// use relvar_core::query::Query;
     ///
-    /// let q = Query::scan("TEST").project(vec!["x"]);
+    /// let q = Query::scan("TEST").project(["x"]);
     /// let explanation = q.explain();
     /// assert!(explanation.contains("Project"));
     /// assert!(explanation.contains("Scan"));
@@ -369,9 +369,9 @@ impl Query {
     /// ```
     /// use relvar_core::query::Query;
     ///
-    /// let q = Query::scan("USERS").project(vec!["name", "email"]);
+    /// let q = Query::scan("USERS").project(["name", "email"]);
     /// ```
-    pub fn project<S: Into<String>>(self, attributes: Vec<S>) -> Self {
+    pub fn project<S: Into<String>, I: IntoIterator<Item = S>>(self, attributes: I) -> Self {
         Query::Project {
             input: Box::new(self),
             attributes: attributes.into_iter().map(|s| s.into()).collect(),
@@ -384,9 +384,9 @@ impl Query {
     /// ```
     /// use relvar_core::query::Query;
     ///
-    /// let q = Query::scan("USERS").rename(vec![("name", "full_name")]);
+    /// let q = Query::scan("USERS").rename([("name", "full_name")]);
     /// ```
-    pub fn rename<S1: Into<String>, S2: Into<String>>(self, mappings: Vec<(S1, S2)>) -> Self {
+    pub fn rename<S1: Into<String>, S2: Into<String>, I: IntoIterator<Item = (S1, S2)>>(self, mappings: I) -> Self {
         Query::Rename {
             input: Box::new(self),
             mappings: mappings
@@ -420,17 +420,17 @@ impl Query {
     /// use relvar_core::query::Query;
     /// use relvar_core::algebra::Aggregation;
     ///
-    /// let q = Query::scan("USERS").summarize(vec!["department"], vec![Aggregation::count("emp_count")]);
+    /// let q = Query::scan("USERS").summarize(["department"], [Aggregation::count("emp_count")]);
     /// ```
-    pub fn summarize<S: Into<String>>(
+    pub fn summarize<S: Into<String>, I1: IntoIterator<Item = S>, I2: IntoIterator<Item = Aggregation>>(
         self,
-        group_by: Vec<S>,
-        aggregations: Vec<Aggregation>,
+        group_by: I1,
+        aggregations: I2,
     ) -> Self {
         Query::Summarize {
             input: Box::new(self),
             group_by: group_by.into_iter().map(|s| s.into()).collect(),
-            aggregations,
+            aggregations: aggregations.into_iter().collect(),
         }
     }
 }

--- a/relvar-core/src/query/tests/basic.rs
+++ b/relvar-core/src/query/tests/basic.rs
@@ -36,7 +36,7 @@ fn test_restrict() {
 #[test]
 fn test_project() {
     let db = setup_db();
-    let query = Query::scan("USERS").project(vec!["name"]);
+    let query = Query::scan("USERS").project(["name"]);
 
     let result = query.execute(&db).unwrap();
     assert_eq!(result.degree(), 1);
@@ -46,7 +46,7 @@ fn test_project() {
 #[test]
 fn test_rename() {
     let db = setup_db();
-    let query = Query::scan("USERS").rename(vec![("name", "full_name")]);
+    let query = Query::scan("USERS").rename([("name", "full_name")]);
 
     let result = query.execute(&db).unwrap();
     assert!(result.relation_type().heading().has_attribute("full_name"));
@@ -69,7 +69,7 @@ fn test_join() {
 #[test]
 fn test_summarize() {
     let db = setup_db();
-    let query = Query::scan("USERS").summarize(vec!["age"], vec![Aggregation::count("count")]);
+    let query = Query::scan("USERS").summarize(["age"], [Aggregation::count("count")]);
     let result = query.execute(&db).unwrap();
 
     // One person with age 25, one with age 30
@@ -84,7 +84,7 @@ fn test_explain() {
             op: CmpOp::Eq,
             right: ValueOrRef::Value(ScalarValue::Int(1)),
         })
-        .project(vec!["name"]);
+        .project(["name"]);
 
     let explain_str = query.explain();
     assert!(explain_str.contains("Project([\"name\"])"));
@@ -94,10 +94,10 @@ fn test_explain() {
     let q_join = Query::scan("A").join(Query::scan("B"));
     assert!(q_join.explain().contains("Join"));
 
-    let q_rename = Query::scan("A").rename(vec![("old", "new")]);
+    let q_rename = Query::scan("A").rename([("old", "new")]);
     assert!(q_rename.explain().contains("Rename([(\"old\", \"new\")])"));
 
-    let q_summarize = Query::scan("A").summarize(vec!["a"], vec![Aggregation::count("cnt")]);
+    let q_summarize = Query::scan("A").summarize(["a"], [Aggregation::count("cnt")]);
     assert!(q_summarize.explain().contains("Summarize"));
 }
 
@@ -106,7 +106,7 @@ fn test_query_error_propagation() {
     let db = setup_db();
 
     // Algebra error in Summarize (grouping by missing attribute)
-    let q_bad_sum = Query::scan("USERS").summarize(vec!["nonexistent_col"], vec![]);
+    let q_bad_sum = Query::scan("USERS").summarize(["nonexistent_col"], []);
     let err = q_bad_sum.execute(&db);
     assert!(matches!(err, Err(QueryError::Algebra(_))));
 }


### PR DESCRIPTION
**Bloat:** Query builder APIs (`Query::project`, `Query::rename`, `Query::summarize`) required passing owned `Vec<T>`, forcing callers to allocate intermediate vectors (`vec!["a", "b"]`) when they could just pass stack-allocated arrays (`["a", "b"]`).

**Cut:** Refactored the signatures of `project`, `rename`, and `summarize` in `relvar-core/src/query/mod.rs` to accept generic `IntoIterator<Item = T>` bounds instead. Replaced `vec![]` invocations with standard array literals `[]` across `Query` tests to prove out the simplified calling convention.

**Saved:** Heap allocation overhead for query builder operations, plus simplification and reduction of cognitive load across caller code, aligning perfectly with the KISS principle.

---
*PR created automatically by Jules for task [1098777912195031600](https://jules.google.com/task/1098777912195031600) started by @madmax983*