### PR TITLE
⚒️ Forge: Refactor Spreadsheet evaluate method

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,6 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+## 2026-05-20 - Extract God Function in Spreadsheet evaluate
+**Learning:** The evaluate method in Spreadsheet was a God Function that combined finding unresolved formulas, resolving arguments, and evaluating formulas into one long block.
+**Action:** Applied the Three-Phase Operator pattern by extracting find_unresolved_formulas, resolve_arguments, and evaluate_resolved_formulas into separate helper functions to improve readability without changing behavior.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+🚮 Smell: The `evaluate` method in `Spreadsheet` was an overly long "God Function" that combined the logic for finding unresolved formulas, resolving their arguments against current values, and evaluating the final mathematical expressions into one continuous block.
+✨ Solution: Applied the "Three-Phase Operator" pattern. Extracted the logic into three private, well-named helper functions: `find_unresolved_formulas`, `resolve_arguments`, and `evaluate_resolved_formulas`.
+🧼 Benefit: Significantly reduces cognitive load. The main loop is now concise and clearly describes the high-level algorithm, while the details of relational joins and extensions are encapsulated in the helper methods.
+🛡️ Verification: Tests passed. No logic changed.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -46,53 +46,10 @@ impl Spreadsheet {
         loop {
             let initial_count = current_values.cardinality();
 
-            // Find unresolved formulas by antijoining/difference with resolved values
-            // We only want formulas whose 'id' is NOT yet in current_values
-            let resolved_ids = current_values.project(&["id"]);
-            let formula_ids = self.formulas.project(&["id"]);
-
-            let unresolved_ids = formula_ids
-                .difference(&resolved_ids)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            let unresolved_formulas = self.formulas.join(&unresolved_ids)?;
-
-            // Rename current_values for arg1
-            let values_arg1 = current_values.rename(&[("id", "arg1"), ("val", "val1")]);
-            // Rename current_values for arg2
-            let values_arg2 = current_values.rename(&[("id", "arg2"), ("val", "val2")]);
-
-            // Join unresolved formulas with arg1 values
-            let with_arg1 = unresolved_formulas.join(&values_arg1)?;
-            // Join with arg2 values
-            let fully_resolved_args = with_arg1.join(&values_arg2)?;
-
-            // Evaluate the formula
-            let evaluated = fully_resolved_args
-                .extend("val", ScalarType::Float, |t| {
-                    let op = t.get_typed::<String>("op").unwrap();
-                    let val1 = t.get_typed::<f64>("val1").unwrap();
-                    let val2 = t.get_typed::<f64>("val2").unwrap();
-
-                    let result = match op.as_str() {
-                        "ADD" => val1 + val2,
-                        "SUB" => val1 - val2,
-                        "MUL" => val1 * val2,
-                        "DIV" => {
-                            if val2 != 0.0 {
-                                val1 / val2
-                            } else {
-                                f64::NAN
-                            }
-                        }
-                        _ => f64::NAN,
-                    };
-                    ScalarValue::Float(result)
-                })
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            // Project back to (id, val)
-            let new_values = evaluated.project(&["id", "val"]);
+            let unresolved_formulas = self.find_unresolved_formulas(&current_values)?;
+            let fully_resolved_args =
+                self.resolve_arguments(&unresolved_formulas, &current_values)?;
+            let new_values = self.evaluate_resolved_formulas(&fully_resolved_args)?;
 
             // Union with current values
             current_values = current_values
@@ -105,6 +62,70 @@ impl Spreadsheet {
         }
 
         Ok(current_values)
+    }
+
+    fn find_unresolved_formulas(
+        &self,
+        current_values: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        // Find unresolved formulas by antijoining/difference with resolved values
+        // We only want formulas whose 'id' is NOT yet in current_values
+        let resolved_ids = current_values.project(&["id"]);
+        let formula_ids = self.formulas.project(&["id"]);
+
+        let unresolved_ids = formula_ids
+            .difference(&resolved_ids)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        self.formulas.join(&unresolved_ids)
+    }
+
+    fn resolve_arguments(
+        &self,
+        unresolved_formulas: &Relation,
+        current_values: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        // Rename current_values for arg1
+        let values_arg1 = current_values.rename(&[("id", "arg1"), ("val", "val1")]);
+        // Rename current_values for arg2
+        let values_arg2 = current_values.rename(&[("id", "arg2"), ("val", "val2")]);
+
+        // Join unresolved formulas with arg1 values
+        let with_arg1 = unresolved_formulas.join(&values_arg1)?;
+        // Join with arg2 values
+        with_arg1.join(&values_arg2)
+    }
+
+    fn evaluate_resolved_formulas(
+        &self,
+        fully_resolved_args: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        // Evaluate the formula
+        let evaluated = fully_resolved_args
+            .extend("val", ScalarType::Float, |t| {
+                let op = t.get_typed::<String>("op").unwrap();
+                let val1 = t.get_typed::<f64>("val1").unwrap();
+                let val2 = t.get_typed::<f64>("val2").unwrap();
+
+                let result = match op.as_str() {
+                    "ADD" => val1 + val2,
+                    "SUB" => val1 - val2,
+                    "MUL" => val1 * val2,
+                    "DIV" => {
+                        if val2 != 0.0 {
+                            val1 / val2
+                        } else {
+                            f64::NAN
+                        }
+                    }
+                    _ => f64::NAN,
+                };
+                ScalarValue::Float(result)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        // Project back to (id, val)
+        Ok(evaluated.project(&["id", "val"]))
     }
 }
 


### PR DESCRIPTION
🚮 Smell: The `evaluate` method in `Spreadsheet` was an overly long "God Function" that combined the logic for finding unresolved formulas, resolving their arguments against current values, and evaluating the final mathematical expressions into one continuous block.
✨ Solution: Applied the "Three-Phase Operator" pattern. Extracted the logic into three private, well-named helper functions: `find_unresolved_formulas`, `resolve_arguments`, and `evaluate_resolved_formulas`.
🧼 Benefit: Significantly reduces cognitive load. The main loop is now concise and clearly describes the high-level algorithm, while the details of relational joins and extensions are encapsulated in the helper methods.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [14924702760319096712](https://jules.google.com/task/14924702760319096712) started by @madmax983*