### PR TITLE
⚡ Bolt: Remove intermediate Vec<String> allocation in group operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,7 @@
 ## 2024-05-20 - String Allocations in Iterators
 **Learning:** `rename_into` previously consumed a tuple's BTreeMap entirely to scalar values by calling `.into_values()`. However, BTreeMaps also implement `into_iter()` which yields owned `(K, V)` pairs. We were discarding the `K` (the original String key) and creating a brand new String key for every column of every tuple, even if the rename mapping didn't touch it.
 **Action:** Always check if we can reuse the owned strings from an input collection instead of reflexively throwing them away and re-allocating them in an iterator pipeline.
+
+## $(date +%Y-%m-%d) - [Group Operator Vec Allocation Removal]
+**Learning:** In relational grouping operations, extracting grouping attributes previously mapped to a `Vec<String>`. `Tuple::new_unchecked` expects a `BTreeMap<String, ScalarValue>`, which natively consumes `String` keys during insertion. Pre-allocating a vector to store all mapped `attr_names` only to clone them later provides no benefit and forces redundant intermediate heap allocations on the hot path.
+**Action:** Remove intermediate `Vec<String>` pre-allocations when creating string keys for `Tuple` properties. Instead, perform `attr.to_string()` lazily at the exact point of insertion into the `BTreeMap`, allowing the compiler to manage just the final necessary string allocations. Update validation helper signatures to pass down slices of references (`&[&str]`) instead of owned strings.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,9 @@
+# ⚡ Bolt: Remove intermediate Vec<String> allocation in group operations
+
+💡 What: Changed the internal signature of `validate_group_request` to return a `Vec<&str>` instead of `Vec<String>`, allowing `grouping_attrs` to be passed as `&[&str]` through the call stack (`build_group_result_heading`, `compute_grouped_tuples`, `group_tuples`). This entirely removed the intermediate `Vec<String>` pre-allocation for `attr_names` and instead directly called `attr.to_string()` during attribute insertion.
+
+🎯 Why: During relational grouping operations, extracting grouping attributes involved mapping and allocating a `Vec<String>`. `Tuple::new_unchecked` expects a `BTreeMap<String, ScalarValue>`, which natively consumes `String` keys. Pre-allocating all `attr_names` only to clone them later provided no benefit and simply created redundant intermediate heap allocations on the hot path for each tuple in a nested group.
+
+📊 Impact: Reduces heap allocation overhead during group operations.
+
+🔬 Measurement: Run benchmark `cargo bench --bench group`.

--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -190,11 +190,11 @@ impl Relation {
 
 // --- Private Helper Functions for Group ---
 
-fn validate_group_request(
-    relation: &Relation,
+fn validate_group_request<'a>(
+    relation: &'a Relation,
     attrs_to_group: &[&str],
     rva_name: &str,
-) -> Result<Vec<String>, GroupError> {
+) -> Result<Vec<&'a str>, GroupError> {
     if attrs_to_group.is_empty() {
         return Err(GroupError::NoAttributesSpecified);
     }
@@ -212,18 +212,18 @@ fn validate_group_request(
     }
 
     // Determine grouping attributes (the ones NOT being grouped into RVA)
-    let grouping_attrs: Vec<String> = relation
+    let grouping_attrs: Vec<&'a str> = relation
         .relation_type()
         .tuple_type()
         .attribute_names()
         .filter(|attr| !attrs_to_group.contains(&attr.as_str()))
-        .map(|s| s.to_string())
+        .map(|s| s.as_str())
         .collect();
 
     // Check RVA name doesn't conflict with grouping attributes
     // Note: We check against the resulting heading, which contains grouping attributes + RVA name
     // If rva_name is one of the grouping attributes, that's a conflict.
-    if grouping_attrs.contains(&rva_name.to_string()) {
+    if grouping_attrs.contains(&rva_name) {
         return Err(GroupError::ResultAttributeExists(rva_name.to_string()));
     }
 
@@ -232,7 +232,7 @@ fn validate_group_request(
 
 fn build_group_result_heading(
     relation: &Relation,
-    grouping_attrs: &[String],
+    grouping_attrs: &[&str],
     attrs_to_group: &[&str],
     rva_name: &str,
 ) -> Result<(TupleType, TupleType), GroupError> {
@@ -246,7 +246,7 @@ fn build_group_result_heading(
             .tuple_type()
             .get_attribute_type(attr)
             .unwrap();
-        result_heading = result_heading.with_attribute(attr.clone(), attr_type.clone());
+        result_heading = result_heading.with_attribute(attr.to_string(), attr_type.clone());
     }
 
     // Build RVA heading (from attributes being grouped)
@@ -276,15 +276,12 @@ fn build_group_result_heading(
 /// this prevents dynamic heap reallocations when constructing the resulting relation.
 fn group_tuples<'a>(
     relation: &'a Relation,
-    grouping_attrs: &[String],
+    grouping_attrs: &[&str],
     attrs_to_group: &[&str],
     rva_heading_arc: std::sync::Arc<TupleType>,
 ) -> Result<HashMap<Vec<&'a ScalarValue>, std::collections::HashSet<Tuple>>, GroupError> {
     let mut groups: HashMap<Vec<&'a ScalarValue>, std::collections::HashSet<Tuple>> =
         HashMap::new();
-
-    // Pre-allocate attribute name strings
-    let attr_names: Vec<String> = attrs_to_group.iter().map(|a| a.to_string()).collect();
 
     // PERF: Reusable buffer for the grouping key avoids allocating a new Vec
     // for every single tuple just to query the HashMap.
@@ -299,8 +296,8 @@ fn group_tuples<'a>(
 
         // Extract grouped attributes for RVA
         let mut rva_values = std::collections::BTreeMap::new();
-        for (i, &attr) in attrs_to_group.iter().enumerate() {
-            rva_values.insert(attr_names[i].clone(), tuple.get(attr).unwrap().clone());
+        for &attr in attrs_to_group.iter() {
+            rva_values.insert(attr.to_string(), tuple.get(attr).unwrap().clone());
         }
 
         let rva_tuple = Tuple::new_unchecked(rva_heading_arc.clone(), rva_values);
@@ -321,7 +318,7 @@ fn group_tuples<'a>(
 
 fn compute_grouped_tuples(
     relation: &Relation,
-    grouping_attrs: &[String],
+    grouping_attrs: &[&str],
     attrs_to_group: &[&str],
     result_heading: &TupleType,
     rva_heading: &TupleType,
@@ -340,7 +337,7 @@ fn compute_grouped_tuples(
 
         // Add grouping attribute values
         for (i, attr) in grouping_attrs.iter().enumerate() {
-            values.insert(attr.clone(), (*key[i]).clone());
+            values.insert(attr.to_string(), (*key[i]).clone());
         }
 
         // Create RVA relation


### PR DESCRIPTION
# ⚡ Bolt: Remove intermediate Vec<String> allocation in group operations

💡 What: Changed the internal signature of `validate_group_request` to return a `Vec<&str>` instead of `Vec<String>`, allowing `grouping_attrs` to be passed as `&[&str]` through the call stack (`build_group_result_heading`, `compute_grouped_tuples`, `group_tuples`). This entirely removed the intermediate `Vec<String>` pre-allocation for `attr_names` and instead directly called `attr.to_string()` during attribute insertion.

🎯 Why: During relational grouping operations, extracting grouping attributes involved mapping and allocating a `Vec<String>`. `Tuple::new_unchecked` expects a `BTreeMap<String, ScalarValue>`, which natively consumes `String` keys. Pre-allocating all `attr_names` only to clone them later provided no benefit and simply created redundant intermediate heap allocations on the hot path for each tuple in a nested group.

📊 Impact: Reduces heap allocation overhead during group operations.

🔬 Measurement: Run benchmark `cargo bench --bench group`.

---
*PR created automatically by Jules for task [6452098231171953523](https://jules.google.com/task/6452098231171953523) started by @madmax983*