### PR TITLE
⚒️ Forge: Refactor compute_kernel_contributions

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,6 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+## 2026-05-22 - Refactored God Function compute_kernel_contributions
+**Learning:** Found a god function `compute_kernel_contributions` in `relvar/src/experimental/image.rs` which combined shifting and scaling, creating new coordinates, calculating weighted color components, appending kernel indexes and renaming schemas all within the main loop.
+**Action:** Applied the 'Three-Phase Operator' pattern by extracting the inline loop operations into distinct helper functions: `calculate_target_coordinates`, `calculate_weighted_colors`, `add_kernel_index`, and `project_and_rename_contribution` to significantly improve readability and reduce nesting.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,7 @@
+🚬 Smell: The `compute_kernel_contributions` function in `relvar/src/experimental/image.rs` was a "God Function" combining target coordinates creation, weighted color components logic, kernel index additions, and attribute renaming/projection all inline within a main loop.
+
+✨ Solution: Extracted the inline inline loop blocks into separate private helper functions: `calculate_target_coordinates`, `calculate_weighted_colors`, `add_kernel_index`, and `project_and_rename_contribution` applying the Three-Phase Operator pattern.
+
+🧽 Benefit: Vastly improves code readability and separation of concerns by flattening the massive loop operations and isolating distinct transformation steps.
+
+🛡️ Verification: Tests passed. No logic changed. All tests related to convolution logic continue to pass.

--- a/relvar/src/experimental/image.rs
+++ b/relvar/src/experimental/image.rs
@@ -197,75 +197,69 @@ fn compute_kernel_contributions(relation: &Relation, kernel: &[KernelTap]) -> Ve
     let mut contributions = Vec::with_capacity(kernel.len());
 
     for (i, tap) in kernel.iter().enumerate() {
-        let dx = tap.dx;
-        let dy = tap.dy;
-        let weight = tap.weight;
         let k_idx = i as i64;
-
-        // Step 1: Shift and Scale
-        // We use extend to compute new coordinates and weighted values
-        // We project to keep only relevant columns + k_idx
-        // Logic: A pixel at (x,y) contributes to (x+dx, y+dy) with weight w.
-        // So for a target pixel (tx, ty), the source is (tx-dx, ty-dy).
-        // But here we are iterating source pixels.
-        // Source (x,y) contributes to Target (x+dx, y+dy).
-        // So let's name the new coordinates `tx` and `ty`.
-
-        // Extend 1: Calculate target coordinates
-        let with_coords = relation
-            .extend("tx", ScalarType::Int, move |t| {
-                let x = t.get_typed::<i64>("x").unwrap();
-                ScalarValue::Int(x + dx)
-            })
-            .unwrap()
-            .extend("ty", ScalarType::Int, move |t| {
-                let y = t.get_typed::<i64>("y").unwrap();
-                ScalarValue::Int(y + dy)
-            })
-            .unwrap();
-
-        // Extend 2: Calculate weighted color components
-        let with_weights = with_coords
-            .extend("wr", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("r").unwrap();
-                ScalarValue::Int(v * weight)
-            })
-            .unwrap()
-            .extend("wg", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("g").unwrap();
-                ScalarValue::Int(v * weight)
-            })
-            .unwrap()
-            .extend("wb", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("b").unwrap();
-                ScalarValue::Int(v * weight)
-            })
-            .unwrap();
-
-        // Extend 3: Add kernel index (to prevent set deduplication of values)
-        let with_idx = with_weights
-            .extend("k_idx", ScalarType::Int, move |_| ScalarValue::Int(k_idx))
-            .unwrap();
-
-        // Project: Keep (tx, ty, wr, wg, wb, k_idx)
-        // But we rename them to a standard schema for Union
-        // Standard: (x, y, r, g, b, k_idx)
-        // Rename mapping: tx->x, ty->y, wr->r, wg->g, wb->b
-        let rename_map = vec![
-            ("tx", "x"),
-            ("ty", "y"),
-            ("wr", "r"),
-            ("wg", "g"),
-            ("wb", "b"),
-        ];
-
-        let projected = with_idx.project(&["tx", "ty", "wr", "wg", "wb", "k_idx"]);
-        let renamed = projected.rename(&rename_map);
+        let with_coords = calculate_target_coordinates(relation, tap.dx, tap.dy);
+        let with_weights = calculate_weighted_colors(&with_coords, tap.weight);
+        let with_idx = add_kernel_index(&with_weights, k_idx);
+        let renamed = project_and_rename_contribution(&with_idx);
 
         contributions.push(renamed);
     }
 
     contributions
+}
+
+fn calculate_target_coordinates(relation: &Relation, dx: i64, dy: i64) -> Relation {
+    relation
+        .extend("tx", ScalarType::Int, move |t| {
+            let x = t.get_typed::<i64>("x").unwrap();
+            ScalarValue::Int(x + dx)
+        })
+        .unwrap()
+        .extend("ty", ScalarType::Int, move |t| {
+            let y = t.get_typed::<i64>("y").unwrap();
+            ScalarValue::Int(y + dy)
+        })
+        .unwrap()
+}
+
+fn calculate_weighted_colors(relation: &Relation, weight: i64) -> Relation {
+    relation
+        .extend("wr", ScalarType::Int, move |t| {
+            let v = t.get_typed::<i64>("r").unwrap();
+            ScalarValue::Int(v * weight)
+        })
+        .unwrap()
+        .extend("wg", ScalarType::Int, move |t| {
+            let v = t.get_typed::<i64>("g").unwrap();
+            ScalarValue::Int(v * weight)
+        })
+        .unwrap()
+        .extend("wb", ScalarType::Int, move |t| {
+            let v = t.get_typed::<i64>("b").unwrap();
+            ScalarValue::Int(v * weight)
+        })
+        .unwrap()
+}
+
+fn add_kernel_index(relation: &Relation, k_idx: i64) -> Relation {
+    relation
+        .extend("k_idx", ScalarType::Int, move |_| ScalarValue::Int(k_idx))
+        .unwrap()
+}
+
+fn project_and_rename_contribution(relation: &Relation) -> Relation {
+    let rename_map = vec![
+        ("tx", "x"),
+        ("ty", "y"),
+        ("wr", "r"),
+        ("wg", "g"),
+        ("wb", "b"),
+    ];
+
+    relation
+        .project(&["tx", "ty", "wr", "wg", "wb", "k_idx"])
+        .rename(&rename_map)
 }
 
 fn union_contributions(contributions: &[Relation]) -> Relation {


### PR DESCRIPTION
🚬 Smell: The `compute_kernel_contributions` function in `relvar/src/experimental/image.rs` was a "God Function" combining target coordinates creation, weighted color components logic, kernel index additions, and attribute renaming/projection all inline within a main loop.

✨ Solution: Extracted the inline inline loop blocks into separate private helper functions: `calculate_target_coordinates`, `calculate_weighted_colors`, `add_kernel_index`, and `project_and_rename_contribution` applying the Three-Phase Operator pattern.

🧽 Benefit: Vastly improves code readability and separation of concerns by flattening the massive loop operations and isolating distinct transformation steps.

🛡️ Verification: Tests passed. No logic changed. All tests related to convolution logic continue to pass.

---
*PR created automatically by Jules for task [15347340925948890651](https://jules.google.com/task/15347340925948890651) started by @madmax983*