### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -132,3 +132,6 @@
 **Learning:** Missing coverage branches for specific operations involving database bulk constraints and cascading failure. `compute_relation_after_update` early exit logic via `?` unrolls some lines in `Database::update` if the logic before reaches an error state.
 
 **Action:** When adding tests for database constraints involving `update` and `delete`, ensure varying degrees of constraint violations such as duplicated primary keys after updates and violations on foreign keys mapped against parent relations to fully hit bulk checks.
+## 2026-05-18 - Unchecked Deserialization Validation Gaps
+**Learning:** `serde` deserialization structs implementing validation logic via `try_from` bounds (`ScalarTypeUnchecked` and `ScalarValueUnchecked`) have uncovered error branches mapping to nested depth limits and invalid UserDefined configurations.
+**Action:** When testing validation logic for private serialization structs bound via `#[serde(try_from)]`, exercise the private error branches by passing simulated JSON string payloads directly to `serde_json::from_str` in the test cases to ensure the deserialization safety constraints perform properly during dynamic loads.

--- a/relvar-core/tests/sentry_scalar_value_coverage.rs
+++ b/relvar-core/tests/sentry_scalar_value_coverage.rs
@@ -67,3 +67,31 @@ fn test_scalar_value_hash_user_defined() {
     val.hash(&mut s);
     let _ = s.finish();
 }
+
+#[test]
+fn test_scalar_value_unchecked_user_defined_invalid_type_def() {
+    let json = r#"
+        {"UserDefined": {
+            "type_def": "Int",
+            "value": {"Int": 42}
+        }}
+    "#;
+    let decoded: Result<ScalarValue, _> = serde_json::from_str(json);
+    assert!(decoded.is_err());
+    let err_msg = decoded.unwrap_err().to_string();
+    assert!(err_msg.contains("Invalid UserDefined value: type definition must be UserDefined"));
+}
+
+#[test]
+fn test_scalar_value_unchecked_user_defined_type_mismatch() {
+    let json = r#"
+        {"UserDefined": {
+            "type_def": {"UserDefined": {"name": "WidgetId", "representation": "Int"}},
+            "value": {"String": "42"}
+        }}
+    "#;
+    let decoded: Result<ScalarValue, _> = serde_json::from_str(json);
+    assert!(decoded.is_err());
+    let err_msg = decoded.unwrap_err().to_string();
+    assert!(err_msg.contains("Type mismatch in UserDefined value: type definition expects Int, but value is String"));
+}


### PR DESCRIPTION
🎯 Target: `ScalarValue::try_from(ScalarValueUnchecked)` deserialization logic in `relvar-core/src/values/scalar.rs`.
💣 Risk: Missing validation checks for invalid `UserDefined` deserialization payloads, which could potentially bypass type constraints if improperly handled during deserialization, though they error currently.
🧪 Strategy: Appended targeted integration tests in `relvar-core/tests/sentry_scalar_value_coverage.rs` utilizing `serde_json::from_str` to explicitly simulate dynamically invalid `UserDefined` structures with missing internal type identities or explicitly mismatched property configurations. 
🔬 Verification: `cargo test --test sentry_scalar_value_coverage --manifest-path relvar-core/Cargo.toml`

---
*PR created automatically by Jules for task [2864542820857712053](https://jules.google.com/task/2864542820857712053) started by @madmax983*