### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+💡 What: Updated `project`, `rename`, and `summarize` APIs in `relvar-core/src/query/mod.rs` to accept `IntoIterator` instead of `Vec`.
+🎯 Why: Eliminates heap allocation overhead by allowing stack-allocated arrays to be passed directly without `vec![]` allocations.
+📊 Impact: Reduces intermediate vector allocations significantly when building query plans.
+🔬 Measurement: Verify tests run successfully using array literals.

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -364,14 +364,17 @@ impl Query {
     }
 
     /// Wraps the query in a Project operation.
+    ///
+    /// ⚡ Performance Note: This accepts an `IntoIterator`, allowing you to pass stack-allocated
+    /// arrays (e.g., `["a", "b"]`) without incurring intermediate heap allocations.
     /// # Examples
     ///
     /// ```
     /// use relvar_core::query::Query;
     ///
-    /// let q = Query::scan("USERS").project(vec!["name", "email"]);
+    /// let q = Query::scan("USERS").project(["name", "email"]);
     /// ```
-    pub fn project<S: Into<String>>(self, attributes: Vec<S>) -> Self {
+    pub fn project<S: Into<String>, I: IntoIterator<Item = S>>(self, attributes: I) -> Self {
         Query::Project {
             input: Box::new(self),
             attributes: attributes.into_iter().map(|s| s.into()).collect(),
@@ -379,14 +382,20 @@ impl Query {
     }
 
     /// Wraps the query in a Rename operation.
+    ///
+    /// ⚡ Performance Note: This accepts an `IntoIterator`, allowing you to pass stack-allocated
+    /// arrays (e.g., `[("a", "b")]`) without incurring intermediate heap allocations.
     /// # Examples
     ///
     /// ```
     /// use relvar_core::query::Query;
     ///
-    /// let q = Query::scan("USERS").rename(vec![("name", "full_name")]);
+    /// let q = Query::scan("USERS").rename([("name", "full_name")]);
     /// ```
-    pub fn rename<S1: Into<String>, S2: Into<String>>(self, mappings: Vec<(S1, S2)>) -> Self {
+    pub fn rename<S1: Into<String>, S2: Into<String>, I: IntoIterator<Item = (S1, S2)>>(
+        self,
+        mappings: I,
+    ) -> Self {
         Query::Rename {
             input: Box::new(self),
             mappings: mappings
@@ -414,23 +423,30 @@ impl Query {
     }
 
     /// Wraps the query in a Summarize operation.
+    ///
+    /// ⚡ Performance Note: This accepts `IntoIterator`s for both groupings and aggregations,
+    /// allowing stack-allocated arrays to be passed and avoiding intermediate heap allocations.
     /// # Examples
     ///
     /// ```
     /// use relvar_core::query::Query;
     /// use relvar_core::algebra::Aggregation;
     ///
-    /// let q = Query::scan("USERS").summarize(vec!["department"], vec![Aggregation::count("emp_count")]);
+    /// let q = Query::scan("USERS").summarize(["department"], [Aggregation::count("emp_count")]);
     /// ```
-    pub fn summarize<S: Into<String>>(
+    pub fn summarize<
+        S: Into<String>,
+        I1: IntoIterator<Item = S>,
+        I2: IntoIterator<Item = Aggregation>,
+    >(
         self,
-        group_by: Vec<S>,
-        aggregations: Vec<Aggregation>,
+        group_by: I1,
+        aggregations: I2,
     ) -> Self {
         Query::Summarize {
             input: Box::new(self),
             group_by: group_by.into_iter().map(|s| s.into()).collect(),
-            aggregations,
+            aggregations: aggregations.into_iter().collect(),
         }
     }
 }

--- a/relvar-core/src/query/tests/basic.rs
+++ b/relvar-core/src/query/tests/basic.rs
@@ -36,7 +36,7 @@ fn test_restrict() {
 #[test]
 fn test_project() {
     let db = setup_db();
-    let query = Query::scan("USERS").project(vec!["name"]);
+    let query = Query::scan("USERS").project(["name"]);
 
     let result = query.execute(&db).unwrap();
     assert_eq!(result.degree(), 1);
@@ -46,7 +46,7 @@ fn test_project() {
 #[test]
 fn test_rename() {
     let db = setup_db();
-    let query = Query::scan("USERS").rename(vec![("name", "full_name")]);
+    let query = Query::scan("USERS").rename([("name", "full_name")]);
 
     let result = query.execute(&db).unwrap();
     assert!(result.relation_type().heading().has_attribute("full_name"));
@@ -69,7 +69,7 @@ fn test_join() {
 #[test]
 fn test_summarize() {
     let db = setup_db();
-    let query = Query::scan("USERS").summarize(vec!["age"], vec![Aggregation::count("count")]);
+    let query = Query::scan("USERS").summarize(["age"], [Aggregation::count("count")]);
     let result = query.execute(&db).unwrap();
 
     // One person with age 25, one with age 30
@@ -84,7 +84,7 @@ fn test_explain() {
             op: CmpOp::Eq,
             right: ValueOrRef::Value(ScalarValue::Int(1)),
         })
-        .project(vec!["name"]);
+        .project(["name"]);
 
     let explain_str = query.explain();
     assert!(explain_str.contains("Project([\"name\"])"));
@@ -94,10 +94,10 @@ fn test_explain() {
     let q_join = Query::scan("A").join(Query::scan("B"));
     assert!(q_join.explain().contains("Join"));
 
-    let q_rename = Query::scan("A").rename(vec![("old", "new")]);
+    let q_rename = Query::scan("A").rename([("old", "new")]);
     assert!(q_rename.explain().contains("Rename([(\"old\", \"new\")])"));
 
-    let q_summarize = Query::scan("A").summarize(vec!["a"], vec![Aggregation::count("cnt")]);
+    let q_summarize = Query::scan("A").summarize(["a"], [Aggregation::count("cnt")]);
     assert!(q_summarize.explain().contains("Summarize"));
 }
 
@@ -106,7 +106,7 @@ fn test_query_error_propagation() {
     let db = setup_db();
 
     // Algebra error in Summarize (grouping by missing attribute)
-    let q_bad_sum = Query::scan("USERS").summarize(vec!["nonexistent_col"], vec![]);
+    let q_bad_sum = Query::scan("USERS").summarize(["nonexistent_col"], []);
     let err = q_bad_sum.execute(&db);
     assert!(matches!(err, Err(QueryError::Algebra(_))));
 }

--- a/relvar-core/tests/sentry_query_coverage.rs
+++ b/relvar-core/tests/sentry_query_coverage.rs
@@ -72,7 +72,7 @@ fn test_query_project_coverage() {
     db.insert("TEST", tuple! { id: 1i64, name: "Alice".to_string() })
         .unwrap();
 
-    let query = Query::scan("TEST").project(vec!["id"]);
+    let query = Query::scan("TEST").project(["id"]);
 
     let result = query.execute(&db).unwrap();
     assert_eq!(result.cardinality(), 1);
@@ -88,7 +88,7 @@ fn test_query_rename_coverage() {
     db.create_relvar("TEST", rel_type).unwrap();
     db.insert("TEST", tuple! { id: 1i64 }).unwrap();
 
-    let query = Query::scan("TEST").rename(vec![("id", "new_id")]);
+    let query = Query::scan("TEST").rename([("id", "new_id")]);
 
     let result = query.execute(&db).unwrap();
     assert_eq!(result.cardinality(), 1);

--- a/relvar/tests/query_builder.rs
+++ b/relvar/tests/query_builder.rs
@@ -60,7 +60,7 @@ fn test_query_builder_e2e() {
             op: CmpOp::Eq,
             right: ValueOrRef::Value(ScalarValue::Int(10)),
         })
-        .project(vec!["name", "salary"]);
+        .project(["name", "salary"]);
 
     // 3. Execute
     let result = query.execute(&db).unwrap();
@@ -171,10 +171,10 @@ fn test_query_rename_aggregations() {
 
     // Query: Rename id -> player_id, Summarize by player_id, Min(score), Max(score), Sum(score)
     let query = Query::scan("SCORES")
-        .rename(vec![("id", "player_id")])
+        .rename([("id", "player_id")])
         .summarize(
-            vec!["player_id"],
-            vec![
+            ["player_id"],
+            [
                 Aggregation::min("min_score", "score", ScalarType::Int),
                 Aggregation::max("max_score", "score", ScalarType::Int),
                 Aggregation::sum("total_score", "score"),


### PR DESCRIPTION
💡 What: Updated `project`, `rename`, and `summarize` APIs in `relvar-core/src/query/mod.rs` to accept `IntoIterator` instead of `Vec`.
🎯 Why: Eliminates heap allocation overhead by allowing stack-allocated arrays to be passed directly without `vec![]` allocations.
📊 Impact: Reduces intermediate vector allocations significantly when building query plans.
🔬 Measurement: Verify tests run successfully using array literals.

---
*PR created automatically by Jules for task [18146088078860517243](https://jules.google.com/task/18146088078860517243) started by @madmax983*