### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -27,3 +27,6 @@
 ## 2024-05-19 - Fixing Public Module Leaks
 **Tangle:** Broad visibility (`pub mod`) across many test and internal modules leaked implementation details and complicated the dependency graph.
 **Blueprint:** Converted most top-level internal module definitions in `relvar-core` and `relvar-storage` and `relvar` to `pub(crate) mod` where appropriate, and fixed some lingering pub use statements.
+## 2024-05-19 - Catalog Entry Domain Boundary
+**Tangle:** The `RelationMetadata` struct name was duplicated across `relvar-core::storage_engine` and `relvar-storage::storage::catalog`, representing different concepts (public logical metadata vs internal physical location tracking), violating clear domain boundaries.
+**Blueprint:** Renamed the catalog-specific struct to `CatalogEntry` to distinguish it from the core logical `RelationMetadata`, removing the name collision and clarifying the physical storage responsibilities.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🗺️ Atlas: [architectural change]
+
+🕸️ Tangle: The `RelationMetadata` struct name was duplicated across `relvar-core::storage_engine` and `relvar-storage::storage::catalog`, representing different concepts (public logical metadata vs internal physical location tracking), violating clear domain boundaries and causing a naming collision.
+📐 Blueprint: Renamed the catalog-specific struct to `CatalogEntry` to distinguish it from the core logical `RelationMetadata`, removing the name collision and clarifying the physical storage responsibilities.
+🧱 Stability: Reduced coupling by clarifying domain boundaries; internal physical metadata is now distinctly named from logical core metadata.
+🔬 Verification: Builds successfully, all tests pass, and strict separation is enforced without leaky abstractions.

--- a/relvar-storage/src/storage/catalog.rs
+++ b/relvar-storage/src/storage/catalog.rs
@@ -78,7 +78,7 @@ const MAX_CATALOG_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
 /// - `relation_type` - The type (heading) defining attribute names and types
 /// - `heap_file_path` - Path to the heap file containing the relation's tuples
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RelationMetadata {
+pub struct CatalogEntry {
     /// The relation's type (heading).
     pub relation_type: RelationType,
     /// Path to the heap file storing the relation's data.
@@ -127,7 +127,7 @@ pub struct RelationMetadata {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Catalog {
     /// Map from relation name to metadata.
-    relations: HashMap<String, RelationMetadata>,
+    relations: HashMap<String, CatalogEntry>,
 }
 
 impl Catalog {
@@ -258,7 +258,7 @@ impl Catalog {
             return Err(CatalogError::RelationExists(name));
         }
 
-        let metadata = RelationMetadata {
+        let metadata = CatalogEntry {
             relation_type,
             heap_file_path,
         };
@@ -285,7 +285,7 @@ impl Catalog {
     /// let meta = catalog.get_relation("my_table").unwrap();
     /// assert_eq!(meta.heap_file_path, PathBuf::from("my_table.heap"));
     /// ```
-    pub fn get_relation(&self, name: &str) -> Result<&RelationMetadata, CatalogError> {
+    pub fn get_relation(&self, name: &str) -> Result<&CatalogEntry, CatalogError> {
         self.relations
             .get(name)
             .ok_or_else(|| CatalogError::RelationNotFound(name.to_string()))
@@ -316,7 +316,7 @@ impl Catalog {
     ///
     /// Returns [`CatalogError::RelationNotFound`] if no relation with
     /// this name exists.
-    pub fn drop_relation(&mut self, name: &str) -> Result<RelationMetadata, CatalogError> {
+    pub fn drop_relation(&mut self, name: &str) -> Result<CatalogEntry, CatalogError> {
         self.relations
             .remove(name)
             .ok_or_else(|| CatalogError::RelationNotFound(name.to_string()))

--- a/relvar-storage/src/storage/mod.rs
+++ b/relvar-storage/src/storage/mod.rs
@@ -66,7 +66,8 @@ pub(crate) mod heap;
 pub(crate) mod manager;
 pub(crate) mod page;
 
-pub use catalog::{Catalog, CatalogError, RelationMetadata};
+pub use catalog::{Catalog, CatalogEntry, CatalogError};
+
 pub use heap::{HeapError, HeapFile};
 pub use manager::StorageManager;
 // TupleId is now pub(crate) in heap.rs, not exported


### PR DESCRIPTION
🕸️ Tangle: The `RelationMetadata` struct name was duplicated across `relvar-core::storage_engine` and `relvar-storage::storage::catalog`, representing different concepts (public logical metadata vs internal physical location tracking), violating clear domain boundaries and causing a naming collision.
📐 Blueprint: Renamed the catalog-specific struct to `CatalogEntry` to distinguish it from the core logical `RelationMetadata`, removing the name collision and clarifying the physical storage responsibilities.
🧱 Stability: Reduced coupling by clarifying domain boundaries; internal physical metadata is now distinctly named from logical core metadata.
🔬 Verification: Builds successfully, all tests pass, and strict separation is enforced without leaky abstractions.

---
*PR created automatically by Jules for task [6989467652906651839](https://jules.google.com/task/6989467652906651839) started by @madmax983*