### PR TITLE
⚒️ Forge: Refactor physics compute_pairwise_forces

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,7 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+
+## 2026-05-20 - Refactor compute_pairwise_forces God Function
+**Learning:** `relvar/src/experimental/physics.rs` contained a "God Function" `compute_pairwise_forces` (81 lines) which combined renaming particles, cross joining them, filtering self-interactions, and then looping over combinations to calculate x and y force components. This convoluted the relational preparation with the computational extending logic.
+**Action:** Applied the 'Three-Phase Operator' pattern by extracting the relational setup logic into `generate_particle_pairs` and the calculation extending logic into `compute_force_components`, which drastically improves readability and adheres to idiomatic standards.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,15 @@
+# ⚒️ Forge: Refactor physics compute_pairwise_forces
+
+**🚮 Smell:**
+The `compute_pairwise_forces` method in `relvar/src/experimental/physics.rs` was an 81-line "God Function". It combined renaming and joining particles to generate pairs, filtering self-interactions, and a massive `extend` closure to compute the `fx` and `fy` force components. This convoluted the relational logic with mathematical calculations, making it difficult to read and maintain.
+
+**✨ Solution:**
+Applied the "Three-Phase Operator" pattern by extracting the logic into two separate, private helper functions:
+1. `generate_particle_pairs` which handles the cross joining, renaming, and filtering.
+2. `compute_force_components` which takes the joined relations and computes the `fx` and `fy` components using `extend`.
+
+**🧼 Benefit:**
+Drastically improves clarity and reduces cognitive load by separating the relational setup from the physics calculations. The main function is now a clean, two-step pipeline. The new structure adheres strictly to idiomatic Rust standards for code organization and function length limits.
+
+**🛡️ Verification:**
+Tests passed successfully (`cargo test --all-features`). No logic was changed, ensuring this is strictly a refactor. All code styling (`cargo fmt`) and linting (`cargo clippy`) checks also passed with no warnings.

--- a/relvar/src/experimental/physics.rs
+++ b/relvar/src/experimental/physics.rs
@@ -59,6 +59,11 @@ impl PhysicsEngine {
     }
 
     fn compute_pairwise_forces(&self) -> Result<Relation, DatabaseError> {
+        let interactions = self.generate_particle_pairs()?;
+        self.compute_force_components(interactions)
+    }
+
+    fn generate_particle_pairs(&self) -> Result<Relation, DatabaseError> {
         // 1. Cross join particles with themselves to compute pairwise forces.
         // Rename attributes to distinguish particle 1 and particle 2.
         let p1 = self.particles.rename(&[
@@ -88,6 +93,10 @@ impl PhysicsEngine {
             id1 != id2
         });
 
+        Ok(interactions)
+    }
+
+    fn compute_force_components(&self, interactions: Relation) -> Result<Relation, DatabaseError> {
         // 3. Compute forces for each pair
         let g = self.g;
         interactions


### PR DESCRIPTION
# ⚒️ Forge: Refactor physics compute_pairwise_forces

**🚮 Smell:** 
The `compute_pairwise_forces` method in `relvar/src/experimental/physics.rs` was an 81-line "God Function". It combined renaming and joining particles to generate pairs, filtering self-interactions, and a massive `extend` closure to compute the `fx` and `fy` force components. This convoluted the relational logic with mathematical calculations, making it difficult to read and maintain.

**✨ Solution:** 
Applied the "Three-Phase Operator" pattern by extracting the logic into two separate, private helper functions:
1. `generate_particle_pairs` which handles the cross joining, renaming, and filtering.
2. `compute_force_components` which takes the joined relations and computes the `fx` and `fy` components using `extend`.

**🧼 Benefit:** 
Drastically improves clarity and reduces cognitive load by separating the relational setup from the physics calculations. The main function is now a clean, two-step pipeline. The new structure adheres strictly to idiomatic Rust standards for code organization and function length limits.

**🛡️ Verification:** 
Tests passed successfully (`cargo test --all-features`). No logic was changed, ensuring this is strictly a refactor. All code styling (`cargo fmt`) and linting (`cargo clippy`) checks also passed with no warnings.

---
*PR created automatically by Jules for task [3770182336291050642](https://jules.google.com/task/3770182336291050642) started by @madmax983*