### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/relvar-storage/src/wal/iter.rs
+++ b/relvar-storage/src/wal/iter.rs
@@ -140,5 +140,4 @@ mod tests {
             panic!("Expected corrupted error");
         }
     }
-
 }

--- a/relvar-storage/src/wal/iter.rs
+++ b/relvar-storage/src/wal/iter.rs
@@ -120,4 +120,25 @@ mod tests {
             assert!(matches!(e, WalError::Corrupted(_, _)));
         }
     }
+
+    #[test]
+    fn test_iter_offset_overflow_coverage() {
+        let mut buffer = Vec::new();
+        // LSN
+        buffer.extend_from_slice(&1u64.to_le_bytes());
+        // Length that will cause overflow when added to offset.
+        // On 64-bit systems usize is u64 so u64::MAX -> causes offset_overflow.
+        // On 32-bit systems, try_from fails immediately, so it triggers "exceeds memory limits".
+        buffer.extend_from_slice(&u64::MAX.to_le_bytes());
+
+        let mut iter = WalRecordIter::new(&buffer);
+        let result = iter.next().unwrap();
+        assert!(result.is_err());
+        if let Err(WalError::Corrupted(_, msg)) = result {
+            assert!(msg.contains("Record length") || msg.contains("offset overflow"));
+        } else {
+            panic!("Expected corrupted error");
+        }
+    }
+
 }


### PR DESCRIPTION
🎯 Target: `relvar-storage/src/wal/iter.rs` `WalRecordIter::next()`.
💣 Risk: Missing test coverage for error conditions when a WAL record length is maliciously constructed to cause offset overflow, which returns `WalError::Corrupted`.
🧪 Strategy: Added a new test case `test_iter_offset_overflow_coverage` that explicitly feeds the `WalRecordIter` with an overflowing `record_len` (`u64::MAX`).
🔬 Verification: Run `cargo test -p relvar-storage`

---
*PR created automatically by Jules for task [8310882530038929869](https://jules.google.com/task/8310882530038929869) started by @madmax983*