### PR TITLE
🔒 Warden: Fix RwLock poisoning in PersistentEngine

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -9,3 +9,6 @@
 ## 2026-04-24 - [Unsafe unwrap in StorageManager]
 **Threat:** Potential panic and crash if `get_or_open_heap_file` fails to retrieve or map a file correctly, resulting in an unhandled `.unwrap()` failure.
 **Defense:** Replaced `.unwrap()` with `HashMap::entry` to ensure safe, graceful error propagation rather than crashing the system without unreachable branches.
+## 2024-05-27 - RwLock Poisoning DoS
+**Threat:** Calling `.unwrap()` on `RwLock::write()` or `RwLock::read()` allows a single poisoned lock (e.g. from a thread panicking during a write) to cascade and panic all subsequent threads attempting to acquire the lock, causing a system-wide Denial of Service.
+**Defense:** Replaced `.unwrap()` calls on `RwLock` operations in `relvar-storage/src/persistent_engine/mod.rs` with safe `.map_err()` propagating a `StorageError`, or `.unwrap_or_else(|e| e.into_inner())` for pure read operations.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,5 @@
+Title: '🔒 Warden: Fix RwLock poisoning in PersistentEngine'
+🦠 Threat: Calling `.unwrap()` on `RwLock::write()` or `RwLock::read()` in `relvar-storage/src/persistent_engine/mod.rs` allows a single poisoned lock (e.g. from a thread panicking during a write) to cascade and panic all subsequent threads attempting to acquire the lock, causing a system-wide Denial of Service.
+🛡️ Defense: Replaced `.unwrap()` calls on `RwLock` operations with safe `.map_err()` propagating a `StorageError`, or `.unwrap_or_else(|e| e.into_inner())` for pure read operations.
+💥 Severity: Critical - could panic server and cause a system-wide Denial of Service.
+🧪 Verification: Ran `cargo test`, `cargo check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --all`. Verified successful test passes.

--- a/relvar-storage/src/persistent_engine/mod.rs
+++ b/relvar-storage/src/persistent_engine/mod.rs
@@ -131,7 +131,7 @@ impl PersistentEngine {
             if self
                 .storage_manager
                 .read()
-                .unwrap()
+                .unwrap_or_else(|e| e.into_inner())
                 .relation_exists(&relation_name)
             {
                 self.cleanup_relation_uncommitted_inserts(&relation_name)?;
@@ -161,11 +161,11 @@ impl PersistentEngine {
         let snapshot = self.get_snapshot_for_current_context()?;
 
         // scan_relation implicitly filters out uncommitted tuples because they are not in committed_txns
-        let relation = self.storage_manager.write().unwrap().scan_relation(
-            relation_name,
-            &snapshot,
-            &self.committed_txns,
-        )?;
+        let relation = self
+            .storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("RwLock poisoned".to_string()))?
+            .scan_relation(relation_name, &snapshot, &self.committed_txns)?;
 
         // Store back (effectively removing uncommitted garbage from the heap file)
         self.store_relation(relation_name, &relation)?;
@@ -197,7 +197,10 @@ impl PersistentEngine {
         self.flush_wal()?;
 
         // Now safe to flush heap files (dirty pages to disk)
-        self.storage_manager.write().unwrap().flush_heap_files()?;
+        self.storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("RwLock poisoned".to_string()))?
+            .flush_heap_files()?;
 
         // Determine minimum active LSN
         let min_active_lsn = self.get_checkpoint_lsn();
@@ -212,7 +215,7 @@ impl PersistentEngine {
         let gc_lsn = self.get_checkpoint_lsn();
         self.storage_manager
             .write()
-            .unwrap()
+            .map_err(|_| StorageError::Other("RwLock poisoned".to_string()))?
             .garbage_collect_versions(gc_lsn, &self.committed_txns)?;
 
         Ok(())
@@ -293,27 +296,36 @@ impl StorageEngine for PersistentEngine {
     ) -> Result<(), StorageError> {
         self.storage_manager
             .write()
-            .unwrap()
+            .map_err(|_| StorageError::Other("RwLock poisoned".to_string()))?
             .create_relation(name, relation_type)
     }
 
     fn drop_relation(&mut self, name: &str) -> Result<(), StorageError> {
-        self.storage_manager.write().unwrap().drop_relation(name)
+        self.storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("RwLock poisoned".to_string()))?
+            .drop_relation(name)
     }
 
     fn relation_exists(&self, name: &str) -> bool {
-        self.storage_manager.read().unwrap().relation_exists(name)
+        self.storage_manager
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .relation_exists(name)
     }
 
     fn get_relation_metadata(&self, name: &str) -> Result<RelationMetadata, StorageError> {
         self.storage_manager
             .read()
-            .unwrap()
+            .map_err(|_| StorageError::Other("RwLock poisoned".to_string()))?
             .get_relation_metadata(name)
     }
 
     fn list_relations(&self) -> Vec<String> {
-        self.storage_manager.read().unwrap().list_relations()
+        self.storage_manager
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .list_relations()
     }
 
     fn load_relation(&self, name: &str) -> Result<Relation, StorageError> {
@@ -321,7 +333,7 @@ impl StorageEngine for PersistentEngine {
         let snapshot = self.get_snapshot_for_current_context()?;
         self.storage_manager
             .write()
-            .unwrap()
+            .map_err(|_| StorageError::Other("RwLock poisoned".to_string()))?
             .scan_relation(name, &snapshot, &self.committed_txns)
     }
 
@@ -330,7 +342,7 @@ impl StorageEngine for PersistentEngine {
 
         self.storage_manager
             .write()
-            .unwrap()
+            .map_err(|_| StorageError::Other("RwLock poisoned".to_string()))?
             .store_relation(name, relation, txn_id)?;
 
         if auto_commit {
@@ -359,7 +371,7 @@ impl StorageEngine for PersistentEngine {
 
         self.storage_manager
             .write()
-            .unwrap()
+            .map_err(|_| StorageError::Other("RwLock poisoned".to_string()))?
             .insert_tuple(name, tuple, txn_id)?;
 
         if auto_commit {
@@ -395,7 +407,10 @@ impl StorageEngine for PersistentEngine {
             .flush()
             .map_err(|e| StorageError::Other(format!("WAL flush error: {}", e)))?;
 
-        self.storage_manager.write().unwrap().flush_heap_files()?;
+        self.storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("RwLock poisoned".to_string()))?
+            .flush_heap_files()?;
 
         self.committed_txns.insert(snapshot.txn_id);
         self.active_txns.commit(snapshot.txn_id);
@@ -448,7 +463,7 @@ impl PersistentEngine {
 
         self.storage_manager
             .write()
-            .unwrap()
+            .map_err(|_| StorageError::Other("RwLock poisoned".to_string()))?
             .scan_relation(name, &snapshot, &self.committed_txns)
     }
 
@@ -473,7 +488,7 @@ impl PersistentEngine {
 
         self.storage_manager
             .write()
-            .unwrap()
+            .map_err(|_| StorageError::Other("RwLock poisoned".to_string()))?
             .insert_tuple(name, tuple, txn_id)
     }
 }


### PR DESCRIPTION
Title: '🔒 Warden: Fix RwLock poisoning in PersistentEngine'
🦠 Threat: Calling `.unwrap()` on `RwLock::write()` or `RwLock::read()` in `relvar-storage/src/persistent_engine/mod.rs` allows a single poisoned lock (e.g. from a thread panicking during a write) to cascade and panic all subsequent threads attempting to acquire the lock, causing a system-wide Denial of Service.
🛡️ Defense: Replaced `.unwrap()` calls on `RwLock` operations with safe `.map_err()` propagating a `StorageError`, or `.unwrap_or_else(|e| e.into_inner())` for pure read operations.
💥 Severity: Critical - could panic server and cause a system-wide Denial of Service.
🧪 Verification: Ran `cargo test`, `cargo check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --all`. Verified successful test passes.

---
*PR created automatically by Jules for task [3780105319137356489](https://jules.google.com/task/3780105319137356489) started by @madmax983*