### PR TITLE
⚒️ Forge: [refactor image processing]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,7 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+
+## 2024-05-30 - Extract God Function in image processing
+**Learning:** `compute_kernel_contributions` in `relvar/src/experimental/image.rs` was a large "God Function" that combined shifting/scaling, weighted component computation, and index addition/projection in a large loop.
+**Action:** Applied the 'Three-Phase Operator' pattern to extract logic into `extend_target_coordinates`, `extend_weighted_colors` and `extend_kernel_idx_and_project` helper functions.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,16 @@
+# ⚒️ Forge: [refactor image processing]
+
+## 🚮 Smell
+The `compute_kernel_contributions` function in `relvar/src/experimental/image.rs` was a classic "God Function" (74 lines long). Inside a loop, it mixed three distinct relational operations: shifting coordinates (`extend`), weighting color components (`extend`), and adding kernel indices before projecting to a standard schema. This large block of nested relational operations made the execution flow hard to read and violated the "Three-Phase Operator" pattern.
+
+## ✨ Solution
+Applied the "Three-Phase Operator" pattern to flatten the structure. The core loop body was extracted into three strictly-typed, descriptive private helper functions:
+1. `extend_target_coordinates`: Handles shifting the coordinates (`tx` and `ty`).
+2. `extend_weighted_colors`: Computes the weighted `r`, `g`, `b` components.
+3. `extend_kernel_idx_and_project`: Appends the kernel index and finalizes the schema mapping.
+
+## 🧼 Benefit
+Dramatically improves readability and decreases cognitive load. The main loop in `compute_kernel_contributions` is now simply a pipeline of three clearly named steps. Types and boundaries act as documentation, and nesting is reduced, strictly following the Forge philosophy of flattened, understandable code.
+
+## 🛡️ Verification
+Ran `cargo test` and `cargo clippy`. Tests passed. No logic was changed, and runtime behavior remains exactly identical.

--- a/relvar/src/experimental/image.rs
+++ b/relvar/src/experimental/image.rs
@@ -197,75 +197,65 @@ fn compute_kernel_contributions(relation: &Relation, kernel: &[KernelTap]) -> Ve
     let mut contributions = Vec::with_capacity(kernel.len());
 
     for (i, tap) in kernel.iter().enumerate() {
-        let dx = tap.dx;
-        let dy = tap.dy;
-        let weight = tap.weight;
-        let k_idx = i as i64;
-
-        // Step 1: Shift and Scale
-        // We use extend to compute new coordinates and weighted values
-        // We project to keep only relevant columns + k_idx
-        // Logic: A pixel at (x,y) contributes to (x+dx, y+dy) with weight w.
-        // So for a target pixel (tx, ty), the source is (tx-dx, ty-dy).
-        // But here we are iterating source pixels.
-        // Source (x,y) contributes to Target (x+dx, y+dy).
-        // So let's name the new coordinates `tx` and `ty`.
-
-        // Extend 1: Calculate target coordinates
-        let with_coords = relation
-            .extend("tx", ScalarType::Int, move |t| {
-                let x = t.get_typed::<i64>("x").unwrap();
-                ScalarValue::Int(x + dx)
-            })
-            .unwrap()
-            .extend("ty", ScalarType::Int, move |t| {
-                let y = t.get_typed::<i64>("y").unwrap();
-                ScalarValue::Int(y + dy)
-            })
-            .unwrap();
-
-        // Extend 2: Calculate weighted color components
-        let with_weights = with_coords
-            .extend("wr", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("r").unwrap();
-                ScalarValue::Int(v * weight)
-            })
-            .unwrap()
-            .extend("wg", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("g").unwrap();
-                ScalarValue::Int(v * weight)
-            })
-            .unwrap()
-            .extend("wb", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("b").unwrap();
-                ScalarValue::Int(v * weight)
-            })
-            .unwrap();
-
-        // Extend 3: Add kernel index (to prevent set deduplication of values)
-        let with_idx = with_weights
-            .extend("k_idx", ScalarType::Int, move |_| ScalarValue::Int(k_idx))
-            .unwrap();
-
-        // Project: Keep (tx, ty, wr, wg, wb, k_idx)
-        // But we rename them to a standard schema for Union
-        // Standard: (x, y, r, g, b, k_idx)
-        // Rename mapping: tx->x, ty->y, wr->r, wg->g, wb->b
-        let rename_map = vec![
-            ("tx", "x"),
-            ("ty", "y"),
-            ("wr", "r"),
-            ("wg", "g"),
-            ("wb", "b"),
-        ];
-
-        let projected = with_idx.project(&["tx", "ty", "wr", "wg", "wb", "k_idx"]);
-        let renamed = projected.rename(&rename_map);
+        let with_coords = extend_target_coordinates(relation, tap.dx, tap.dy);
+        let with_weights = extend_weighted_colors(&with_coords, tap.weight);
+        let renamed = extend_kernel_idx_and_project(&with_weights, i as i64);
 
         contributions.push(renamed);
     }
 
     contributions
+}
+
+fn extend_target_coordinates(relation: &Relation, dx: i64, dy: i64) -> Relation {
+    relation
+        .extend("tx", ScalarType::Int, move |t| {
+            let x = t.get_typed::<i64>("x").unwrap();
+            ScalarValue::Int(x + dx)
+        })
+        .unwrap()
+        .extend("ty", ScalarType::Int, move |t| {
+            let y = t.get_typed::<i64>("y").unwrap();
+            ScalarValue::Int(y + dy)
+        })
+        .unwrap()
+}
+
+fn extend_weighted_colors(relation: &Relation, weight: i64) -> Relation {
+    relation
+        .extend("wr", ScalarType::Int, move |t| {
+            let v = t.get_typed::<i64>("r").unwrap();
+            ScalarValue::Int(v * weight)
+        })
+        .unwrap()
+        .extend("wg", ScalarType::Int, move |t| {
+            let v = t.get_typed::<i64>("g").unwrap();
+            ScalarValue::Int(v * weight)
+        })
+        .unwrap()
+        .extend("wb", ScalarType::Int, move |t| {
+            let v = t.get_typed::<i64>("b").unwrap();
+            ScalarValue::Int(v * weight)
+        })
+        .unwrap()
+}
+
+fn extend_kernel_idx_and_project(relation: &Relation, k_idx: i64) -> Relation {
+    let with_idx = relation
+        .extend("k_idx", ScalarType::Int, move |_| ScalarValue::Int(k_idx))
+        .unwrap();
+
+    let rename_map = vec![
+        ("tx", "x"),
+        ("ty", "y"),
+        ("wr", "r"),
+        ("wg", "g"),
+        ("wb", "b"),
+    ];
+
+    with_idx
+        .project(&["tx", "ty", "wr", "wg", "wb", "k_idx"])
+        .rename(&rename_map)
 }
 
 fn union_contributions(contributions: &[Relation]) -> Relation {


### PR DESCRIPTION
# ⚒️ Forge: [refactor image processing]

## 🚮 Smell
The `compute_kernel_contributions` function in `relvar/src/experimental/image.rs` was a classic "God Function" (74 lines long). Inside a loop, it mixed three distinct relational operations: shifting coordinates (`extend`), weighting color components (`extend`), and adding kernel indices before projecting to a standard schema. This large block of nested relational operations made the execution flow hard to read and violated the "Three-Phase Operator" pattern.

## ✨ Solution
Applied the "Three-Phase Operator" pattern to flatten the structure. The core loop body was extracted into three strictly-typed, descriptive private helper functions:
1. `extend_target_coordinates`: Handles shifting the coordinates (`tx` and `ty`).
2. `extend_weighted_colors`: Computes the weighted `r`, `g`, `b` components.
3. `extend_kernel_idx_and_project`: Appends the kernel index and finalizes the schema mapping.

## 🧼 Benefit
Dramatically improves readability and decreases cognitive load. The main loop in `compute_kernel_contributions` is now simply a pipeline of three clearly named steps. Types and boundaries act as documentation, and nesting is reduced, strictly following the Forge philosophy of flattened, understandable code.

## 🛡️ Verification
Ran `cargo test` and `cargo clippy`. Tests passed. No logic was changed, and runtime behavior remains exactly identical.

---
*PR created automatically by Jules for task [11718536806601907703](https://jules.google.com/task/11718536806601907703) started by @madmax983*