### PR TITLE
⚒️ Forge: Extract God Function in Image Kernel

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,7 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+
+## 2026-05-20 - Extract God Function in Image Kernel
+**Learning:** `relvar/src/experimental/image.rs` contained a "God Function" `compute_kernel_contributions` (74 lines) which conflated shifting coordinates, scaling colors, and finalizing contributions in a single continuous block, harming readability and violating the 'Three-Phase Operator' pattern.
+**Action:** Extracted the distinct logical phases into properly typed, private helper functions (`shift_coordinates`, `scale_colors`, `finalize_contribution`) to drastically improve clarity without altering behavior.

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,131 @@
+--- relvar/src/experimental/image.rs
++++ relvar/src/experimental/image.rs
+@@ -193,76 +193,64 @@
+     summarize_and_normalize(&unioned, total_weight)
+ }
+
+-fn compute_kernel_contributions(relation: &Relation, kernel: &[KernelTap]) -> Vec<Relation> {
+-    let mut contributions = Vec::with_capacity(kernel.len());
++fn shift_coordinates(relation: &Relation, dx: i64, dy: i64) -> Relation {
++    relation
++        .extend("tx", ScalarType::Int, move |t| {
++            let x = t.get_typed::<i64>("x").unwrap();
++            ScalarValue::Int(x + dx)
++        })
++        .unwrap()
++        .extend("ty", ScalarType::Int, move |t| {
++            let y = t.get_typed::<i64>("y").unwrap();
++            ScalarValue::Int(y + dy)
++        })
++        .unwrap()
++}
+
+-    for (i, tap) in kernel.iter().enumerate() {
+-        let dx = tap.dx;
+-        let dy = tap.dy;
+-        let weight = tap.weight;
+-        let k_idx = i as i64;
+-
+-        // Step 1: Shift and Scale
+-        // We use extend to compute new coordinates and weighted values
+-        // We project to keep only relevant columns + k_idx
+-        // Logic: A pixel at (x,y) contributes to (x+dx, y+dy) with weight w.
+-        // So for a target pixel (tx, ty), the source is (tx-dx, ty-dy).
+-        // But here we are iterating source pixels.
+-        // Source (x,y) contributes to Target (x+dx, y+dy).
+-        // So let's name the new coordinates `tx` and `ty`.
+-
+-        // Extend 1: Calculate target coordinates
+-        let with_coords = relation
+-            .extend("tx", ScalarType::Int, move |t| {
+-                let x = t.get_typed::<i64>("x").unwrap();
+-                ScalarValue::Int(x + dx)
+-            })
+-            .unwrap()
+-            .extend("ty", ScalarType::Int, move |t| {
+-                let y = t.get_typed::<i64>("y").unwrap();
+-                ScalarValue::Int(y + dy)
+-            })
+-            .unwrap();
++fn scale_colors(relation: &Relation, weight: i64) -> Relation {
++    relation
++        .extend("wr", ScalarType::Int, move |t| {
++            let v = t.get_typed::<i64>("r").unwrap();
++            ScalarValue::Int(v * weight)
++        })
++        .unwrap()
++        .extend("wg", ScalarType::Int, move |t| {
++            let v = t.get_typed::<i64>("g").unwrap();
++            ScalarValue::Int(v * weight)
++        })
++        .unwrap()
++        .extend("wb", ScalarType::Int, move |t| {
++            let v = t.get_typed::<i64>("b").unwrap();
++            ScalarValue::Int(v * weight)
++        })
++        .unwrap()
++}
+
+-        // Extend 2: Calculate weighted color components
+-        let with_weights = with_coords
+-            .extend("wr", ScalarType::Int, move |t| {
+-                let v = t.get_typed::<i64>("r").unwrap();
+-                ScalarValue::Int(v * weight)
+-            })
+-            .unwrap()
+-            .extend("wg", ScalarType::Int, move |t| {
+-                let v = t.get_typed::<i64>("g").unwrap();
+-                ScalarValue::Int(v * weight)
+-            })
+-            .unwrap()
+-            .extend("wb", ScalarType::Int, move |t| {
+-                let v = t.get_typed::<i64>("b").unwrap();
+-                ScalarValue::Int(v * weight)
+-            })
+-            .unwrap();
++fn finalize_contribution(relation: &Relation, k_idx: i64) -> Relation {
++    let with_idx = relation
++        .extend("k_idx", ScalarType::Int, move |_| ScalarValue::Int(k_idx))
++        .unwrap();
+
+-        // Extend 3: Add kernel index (to prevent set deduplication of values)
+-        let with_idx = with_weights
+-            .extend("k_idx", ScalarType::Int, move |_| ScalarValue::Int(k_idx))
+-            .unwrap();
++    let projected = with_idx.project(&["tx", "ty", "wr", "wg", "wb", "k_idx"]);
++
++    projected.rename(&[
++        ("tx", "x"),
++        ("ty", "y"),
++        ("wr", "r"),
++        ("wg", "g"),
++        ("wb", "b"),
++    ])
++}
+
+-        // Project: Keep (tx, ty, wr, wg, wb, k_idx)
+-        // But we rename them to a standard schema for Union
+-        // Standard: (x, y, r, g, b, k_idx)
+-        // Rename mapping: tx->x, ty->y, wr->r, wg->g, wb->b
+-        let rename_map = vec![
+-            ("tx", "x"),
+-            ("ty", "y"),
+-            ("wr", "r"),
+-            ("wg", "g"),
+-            ("wb", "b"),
+-        ];
++fn compute_kernel_contributions(relation: &Relation, kernel: &[KernelTap]) -> Vec<Relation> {
++    let mut contributions = Vec::with_capacity(kernel.len());
+
+-        let projected = with_idx.project(&["tx", "ty", "wr", "wg", "wb", "k_idx"]);
+-        let renamed = projected.rename(&rename_map);
++    for (i, tap) in kernel.iter().enumerate() {
++        let with_coords = shift_coordinates(relation, tap.dx, tap.dy);
++        let with_weights = scale_colors(&with_coords, tap.weight);
++        let finalized = finalize_contribution(&with_weights, i as i64);
+
+-        contributions.push(renamed);
++        contributions.push(finalized);
+     }
+
+     contributions

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+🚮 Smell: The `compute_kernel_contributions` function in `relvar/src/experimental/image.rs` was a "God Function" exceeding 70 lines. It conflated shifting coordinates, scaling colors via extension, and finalizing projections all within a single massive iterator loop, making the relational logic difficult to track.
+✨ Solution: Applied the "Three-Phase Operator" pattern by extracting the inline logic into three clear, properly typed private helper functions: `shift_coordinates`, `scale_colors`, and `finalize_contribution`. The main function now delegates efficiently.
+🧼 Benefit: Substantially improves readability, strictly separates distinct relational operations, flattens the inner block, and eliminates the inline variable bloat.
+🛡️ Verification: `cargo test` passes seamlessly. No logic changed. `cargo clippy` and `cargo fmt` executed.

--- a/relvar/src/experimental/image.rs
+++ b/relvar/src/experimental/image.rs
@@ -193,76 +193,64 @@ pub fn apply_kernel(relation: &Relation, kernel: &[KernelTap]) -> Relation {
     summarize_and_normalize(&unioned, total_weight)
 }
 
+fn shift_coordinates(relation: &Relation, dx: i64, dy: i64) -> Relation {
+    relation
+        .extend("tx", ScalarType::Int, move |t| {
+            let x = t.get_typed::<i64>("x").unwrap();
+            ScalarValue::Int(x + dx)
+        })
+        .unwrap()
+        .extend("ty", ScalarType::Int, move |t| {
+            let y = t.get_typed::<i64>("y").unwrap();
+            ScalarValue::Int(y + dy)
+        })
+        .unwrap()
+}
+
+fn scale_colors(relation: &Relation, weight: i64) -> Relation {
+    relation
+        .extend("wr", ScalarType::Int, move |t| {
+            let v = t.get_typed::<i64>("r").unwrap();
+            ScalarValue::Int(v * weight)
+        })
+        .unwrap()
+        .extend("wg", ScalarType::Int, move |t| {
+            let v = t.get_typed::<i64>("g").unwrap();
+            ScalarValue::Int(v * weight)
+        })
+        .unwrap()
+        .extend("wb", ScalarType::Int, move |t| {
+            let v = t.get_typed::<i64>("b").unwrap();
+            ScalarValue::Int(v * weight)
+        })
+        .unwrap()
+}
+
+fn finalize_contribution(relation: &Relation, k_idx: i64) -> Relation {
+    let with_idx = relation
+        .extend("k_idx", ScalarType::Int, move |_| ScalarValue::Int(k_idx))
+        .unwrap();
+
+    let projected = with_idx.project(&["tx", "ty", "wr", "wg", "wb", "k_idx"]);
+
+    projected.rename(&[
+        ("tx", "x"),
+        ("ty", "y"),
+        ("wr", "r"),
+        ("wg", "g"),
+        ("wb", "b"),
+    ])
+}
+
 fn compute_kernel_contributions(relation: &Relation, kernel: &[KernelTap]) -> Vec<Relation> {
     let mut contributions = Vec::with_capacity(kernel.len());
 
     for (i, tap) in kernel.iter().enumerate() {
-        let dx = tap.dx;
-        let dy = tap.dy;
-        let weight = tap.weight;
-        let k_idx = i as i64;
+        let with_coords = shift_coordinates(relation, tap.dx, tap.dy);
+        let with_weights = scale_colors(&with_coords, tap.weight);
+        let finalized = finalize_contribution(&with_weights, i as i64);
 
-        // Step 1: Shift and Scale
-        // We use extend to compute new coordinates and weighted values
-        // We project to keep only relevant columns + k_idx
-        // Logic: A pixel at (x,y) contributes to (x+dx, y+dy) with weight w.
-        // So for a target pixel (tx, ty), the source is (tx-dx, ty-dy).
-        // But here we are iterating source pixels.
-        // Source (x,y) contributes to Target (x+dx, y+dy).
-        // So let's name the new coordinates `tx` and `ty`.
-
-        // Extend 1: Calculate target coordinates
-        let with_coords = relation
-            .extend("tx", ScalarType::Int, move |t| {
-                let x = t.get_typed::<i64>("x").unwrap();
-                ScalarValue::Int(x + dx)
-            })
-            .unwrap()
-            .extend("ty", ScalarType::Int, move |t| {
-                let y = t.get_typed::<i64>("y").unwrap();
-                ScalarValue::Int(y + dy)
-            })
-            .unwrap();
-
-        // Extend 2: Calculate weighted color components
-        let with_weights = with_coords
-            .extend("wr", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("r").unwrap();
-                ScalarValue::Int(v * weight)
-            })
-            .unwrap()
-            .extend("wg", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("g").unwrap();
-                ScalarValue::Int(v * weight)
-            })
-            .unwrap()
-            .extend("wb", ScalarType::Int, move |t| {
-                let v = t.get_typed::<i64>("b").unwrap();
-                ScalarValue::Int(v * weight)
-            })
-            .unwrap();
-
-        // Extend 3: Add kernel index (to prevent set deduplication of values)
-        let with_idx = with_weights
-            .extend("k_idx", ScalarType::Int, move |_| ScalarValue::Int(k_idx))
-            .unwrap();
-
-        // Project: Keep (tx, ty, wr, wg, wb, k_idx)
-        // But we rename them to a standard schema for Union
-        // Standard: (x, y, r, g, b, k_idx)
-        // Rename mapping: tx->x, ty->y, wr->r, wg->g, wb->b
-        let rename_map = vec![
-            ("tx", "x"),
-            ("ty", "y"),
-            ("wr", "r"),
-            ("wg", "g"),
-            ("wb", "b"),
-        ];
-
-        let projected = with_idx.project(&["tx", "ty", "wr", "wg", "wb", "k_idx"]);
-        let renamed = projected.rename(&rename_map);
-
-        contributions.push(renamed);
+        contributions.push(finalized);
     }
 
     contributions


### PR DESCRIPTION
🚮 Smell: The `compute_kernel_contributions` function in `relvar/src/experimental/image.rs` was a "God Function" exceeding 70 lines. It conflated shifting coordinates, scaling colors via extension, and finalizing projections all within a single massive iterator loop, making the relational logic difficult to track.
✨ Solution: Applied the "Three-Phase Operator" pattern by extracting the inline logic into three clear, properly typed private helper functions: `shift_coordinates`, `scale_colors`, and `finalize_contribution`. The main function now delegates efficiently.
🧼 Benefit: Substantially improves readability, strictly separates distinct relational operations, flattens the inner block, and eliminates the inline variable bloat.
🛡️ Verification: `cargo test` passes seamlessly. No logic changed. `cargo clippy` and `cargo fmt` executed.

---
*PR created automatically by Jules for task [9894600724183220027](https://jules.google.com/task/9894600724183220027) started by @madmax983*