### PR TITLE
🎻 Bard: [documentation update] Spreadsheet

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -33,3 +33,6 @@
 ## 2025-05-06 - [The Ghost Knowledge Graph]
 **Confusion:** The experimental `KnowledgeGraph` module was completely undocumented, leaving users to guess how it connects to the relational model.
 **Clarification:** Wrote comprehensive module-level documentation and executable doctests for `KnowledgeGraph` and `TriplePattern` explaining the "Relational Semantic Web" concept.
+## 2025-05-26 - The "Spreadsheet" Example
+**Confusion:** The experimental `Spreadsheet` module had module-level docs missing and placeholder examples in doc-tests for the main struct and its methods (`new` and `evaluate`). This lack of examples made it confusing to understand how to instantiate relations and formulas for spreadsheet evaluation.
+**Clarification:** Added module-level documentation and executable `/// # Examples` doc-tests for `Spreadsheet` and its methods, demonstrating how to construct the necessary values and formulas relations and perform spreadsheet evaluation using relational algebra.

--- a/plan.md
+++ b/plan.md
@@ -1,2 +1,19 @@
-1. **Submit the clean audit report.**
-   - Since no active vulnerabilities were found during the investigation of `unsafe` blocks, bounds checking, buffer limits, and data serialization (verifying that they either safely bounded or properly capped), I will submit the PR to confirm the codebase is secure under the given scope.
+1. **Add executable doc-tests to `Spreadsheet` module and struct**
+   - Use `replace_with_git_merge_diff` to add module-level docs `//!` to `relvar/src/experimental/spreadsheet.rs`.
+   - Add an executable `/// # Examples` block for `Spreadsheet`.
+   - Update `Spreadsheet::new` and `Spreadsheet::evaluate` to have real executable doc-tests instead of placeholders.
+2. **Verify documentation rendering and execution**
+   - Run `cargo test --doc` to ensure all doctests compile and run correctly.
+   - Run `cargo doc --no-deps --open` to check visual rendering (if applicable, or just build docs).
+3. **Run standard checks**
+   - Run `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, `cargo fmt --all`, and `cargo check`.
+4. **Append learning to Bard's journal**
+   - Append the learning regarding the spreadsheet module documentation to `.jules/bard.md`.
+5. **Verify journal modification**
+   - Execute `cat .jules/bard.md` to ensure the journal was updated correctly.
+6. **Create PR description**
+   - Use `write_file` to create `pr_description.md` with the required PR format (Chapter, Insight, Example, Preview).
+7. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+   - Call `pre_commit_instructions` and follow the provided steps.
+8. **Submit the PR**
+   - Run `python3 pr.py` to submit the PR.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+📖 Chapter: The `Spreadsheet` module
+🔦 Insight: Explained how spreadsheet cells and formulas can be evaluated using relational joins and extensions, and provided module-level docs and executable examples replacing placeholder comments.
+🧪 Example: Added 3 executable doc-tests for `Spreadsheet`, `Spreadsheet::new`, and `Spreadsheet::evaluate`.
+🖼️ Preview: Documentation renders successfully and all tests pass.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -1,3 +1,9 @@
+//! # Relational Spreadsheet Engine
+//!
+//! This module models a spreadsheet where cells can contain raw values or formulas referencing
+//! other cells. Evaluation is performed purely using relational algebra (joins and extensions)
+//! until all cell values are resolved (fixpoint).
+
 use relvar_core::{
     error::DatabaseError,
     types::ScalarType,
@@ -9,6 +15,35 @@ use relvar_core::{
 /// Models a spreadsheet where cells can contain raw values or formulas referencing
 /// other cells. Evaluation is performed purely using relational joins and extensions
 /// until all cell values are resolved (fixpoint).
+///
+/// # Examples
+///
+/// ```
+/// use relvar::{Relation, RelationType, ScalarType, TupleType};
+/// use relvar::tuple;
+/// use relvar::experimental::spreadsheet::Spreadsheet;
+///
+/// let val_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("val", ScalarType::Float);
+/// let mut values = Relation::new(RelationType::new(val_heading));
+///
+/// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+/// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+///
+/// let form_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("op", ScalarType::String)
+///     .with_attribute("arg1", ScalarType::String)
+///     .with_attribute("arg2", ScalarType::String);
+/// let mut formulas = Relation::new(RelationType::new(form_heading));
+///
+/// formulas.insert(tuple! {
+///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+/// }).unwrap();
+///
+/// let spreadsheet = Spreadsheet::new(values, formulas);
+/// ```
 pub struct Spreadsheet {
     /// Resolved values. Schema: `(id: String, val: Float)`
     pub values: Relation,
@@ -25,7 +60,20 @@ impl Spreadsheet {
     /// ```
     /// use relvar::{Relation, RelationType, ScalarType, TupleType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let values = Relation::new(RelationType::new(val_heading));
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let formulas = Relation::new(RelationType::new(form_heading));
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -37,8 +85,32 @@ impl Spreadsheet {
     ///
     /// ```
     /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::tuple;
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    ///
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_heading));
+    ///
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    ///
+    /// assert_eq!(result.cardinality(), 3); // A1, A2, and B1
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
📖 Chapter: The `Spreadsheet` module
🔦 Insight: Explained how spreadsheet cells and formulas can be evaluated using relational joins and extensions, and provided module-level docs and executable examples replacing placeholder comments.
🧪 Example: Added 3 executable doc-tests for `Spreadsheet`, `Spreadsheet::new`, and `Spreadsheet::evaluate`.
🖼️ Preview: Documentation renders successfully and all tests pass.

---
*PR created automatically by Jules for task [9670631447718508853](https://jules.google.com/task/9670631447718508853) started by @madmax983*