### PR TITLE
🔒 Warden: Prevent RwLock Poisoning DoS

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -9,3 +9,6 @@
 ## 2026-04-24 - [Unsafe unwrap in StorageManager]
 **Threat:** Potential panic and crash if `get_or_open_heap_file` fails to retrieve or map a file correctly, resulting in an unhandled `.unwrap()` failure.
 **Defense:** Replaced `.unwrap()` with `HashMap::entry` to ensure safe, graceful error propagation rather than crashing the system without unreachable branches.
+## 2024-05-18 - RwLock Poisoning DoS
+**Threat:** Calling `.unwrap()` on `RwLock` operations (like `read()` or `write()`) risks a system-wide panic cascade (Denial of Service) if a thread panics while holding the lock, poisoning it.
+**Defense:** Replaced all `.unwrap()` calls on `RwLock` results in `PersistentEngine` (`relvar-storage/src/persistent_engine/mod.rs`) with safe error handling using `.map_err(|_| StorageError::Other("Lock poisoned".to_string()))?` for functions returning `Result` and `.unwrap_or_else(|e| e.into_inner())` for pure read operations.

--- a/relvar-storage/src/persistent_engine/mod.rs
+++ b/relvar-storage/src/persistent_engine/mod.rs
@@ -161,11 +161,11 @@ impl PersistentEngine {
         let snapshot = self.get_snapshot_for_current_context()?;
 
         // scan_relation implicitly filters out uncommitted tuples because they are not in committed_txns
-        let relation = self.storage_manager.write().unwrap().scan_relation(
-            relation_name,
-            &snapshot,
-            &self.committed_txns,
-        )?;
+        let relation = self
+            .storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("Lock poisoned".to_string()))?
+            .scan_relation(relation_name, &snapshot, &self.committed_txns)?;
 
         // Store back (effectively removing uncommitted garbage from the heap file)
         self.store_relation(relation_name, &relation)?;
@@ -197,7 +197,10 @@ impl PersistentEngine {
         self.flush_wal()?;
 
         // Now safe to flush heap files (dirty pages to disk)
-        self.storage_manager.write().unwrap().flush_heap_files()?;
+        self.storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("Lock poisoned".to_string()))?
+            .flush_heap_files()?;
 
         // Determine minimum active LSN
         let min_active_lsn = self.get_checkpoint_lsn();
@@ -298,11 +301,17 @@ impl StorageEngine for PersistentEngine {
     }
 
     fn drop_relation(&mut self, name: &str) -> Result<(), StorageError> {
-        self.storage_manager.write().unwrap().drop_relation(name)
+        self.storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("Lock poisoned".to_string()))?
+            .drop_relation(name)
     }
 
     fn relation_exists(&self, name: &str) -> bool {
-        self.storage_manager.read().unwrap().relation_exists(name)
+        self.storage_manager
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .relation_exists(name)
     }
 
     fn get_relation_metadata(&self, name: &str) -> Result<RelationMetadata, StorageError> {
@@ -313,7 +322,10 @@ impl StorageEngine for PersistentEngine {
     }
 
     fn list_relations(&self) -> Vec<String> {
-        self.storage_manager.read().unwrap().list_relations()
+        self.storage_manager
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .list_relations()
     }
 
     fn load_relation(&self, name: &str) -> Result<Relation, StorageError> {
@@ -395,7 +407,10 @@ impl StorageEngine for PersistentEngine {
             .flush()
             .map_err(|e| StorageError::Other(format!("WAL flush error: {}", e)))?;
 
-        self.storage_manager.write().unwrap().flush_heap_files()?;
+        self.storage_manager
+            .write()
+            .map_err(|_| StorageError::Other("Lock poisoned".to_string()))?
+            .flush_heap_files()?;
 
         self.committed_txns.insert(snapshot.txn_id);
         self.active_txns.commit(snapshot.txn_id);


### PR DESCRIPTION
🦠 Threat: Calling `.unwrap()` on `RwLock` results (such as `read().unwrap()` or `write().unwrap()`) within `relvar-storage/src/persistent_engine/mod.rs` risks a system-wide cascade of panics (Denial of Service) if a thread panics while holding the lock and poisons it.

🛡️ Defense: Replaced `.unwrap()` calls on `RwLock` instances in `PersistentEngine` with graceful error propagation using `.map_err(|_| StorageError::Other("Lock poisoned".to_string()))?` or `.unwrap_or_else(|e| e.into_inner())` for infallible read operations.

💥 Severity: High. Could lead to persistent Denial of Service across the application by crashing the storage engine unexpectedly on any lock poisoning event.

🧪 Verification: Ran `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo check`. Added journal entry to `.jules/warden.md` logging the threat and defense.

---
*PR created automatically by Jules for task [2451896735080311340](https://jules.google.com/task/2451896735080311340) started by @madmax983*