### PR TITLE
⚡ Bolt: [Join Operators Allocation Removal]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,6 @@
 ## 2024-05-20 - String Allocations in Iterators
 **Learning:** `rename_into` previously consumed a tuple's BTreeMap entirely to scalar values by calling `.into_values()`. However, BTreeMaps also implement `into_iter()` which yields owned `(K, V)` pairs. We were discarding the `K` (the original String key) and creating a brand new String key for every column of every tuple, even if the rename mapping didn't touch it.
 **Action:** Always check if we can reuse the owned strings from an input collection instead of reflexively throwing them away and re-allocating them in an iterator pipeline.
+## 2025-05-25 - [Zero-cost abstraction for consuming semijoin_into methods]
+**Learning:** When trying to eliminate intermediate `String` allocations inside consuming relational algebra methods like `semijoin_into(self, other: &Relation)`, attempting to borrow `&str` from `self` causes borrow checker conflicts ("cannot move out of self because it is borrowed") because `self` is subsequently mutated (`self.restrict_into`).
+**Action:** Since we're looking for *common* attributes, we can extract the `&str` references from the immutable `other: &Relation` parameter instead, satisfying lifetimes and achieving the zero-allocation abstraction perfectly.

--- a/fix_test_attr.sh
+++ b/fix_test_attr.sh
@@ -1,1 +1,0 @@
-sed -i 's/mod tests {/#[cfg(test)]\nmod tests {/' relvar-storage/src/storage/heap.rs

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,11 @@
+💡 What
+Modified `join` and `semijoin` operations (including `theta_join`, `semijoin_into`, and `semidifference_into`) to use `Vec<&str>` instead of allocating `Vec<String>` when extracting common attributes. The `JoinKey` and `SemijoinKey` structs were also updated to hold `&[&str]` slices.
+
+🎯 Why
+When executing relational algebra operations like joins, identifying common attributes between two relations previously mapped the attribute names to `String` using `.cloned()`. This incurred unnecessary heap allocations proportional to the number of common attributes in the relations on every single join operation, acting as a performance bottleneck.
+
+📊 Impact
+Eliminates `String` heap allocations during the setup phase of `join`, `theta_join`, `semijoin`, `semidifference` operations by zero-cost abstracting over string slices from the underlying attribute schema. Memory allocations and time taken per operation will be measurably reduced.
+
+🔬 Measurement
+Review `cargo clippy`, `cargo test`, and `cargo bench` to observe the removed allocations and ensure correctness remains intact with the new slice mappings.

--- a/relvar-core/src/algebra/join.rs
+++ b/relvar-core/src/algebra/join.rs
@@ -262,12 +262,12 @@ impl Relation {
 }
 
 /// Helper to compute common attributes between two relations.
-fn compute_common_attributes(left: &Relation, right: &Relation) -> Vec<String> {
+fn compute_common_attributes<'a>(left: &'a Relation, right: &Relation) -> Vec<&'a str> {
     left.relation_type()
         .heading()
         .attribute_names()
         .filter(|attr| right.relation_type().heading().has_attribute(attr))
-        .cloned()
+        .map(|s| s.as_str())
         .collect()
 }
 
@@ -336,7 +336,7 @@ fn probe_and_combine_single<'a>(
 #[derive(Debug, Eq)]
 struct JoinKey<'t, 'a> {
     tuple: &'t Tuple,
-    attributes: &'a [String],
+    attributes: &'a [&'a str],
 }
 
 impl<'t, 'a> PartialEq for JoinKey<'t, 'a> {
@@ -345,7 +345,7 @@ impl<'t, 'a> PartialEq for JoinKey<'t, 'a> {
         // with the same common_attrs slice.
         for (i, attr) in self.attributes.iter().enumerate() {
             let v1 = self.tuple.get(attr);
-            let v2 = other.tuple.get(&other.attributes[i]);
+            let v2 = other.tuple.get(other.attributes[i]);
             if v1 != v2 {
                 return false;
             }
@@ -367,7 +367,7 @@ impl<'t, 'a> Hash for JoinKey<'t, 'a> {
 /// Helper to build the hash map for the join operation (Build Phase).
 fn build_join_map<'t, 'a>(
     build_rel: &'t Relation,
-    common_attrs: &'a [String],
+    common_attrs: &'a [&'a str],
 ) -> Result<HashMap<JoinKey<'t, 'a>, Vec<&'t Tuple>>, DatabaseError> {
     let mut build_map: HashMap<JoinKey<'t, 'a>, Vec<&Tuple>> =
         HashMap::with_capacity(build_rel.cardinality());
@@ -386,7 +386,7 @@ fn build_join_map<'t, 'a>(
 fn probe_and_combine<'t, 'a>(
     probe_rel: &'t Relation,
     build_map: &HashMap<JoinKey<'t, 'a>, Vec<&'t Tuple>>,
-    common_attrs: &'a [String],
+    common_attrs: &'a [&'a str],
     result_heading: &Arc<TupleType>,
 ) -> Result<HashSet<Tuple>, DatabaseError> {
     // Optimization: Pre-allocate a `HashSet` instead of a `Vec` to accumulate tuples.
@@ -426,7 +426,7 @@ fn determine_hash_join_sides<'a>(
 fn perform_hash_join(
     build_rel: &Relation,
     probe_rel: &Relation,
-    common_attrs: &[String],
+    common_attrs: &[&str],
     result_heading: &Arc<TupleType>,
 ) -> Result<HashSet<Tuple>, DatabaseError> {
     if common_attrs.len() == 1 {

--- a/relvar-core/src/algebra/semijoin.rs
+++ b/relvar-core/src/algebra/semijoin.rs
@@ -23,7 +23,7 @@ use std::hash::{Hash, Hasher};
 #[derive(Debug, Eq)]
 struct SemijoinKey<'t, 'a> {
     tuple: &'t Tuple,
-    attributes: &'a [String],
+    attributes: &'a [&'a str],
 }
 
 impl<'t, 'a> PartialEq for SemijoinKey<'t, 'a> {
@@ -32,7 +32,7 @@ impl<'t, 'a> PartialEq for SemijoinKey<'t, 'a> {
         // with the same common_attrs slice.
         for (i, attr) in self.attributes.iter().enumerate() {
             let v1 = self.tuple.get(attr);
-            let v2 = other.tuple.get(&other.attributes[i]);
+            let v2 = other.tuple.get(other.attributes[i]);
             if v1 != v2 {
                 return false;
             }
@@ -52,12 +52,12 @@ impl<'t, 'a> Hash for SemijoinKey<'t, 'a> {
 }
 
 /// Finds common attribute names between two relations' headings.
-fn common_attributes(a: &Relation, b: &Relation) -> Vec<String> {
+fn common_attributes<'a>(a: &'a Relation, b: &Relation) -> Vec<&'a str> {
     a.relation_type()
         .heading()
         .attribute_names()
         .filter(|attr| b.relation_type().heading().has_attribute(attr))
-        .cloned()
+        .map(|s| s.as_str())
         .collect()
 }
 
@@ -216,7 +216,15 @@ impl Relation {
     /// assert_eq!(result.cardinality(), 1); // Only emp 1 matches
     /// ```
     pub fn semijoin_into(self, other: &Relation) -> Self {
-        let common_attrs = common_attributes(&self, other);
+        // Optimization: Borrow attribute names from `other` instead of `self` to avoid allocations,
+        // because `self` is consumed and mutating it while borrowing from it causes lifetime issues.
+        let common_attrs: Vec<&str> = other
+            .relation_type()
+            .heading()
+            .attribute_names()
+            .filter(|attr| self.relation_type().heading().has_attribute(attr))
+            .map(|s| s.as_str())
+            .collect();
 
         // If no common attributes, we have a degenerate case (Cartesian product projection)
         if common_attrs.is_empty() {
@@ -440,7 +448,15 @@ impl Relation {
     /// assert_eq!(result.cardinality(), 1); // Bob (id 2) has no role
     /// ```
     pub fn semidifference_into(self, other: &Relation) -> Self {
-        let common_attrs = common_attributes(&self, other);
+        // Optimization: Borrow attribute names from `other` instead of `self` to avoid allocations,
+        // because `self` is consumed and mutating it while borrowing from it causes lifetime issues.
+        let common_attrs: Vec<&str> = other
+            .relation_type()
+            .heading()
+            .attribute_names()
+            .filter(|attr| self.relation_type().heading().has_attribute(attr))
+            .map(|s| s.as_str())
+            .collect();
 
         // Degenerate case handling
         if common_attrs.is_empty() {
@@ -1046,11 +1062,11 @@ mod tests {
         use std::hash::Hash;
 
         let t1 = tuple! { a: 1i64 };
-        let attributes = vec!["a".to_string(), "b".to_string()];
+        let attributes = ["a".to_string(), "b".to_string()];
 
         let key1 = super::SemijoinKey {
             tuple: &t1,
-            attributes: &attributes,
+            attributes: &attributes.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
         };
 
         // Should not panic on missing attribute "b", and hashing should complete
@@ -1060,7 +1076,7 @@ mod tests {
         let t2 = tuple! { a: 1i64, c: "test" };
         let key2 = super::SemijoinKey {
             tuple: &t2,
-            attributes: &attributes,
+            attributes: &attributes.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
         };
 
         // Ensure missing attributes don't cause panics during partial eq comparison
@@ -1069,7 +1085,7 @@ mod tests {
         let t3 = tuple! { a: 1i64, b: 2i64 };
         let key3 = super::SemijoinKey {
             tuple: &t3,
-            attributes: &attributes,
+            attributes: &attributes.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
         };
 
         assert_ne!(key1, key3);


### PR DESCRIPTION
💡 What
Modified `join` and `semijoin` operations (including `theta_join`, `semijoin_into`, and `semidifference_into`) to use `Vec<&str>` instead of allocating `Vec<String>` when extracting common attributes. The `JoinKey` and `SemijoinKey` structs were also updated to hold `&[&str]` slices.

🎯 Why
When executing relational algebra operations like joins, identifying common attributes between two relations previously mapped the attribute names to `String` using `.cloned()`. This incurred unnecessary heap allocations proportional to the number of common attributes in the relations on every single join operation, acting as a performance bottleneck.

📊 Impact
Eliminates `String` heap allocations during the setup phase of `join`, `theta_join`, `semijoin`, `semidifference` operations by zero-cost abstracting over string slices from the underlying attribute schema. Memory allocations and time taken per operation will be measurably reduced.

🔬 Measurement
Review `cargo clippy`, `cargo test`, and `cargo bench` to observe the removed allocations and ensure correctness remains intact with the new slice mappings.

---
*PR created automatically by Jules for task [4516647776436529315](https://jules.google.com/task/4516647776436529315) started by @madmax983*