### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+📖 Chapter: The `Spreadsheet` Experimental Engine
+🔦 Insight: Executable doc-tests have been systematically added to `Spreadsheet`'s `new` and `evaluate` methods. Previously, these functions contained empty placeholder examples which made it confusing to understand how to initialize the relations representing values and formulas or how the fixpoint evaluation executed the arithmetic formulas purely using relational algebra.
+🧪 Example: Added 2 comprehensive, executable doctests demonstrating how to populate raw values, define "ADD" formulas linking cells, and successfully evaluate the spreadsheet.
+🖼️ Preview: Evaluated the addition formula natively during the doc-tests via `cargo test --doc`.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -23,9 +23,28 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar_core::tuple;
+    /// use relvar_core::types::{RelationType, ScalarType, TupleType};
+    /// use relvar_core::values::{Relation, ScalarValue};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_heading));
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -36,9 +55,32 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar_core::tuple;
+    /// use relvar_core::types::{RelationType, ScalarType, TupleType};
+    /// use relvar_core::values::{Relation, ScalarValue};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_heading));
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    ///
+    /// assert_eq!(result.cardinality(), 3); // A1, A2, and B1 (which is 10 + 20 = 30)
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
📖 Chapter: The `Spreadsheet` Experimental Engine
🔦 Insight: Executable doc-tests have been systematically added to `Spreadsheet`'s `new` and `evaluate` methods. Previously, these functions contained empty placeholder examples which made it confusing to understand how to initialize the relations representing values and formulas or how the fixpoint evaluation executed the arithmetic formulas purely using relational algebra.
🧪 Example: Added 2 comprehensive, executable doctests demonstrating how to populate raw values, define "ADD" formulas linking cells, and successfully evaluate the spreadsheet.
🖼️ Preview: Evaluated the addition formula natively during the doc-tests via `cargo test --doc`.

---
*PR created automatically by Jules for task [10851182753909554668](https://jules.google.com/task/10851182753909554668) started by @madmax983*