### PR TITLE
🔒 Warden: [security fix] Fix RwLock Poisoning DoS in PersistentEngine

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -12,3 +12,7 @@
 ## 2024-06-13 - [Denial of Service via Unbounded Recursion]
 **Threat:** Stack overflow Denial of Service (DoS) vulnerability triggered by malicious actors submitting deeply nested `Query` or `ConstraintExpression` AST structures. `postcard` has no default recursion depth limits, meaning deserialization of deep inputs directly overflows the call stack, crashing the server process.
 **Defense:** Applied `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` to the recursive `Box` fields in both `Query` and `ConstraintExpression` enums.
+
+## 2026-05-24 - [RwLock Poisoning DoS in PersistentEngine]
+**Threat:** Application panic due to `.unwrap()` calls on `storage_manager.read()` and `storage_manager.write()`. If a thread panics while holding the lock, it poisons the `RwLock`, causing subsequent threads to panic, resulting in a denial-of-service (DoS) cascade.
+**Defense:** Replaced `.unwrap()` with safe error handling on lock acquisition in `PersistentEngine`. Used `.map_err()` to propagate `StorageError::Other` for operations returning a `Result`, and used `.unwrap_or_else(|e| e.into_inner())` for read-only methods returning non-Results, safely extracting the guard without propagating a panic.

--- a/relvar-storage/src/persistent_engine/mod.rs
+++ b/relvar-storage/src/persistent_engine/mod.rs
@@ -161,11 +161,11 @@ impl PersistentEngine {
         let snapshot = self.get_snapshot_for_current_context()?;
 
         // scan_relation implicitly filters out uncommitted tuples because they are not in committed_txns
-        let relation = self.storage_manager.write().unwrap().scan_relation(
-            relation_name,
-            &snapshot,
-            &self.committed_txns,
-        )?;
+        let relation = self
+            .storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("StorageManager lock poisoned".to_string()))?
+            .scan_relation(relation_name, &snapshot, &self.committed_txns)?;
 
         // Store back (effectively removing uncommitted garbage from the heap file)
         self.store_relation(relation_name, &relation)?;
@@ -197,7 +197,10 @@ impl PersistentEngine {
         self.flush_wal()?;
 
         // Now safe to flush heap files (dirty pages to disk)
-        self.storage_manager.write().unwrap().flush_heap_files()?;
+        self.storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("StorageManager lock poisoned".to_string()))?
+            .flush_heap_files()?;
 
         // Determine minimum active LSN
         let min_active_lsn = self.get_checkpoint_lsn();
@@ -298,11 +301,17 @@ impl StorageEngine for PersistentEngine {
     }
 
     fn drop_relation(&mut self, name: &str) -> Result<(), StorageError> {
-        self.storage_manager.write().unwrap().drop_relation(name)
+        self.storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("StorageManager lock poisoned".to_string()))?
+            .drop_relation(name)
     }
 
     fn relation_exists(&self, name: &str) -> bool {
-        self.storage_manager.read().unwrap().relation_exists(name)
+        self.storage_manager
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .relation_exists(name)
     }
 
     fn get_relation_metadata(&self, name: &str) -> Result<RelationMetadata, StorageError> {
@@ -313,7 +322,10 @@ impl StorageEngine for PersistentEngine {
     }
 
     fn list_relations(&self) -> Vec<String> {
-        self.storage_manager.read().unwrap().list_relations()
+        self.storage_manager
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .list_relations()
     }
 
     fn load_relation(&self, name: &str) -> Result<Relation, StorageError> {
@@ -395,7 +407,10 @@ impl StorageEngine for PersistentEngine {
             .flush()
             .map_err(|e| StorageError::Other(format!("WAL flush error: {}", e)))?;
 
-        self.storage_manager.write().unwrap().flush_heap_files()?;
+        self.storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("StorageManager lock poisoned".to_string()))?
+            .flush_heap_files()?;
 
         self.committed_txns.insert(snapshot.txn_id);
         self.active_txns.commit(snapshot.txn_id);


### PR DESCRIPTION
# 🔒 Warden: [security fix] Fix RwLock Poisoning DoS in PersistentEngine

## 🦠 Threat
Application panic and cascading denial-of-service (DoS) due to unsafe `.unwrap()` calls on `storage_manager.read()` and `storage_manager.write()` inside `PersistentEngine`. If a thread panics while holding the lock, it poisons the `RwLock`, causing subsequent threads attempting to acquire the lock to panic as well, essentially freezing or crashing the system entirely.

## 🛡️ Defense
Replaced unhandled `.unwrap()` calls with robust lock acquisition error handling:
- **Write Operations:** Replaced `.write().unwrap()` with `.write().map_err(|_| StorageError::Other("StorageManager lock poisoned".to_string()))?` to propagate an error gracefully if the lock is poisoned.
- **Read Operations:** Replaced `.read().unwrap()` with `.read().unwrap_or_else(|e| e.into_inner())` for read-only methods that do not return `Result` (like `relation_exists` and `list_relations`), safely extracting the guard without propagating a panic.

## 💥 Severity
Critical - could cause widespread system panic and denial-of-service on lock poisoning.

## 🧪 Verification
Executed `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` to verify standard operation is maintained. Checked that read operations correctly use the unwrap_or_else mechanism without requiring major API signatures changes.

---
*PR created automatically by Jules for task [2990737171466969709](https://jules.google.com/task/2990737171466969709) started by @madmax983*