### PR TITLE
⚡ Bolt: Optimized common_attributes allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,6 @@
 ## 2024-05-20 - String Allocations in Iterators
 **Learning:** `rename_into` previously consumed a tuple's BTreeMap entirely to scalar values by calling `.into_values()`. However, BTreeMaps also implement `into_iter()` which yields owned `(K, V)` pairs. We were discarding the `K` (the original String key) and creating a brand new String key for every column of every tuple, even if the rename mapping didn't touch it.
 **Action:** Always check if we can reuse the owned strings from an input collection instead of reflexively throwing them away and re-allocating them in an iterator pipeline.
+## 2024-05-27 - [Semijoin Common Attributes Allocation Removal]
+**Learning:** The `common_attributes` helper function returned a `Vec<String>` requiring cloning of attribute names, even though the result was just used for read-only lookups in operations like `semijoin` and `semidifference`. Returning a `Vec<&str>` avoids string cloning entirely.
+**Action:** Replaced `.cloned()` and `Vec<String>` with `.map(|s| s.as_str())` and `Vec<&'a str>` in `common_attributes` in `semijoin.rs`. Updated dependent structs like `SemijoinKey` to use `&[&str]`.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,7 @@
+💡 What: Optimized `common_attributes` helper in `semijoin.rs` to return `Vec<&'a str>` instead of `Vec<String>`.
+
+🎯 Why: To eliminate unnecessary heap allocations for string cloning when extracting common attribute names for read-only lookups in relational operations.
+
+📊 Impact: Removes one string allocation per common attribute when performing semijoin or semidifference.
+
+🔬 Measurement: Run `cargo test` to verify correctness.

--- a/relvar-core/src/algebra/semijoin.rs
+++ b/relvar-core/src/algebra/semijoin.rs
@@ -23,7 +23,7 @@ use std::hash::{Hash, Hasher};
 #[derive(Debug, Eq)]
 struct SemijoinKey<'t, 'a> {
     tuple: &'t Tuple,
-    attributes: &'a [String],
+    attributes: &'a [&'a str],
 }
 
 impl<'t, 'a> PartialEq for SemijoinKey<'t, 'a> {
@@ -32,7 +32,7 @@ impl<'t, 'a> PartialEq for SemijoinKey<'t, 'a> {
         // with the same common_attrs slice.
         for (i, attr) in self.attributes.iter().enumerate() {
             let v1 = self.tuple.get(attr);
-            let v2 = other.tuple.get(&other.attributes[i]);
+            let v2 = other.tuple.get(other.attributes[i]);
             if v1 != v2 {
                 return false;
             }
@@ -52,12 +52,12 @@ impl<'t, 'a> Hash for SemijoinKey<'t, 'a> {
 }
 
 /// Finds common attribute names between two relations' headings.
-fn common_attributes(a: &Relation, b: &Relation) -> Vec<String> {
+fn common_attributes<'a>(a: &'a Relation, b: &Relation) -> Vec<&'a str> {
     a.relation_type()
         .heading()
         .attribute_names()
         .filter(|attr| b.relation_type().heading().has_attribute(attr))
-        .cloned()
+        .map(|s| s.as_str())
         .collect()
 }
 
@@ -216,7 +216,7 @@ impl Relation {
     /// assert_eq!(result.cardinality(), 1); // Only emp 1 matches
     /// ```
     pub fn semijoin_into(self, other: &Relation) -> Self {
-        let common_attrs = common_attributes(&self, other);
+        let common_attrs = common_attributes(other, &self);
 
         // If no common attributes, we have a degenerate case (Cartesian product projection)
         if common_attrs.is_empty() {
@@ -440,7 +440,7 @@ impl Relation {
     /// assert_eq!(result.cardinality(), 1); // Bob (id 2) has no role
     /// ```
     pub fn semidifference_into(self, other: &Relation) -> Self {
-        let common_attrs = common_attributes(&self, other);
+        let common_attrs = common_attributes(other, &self);
 
         // Degenerate case handling
         if common_attrs.is_empty() {
@@ -1046,7 +1046,7 @@ mod tests {
         use std::hash::Hash;
 
         let t1 = tuple! { a: 1i64 };
-        let attributes = vec!["a".to_string(), "b".to_string()];
+        let attributes = vec!["a", "b"];
 
         let key1 = super::SemijoinKey {
             tuple: &t1,


### PR DESCRIPTION
💡 What: Optimized `common_attributes` helper in `semijoin.rs` to return `Vec<&'a str>` instead of `Vec<String>`.

🎯 Why: To eliminate unnecessary heap allocations for string cloning when extracting common attribute names for read-only lookups in relational operations.

📊 Impact: Removes one string allocation per common attribute when performing semijoin or semidifference.

🔬 Measurement: Run `cargo test` to verify correctness.

---
*PR created automatically by Jules for task [7926093618658812164](https://jules.google.com/task/7926093618658812164) started by @madmax983*