### PR TITLE
🔒 Warden: Prevent panic cascade on poisoned lock

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -9,3 +9,6 @@
 ## 2026-04-24 - [Unsafe unwrap in StorageManager]
 **Threat:** Potential panic and crash if `get_or_open_heap_file` fails to retrieve or map a file correctly, resulting in an unhandled `.unwrap()` failure.
 **Defense:** Replaced `.unwrap()` with `HashMap::entry` to ensure safe, graceful error propagation rather than crashing the system without unreachable branches.
+## 2025-02-23 - Handle RwLock PoisonError gracefully
+**Threat:** System-wide panic cascade (DoS) on lock poisoning if `unwrap()` is called on `RwLock` results in `relvar-storage`.
+**Defense:** Replaced `.unwrap()` with `.map_err(...)` or `.unwrap_or_else(|e| e.into_inner())` on shared `RwLock` state to prevent panics and handle poisoned states gracefully.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+🦠 Threat: Denial of Service (DoS) due to system-wide panic cascade. If an RwLock in `PersistentEngine` (which guards `StorageManager`) became poisoned (e.g., due to a panic during a write lock), subsequent calls to `.unwrap()` would also panic, leading to a complete crash of the storage engine.
+🛡️ Defense: Replaced `.unwrap()` calls on `RwLock` results with `.map_err()` for functions returning `Result<T, StorageError>`, and `.unwrap_or_else(|e| e.into_inner())` for read-only operations where lock poison doesn't invalidate the ability to read the current state safely.
+💥 Severity: High. A panic in any thread holding the write lock would render the entire database unusable until restart, acting as an internal DoS vector.
+🧪 Verification: Ran `cargo test` and `cargo clippy`. Verified the replacement logic manually. Added entry to `.jules/warden.md`.

--- a/relvar-storage/src/persistent_engine/mod.rs
+++ b/relvar-storage/src/persistent_engine/mod.rs
@@ -161,11 +161,11 @@ impl PersistentEngine {
         let snapshot = self.get_snapshot_for_current_context()?;
 
         // scan_relation implicitly filters out uncommitted tuples because they are not in committed_txns
-        let relation = self.storage_manager.write().unwrap().scan_relation(
-            relation_name,
-            &snapshot,
-            &self.committed_txns,
-        )?;
+        let relation = self
+            .storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("Storage manager lock poisoned".to_string()))?
+            .scan_relation(relation_name, &snapshot, &self.committed_txns)?;
 
         // Store back (effectively removing uncommitted garbage from the heap file)
         self.store_relation(relation_name, &relation)?;
@@ -197,7 +197,10 @@ impl PersistentEngine {
         self.flush_wal()?;
 
         // Now safe to flush heap files (dirty pages to disk)
-        self.storage_manager.write().unwrap().flush_heap_files()?;
+        self.storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("Storage manager lock poisoned".to_string()))?
+            .flush_heap_files()?;
 
         // Determine minimum active LSN
         let min_active_lsn = self.get_checkpoint_lsn();
@@ -293,27 +296,36 @@ impl StorageEngine for PersistentEngine {
     ) -> Result<(), StorageError> {
         self.storage_manager
             .write()
-            .unwrap()
+            .map_err(|_| StorageError::Other("Storage manager lock poisoned".to_string()))?
             .create_relation(name, relation_type)
     }
 
     fn drop_relation(&mut self, name: &str) -> Result<(), StorageError> {
-        self.storage_manager.write().unwrap().drop_relation(name)
+        self.storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("Storage manager lock poisoned".to_string()))?
+            .drop_relation(name)
     }
 
     fn relation_exists(&self, name: &str) -> bool {
-        self.storage_manager.read().unwrap().relation_exists(name)
+        self.storage_manager
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .relation_exists(name)
     }
 
     fn get_relation_metadata(&self, name: &str) -> Result<RelationMetadata, StorageError> {
         self.storage_manager
             .read()
-            .unwrap()
+            .map_err(|_| StorageError::Other("Storage manager lock poisoned".to_string()))?
             .get_relation_metadata(name)
     }
 
     fn list_relations(&self) -> Vec<String> {
-        self.storage_manager.read().unwrap().list_relations()
+        self.storage_manager
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .list_relations()
     }
 
     fn load_relation(&self, name: &str) -> Result<Relation, StorageError> {
@@ -395,7 +407,10 @@ impl StorageEngine for PersistentEngine {
             .flush()
             .map_err(|e| StorageError::Other(format!("WAL flush error: {}", e)))?;
 
-        self.storage_manager.write().unwrap().flush_heap_files()?;
+        self.storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("Storage manager lock poisoned".to_string()))?
+            .flush_heap_files()?;
 
         self.committed_txns.insert(snapshot.txn_id);
         self.active_txns.commit(snapshot.txn_id);


### PR DESCRIPTION
🦠 Threat: Denial of Service (DoS) due to system-wide panic cascade. If an RwLock in `PersistentEngine` (which guards `StorageManager`) became poisoned (e.g., due to a panic during a write lock), subsequent calls to `.unwrap()` would also panic, leading to a complete crash of the storage engine.
🛡️ Defense: Replaced `.unwrap()` calls on `RwLock` results with `.map_err()` for functions returning `Result<T, StorageError>`, and `.unwrap_or_else(|e| e.into_inner())` for read-only operations where lock poison doesn't invalidate the ability to read the current state safely.
💥 Severity: High. A panic in any thread holding the write lock would render the entire database unusable until restart, acting as an internal DoS vector.
🧪 Verification: Ran `cargo test` and `cargo clippy`. Verified the replacement logic manually. Added entry to `.jules/warden.md`.

---
*PR created automatically by Jules for task [8683188955124139617](https://jules.google.com/task/8683188955124139617) started by @madmax983*