### PR TITLE
⚒️ Forge: [refactor bench_insert_with_check_constraint]

### DIFF
--- a/benches/database.rs
+++ b/benches/database.rs
@@ -477,6 +477,18 @@ fn bench_virtual_relvar_query(c: &mut Criterion) {
     group.finish();
 }
 
+// Helper to create a database with EMP relvar and optional constraints
+fn setup_emp_db_with_constraints(constraints: Option<CheckConstraints>) -> (TempDir, Database) {
+    let temp_dir = TempDir::new().unwrap();
+    let mut db = Database::open(temp_dir.path()).unwrap();
+    let emp_type = create_employee_type();
+    db.create_relvar("EMP", emp_type).unwrap();
+    if let Some(c) = constraints {
+        db.set_check_constraints("EMP", c).unwrap();
+    }
+    (temp_dir, db)
+}
+
 // CHECK constraint benchmarks (TTM RM Prescription 9)
 fn bench_insert_with_check_constraint(c: &mut Criterion) {
     let mut group = c.benchmark_group("insert_with_check_constraint");
@@ -485,13 +497,6 @@ fn bench_insert_with_check_constraint(c: &mut Criterion) {
     group.bench_function("simple_check", |b| {
         b.iter_batched(
             || {
-                // Setup: create database with CHECK constraint
-                let temp_dir = TempDir::new().unwrap();
-                let mut db = Database::open(temp_dir.path()).unwrap();
-                let emp_type = create_employee_type();
-                db.create_relvar("EMP", emp_type).unwrap();
-
-                // Add CHECK constraint: salary > 0
                 let constraints = CheckConstraints::new().with_constraint(
                     CheckConstraint::from_expression(
                         "positive_salary",
@@ -502,9 +507,7 @@ fn bench_insert_with_check_constraint(c: &mut Criterion) {
                         ),
                     ),
                 );
-                db.set_check_constraints("EMP", constraints).unwrap();
-
-                (temp_dir, db)
+                setup_emp_db_with_constraints(Some(constraints))
             },
             |(_temp_dir, mut db)| {
                 // Measured: insert with CHECK constraint
@@ -525,12 +528,6 @@ fn bench_insert_with_check_constraint(c: &mut Criterion) {
     group.bench_function("complex_check", |b| {
         b.iter_batched(
             || {
-                let temp_dir = TempDir::new().unwrap();
-                let mut db = Database::open(temp_dir.path()).unwrap();
-                let emp_type = create_employee_type();
-                db.create_relvar("EMP", emp_type).unwrap();
-
-                // Add CHECK constraint: salary > 0 AND salary < 1000000
                 let constraints = CheckConstraints::new().with_constraint(
                     CheckConstraint::from_expression(
                         "valid_salary_range",
@@ -547,9 +544,7 @@ fn bench_insert_with_check_constraint(c: &mut Criterion) {
                         ),
                     ),
                 );
-                db.set_check_constraints("EMP", constraints).unwrap();
-
-                (temp_dir, db)
+                setup_emp_db_with_constraints(Some(constraints))
             },
             |(_temp_dir, mut db)| {
                 let tuple = tuple! {
@@ -569,11 +564,7 @@ fn bench_insert_with_check_constraint(c: &mut Criterion) {
     group.bench_function("no_check", |b| {
         b.iter_batched(
             || {
-                let temp_dir = TempDir::new().unwrap();
-                let mut db = Database::open(temp_dir.path()).unwrap();
-                let emp_type = create_employee_type();
-                db.create_relvar("EMP", emp_type).unwrap();
-                (temp_dir, db)
+                setup_emp_db_with_constraints(None)
             },
             |(_temp_dir, mut db)| {
                 let tuple = tuple! {

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+🚮 Smell: `bench_insert_with_check_constraint` in `benches/database.rs` was over 100 lines long ("God Function") and contained duplicate logic for setting up a temporary database with an `EMP` relation across three different benchmark functions.
+✨ Solution: Extracted the common setup logic into a new private helper function `setup_emp_db_with_constraints(constraints: Option<CheckConstraints>) -> (TempDir, Database)`. Used this helper within `simple_check`, `complex_check`, and `no_check`.
+🧼 Benefit: Significantly reduces boilerplate and duplicate logic, shortening the `bench_insert_with_check_constraint` function and enforcing the DRY principle. Makes the benchmark setups easier to understand and maintain.
+🛡️ Verification: Tests passed. No logic changed. Verified via `git diff`.


### PR DESCRIPTION
🚮 Smell: `bench_insert_with_check_constraint` in `benches/database.rs` was over 100 lines long ("God Function") and contained duplicate logic for setting up a temporary database with an `EMP` relation across three different benchmark functions.
✨ Solution: Extracted the common setup logic into a new private helper function `setup_emp_db_with_constraints(constraints: Option<CheckConstraints>) -> (TempDir, Database)`. Used this helper within `simple_check`, `complex_check`, and `no_check`.
🧼 Benefit: Significantly reduces boilerplate and duplicate logic, shortening the `bench_insert_with_check_constraint` function and enforcing the DRY principle. Makes the benchmark setups easier to understand and maintain.
🛡️ Verification: Tests passed. No logic changed. Verified via `git diff`.

---
*PR created automatically by Jules for task [10223239558870488605](https://jules.google.com/task/10223239558870488605) started by @madmax983*