### PR TITLE
🪒 Razor: Eliminate Factory Factory and Zombie Code

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -21,3 +21,13 @@
 **Bloat:** Single-variant enum `RelationError` in `relvar-core/src/values/relation.rs` acting as a unit struct, with an unused variant `DuplicateTuple` and only one used variant `TypeMismatch`.
 **Cut:** Converted to unit struct `pub struct RelationError;` with `#[error("Tuple does not conform to relation type")]` directly. Removed the unused `DuplicateTuple` variant.
 **Saved:** Unnecessary enum matching, simplified error handling code significantly.
+
+## [Reduction]
+**Bloat:** `KeyConstraints::would_violate_on_insert` was a zombie method only used in its own tests, while the actual validation logic in `ConstraintManager` used lower-level methods (`would_violate`). The method also returned a convoluted `Result<Option<Vec<String>>, KeyConstraintError>`.
+**Cut:** Deleted `KeyConstraints::would_violate_on_insert` and its associated isolated tests.
+**Saved:** Unnecessary abstraction layer and roughly 50 lines of zombie code and tests.
+
+## [Reduction]
+**Bloat:** `MockRelation` used a "Factory Factory" (Builder Pattern) merely to accept two simple configuration arguments (`count`, `seed`) alongside the mandatory `relation_type`.
+**Cut:** Flattened the builder pattern by removing `count()` and `seed()` methods, and modified `MockRelation::new` to accept `(relation_type, count, seed)` directly.
+**Saved:** Boilerplate builder pattern methods and simpler instantiation at call sites.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,11 @@
+# 🪒 Razor: Eliminate Factory Factory and Zombie Code
+
+## [Reduction]
+**Bloat:** `KeyConstraints::would_violate_on_insert` was a zombie method only used in its own tests, while the actual validation logic in `ConstraintManager` used lower-level methods (`would_violate`). The method also returned a convoluted `Result<Option<Vec<String>>, KeyConstraintError>`.
+**Cut:** Deleted `KeyConstraints::would_violate_on_insert` and its associated isolated tests.
+**Saved:** Unnecessary abstraction layer and roughly 50 lines of zombie code and tests.
+
+## [Reduction]
+**Bloat:** `MockRelation` used a "Factory Factory" (Builder Pattern) merely to accept two simple configuration arguments (`count`, `seed`) alongside the mandatory `relation_type`.
+**Cut:** Flattened the builder pattern by removing `count()` and `seed()` methods, and modified `MockRelation::new` to accept `(relation_type, count, seed)` directly.
+**Saved:** Boilerplate builder pattern methods and simpler instantiation at call sites.

--- a/relvar-core/src/constraints/key.rs
+++ b/relvar-core/src/constraints/key.rs
@@ -59,11 +59,10 @@
 //!
 //! // Check if inserting a duplicate would violate the constraint
 //! let duplicate = tuple! { emp_id: 1i64, name: "Charlie" };  // emp_id=1 already exists!
-//! let violation = constraints.would_violate_on_insert(&relation, &duplicate).unwrap();
+//! let violation = constraints.primary_key().unwrap().would_violate(&relation, &duplicate).unwrap();
 //!
-//! // Violation detected - returns the violated key attributes
-//! assert!(violation.is_some());
-//! assert_eq!(violation.unwrap(), vec!["emp_id"]);
+//! // Violation detected
+//! assert!(violation);
 //! ```
 
 use crate::values::{Relation, Tuple};
@@ -377,35 +376,6 @@ impl KeyConstraints {
 
         Ok(true)
     }
-
-    /// Check if inserting a tuple would violate any key constraints
-    ///
-    /// # Examples
-    ///
-    /// ```text
-    /// // Example
-    /// ```
-    pub fn would_violate_on_insert(
-        &self,
-        relation: &Relation,
-        new_tuple: &Tuple,
-    ) -> Result<Option<Vec<String>>, KeyConstraintError> {
-        // Check primary key
-        if let Some(pk) = &self.primary_key
-            && pk.would_violate(relation, new_tuple)?
-        {
-            return Ok(Some(pk.attributes().to_vec()));
-        }
-
-        // Check candidate keys
-        for ck in &self.candidate_keys {
-            if ck.would_violate(relation, new_tuple)? {
-                return Ok(Some(ck.attributes().to_vec()));
-            }
-        }
-
-        Ok(None)
-    }
 }
 
 impl Default for KeyConstraints {
@@ -485,22 +455,6 @@ mod tests {
     }
 
     #[test]
-    fn test_would_violate_on_insert() {
-        let mut relation = create_employee_relation();
-        relation
-            .insert(tuple! { emp_id: 1i64, name: "Alice", dept_id: 10i64 })
-            .unwrap();
-
-        let key = CandidateKey::new(vec!["emp_id".to_string()]).unwrap();
-
-        let new_tuple = tuple! { emp_id: 1i64, name: "Bob", dept_id: 20i64 };
-        assert!(key.would_violate(&relation, &new_tuple).unwrap());
-
-        let new_tuple2 = tuple! { emp_id: 2i64, name: "Charlie", dept_id: 30i64 };
-        assert!(!key.would_violate(&relation, &new_tuple2).unwrap());
-    }
-
-    #[test]
     fn test_primary_key() {
         let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
         assert_eq!(pk.attributes(), &["emp_id"]);
@@ -533,25 +487,6 @@ mod tests {
     }
 
     #[test]
-    fn test_key_constraints_violation_detection() {
-        let pk = PrimaryKey::new(vec!["emp_id".to_string()]).unwrap();
-        let constraints = KeyConstraints::new().with_primary_key(pk);
-
-        let mut relation = create_employee_relation();
-        relation
-            .insert(tuple! { emp_id: 1i64, name: "Alice", dept_id: 10i64 })
-            .unwrap();
-
-        let new_tuple = tuple! { emp_id: 1i64, name: "Bob", dept_id: 20i64 };
-        let violation = constraints
-            .would_violate_on_insert(&relation, &new_tuple)
-            .unwrap();
-
-        assert!(violation.is_some());
-        assert_eq!(violation.unwrap(), vec!["emp_id"]);
-    }
-
-    #[test]
     fn test_multiple_candidate_keys() {
         let heading = TupleType::new()
             .with_attribute("emp_id".to_string(), ScalarType::Int)
@@ -574,13 +509,6 @@ mod tests {
             .with_candidate_key(ck);
 
         assert!(constraints.are_satisfied_by(&relation).unwrap());
-
-        // Try to insert with duplicate email
-        let new_tuple = tuple! { emp_id: 3i64, email: "alice@example.com", name: "Alice2" };
-        let violation = constraints
-            .would_violate_on_insert(&relation, &new_tuple)
-            .unwrap();
-        assert!(violation.is_some());
     }
 
     #[test]

--- a/relvar/src/experimental/mock.rs
+++ b/relvar/src/experimental/mock.rs
@@ -19,10 +19,7 @@
 //! );
 //!
 //! // 2. Generate random data
-//! let relation = MockRelation::new(rel_type)
-//!     .count(100)       // Generate 100 tuples
-//!     .seed(42)         // Use fixed seed for deterministic results
-//!     .generate();
+//! let relation = MockRelation::new(rel_type, 100, Some(42)).generate();
 //!
 //! assert_eq!(relation.cardinality(), 100);
 //! ```
@@ -47,10 +44,7 @@ use std::collections::BTreeMap;
 ///         .with_attribute("name", ScalarType::String)
 /// );
 ///
-/// let relation = MockRelation::new(rel_type)
-///     .count(10)
-///     .seed(42)
-///     .generate();
+/// let relation = MockRelation::new(rel_type, 10, Some(42)).generate();
 ///
 /// assert_eq!(relation.cardinality(), 10);
 /// ```
@@ -69,42 +63,12 @@ impl MockRelation {
     /// use relvar::experimental::mock::MockRelation;
     /// // Note: This is a placeholder example
     /// ```
-    pub fn new(relation_type: RelationType) -> Self {
+    pub fn new(relation_type: RelationType, count: usize, seed: Option<u64>) -> Self {
         Self {
             relation_type,
-            count: 0,
-            seed: None,
+            count,
+            seed,
         }
-    }
-
-    /// Set the number of tuples to generate.
-    ///
-    /// Note: Since relations are sets, duplicate tuples will be ignored.
-    /// If the random generation produces duplicates, the final cardinality
-    /// might be less than `count`.
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
-    /// use relvar::experimental::mock::MockRelation;
-    /// // Note: This is a placeholder example
-    /// ```
-    pub fn count(mut self, count: usize) -> Self {
-        self.count = count;
-        self
-    }
-
-    /// Set the random seed for deterministic generation.
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
-    /// use relvar::experimental::mock::MockRelation;
-    /// // Note: This is a placeholder example
-    /// ```
-    pub fn seed(mut self, seed: u64) -> Self {
-        self.seed = Some(seed);
-        self
     }
 
     /// Generate the relation.
@@ -192,10 +156,7 @@ mod tests {
                 .with_attribute("active", ScalarType::Bool),
         );
 
-        let relation = MockRelation::new(rel_type)
-            .count(50)
-            .seed(12345) // Deterministic
-            .generate();
+        let relation = MockRelation::new(rel_type, 50, Some(12345)).generate();
 
         assert_eq!(relation.cardinality(), 50);
         assert_eq!(relation.degree(), 3);
@@ -222,7 +183,7 @@ mod tests {
                 .with_attribute("user_val", user_defined_type),
         );
 
-        let relation = MockRelation::new(rel_type).count(10).seed(42).generate();
+        let relation = MockRelation::new(rel_type, 10, Some(42)).generate();
 
         assert_eq!(relation.degree(), 7);
         assert_eq!(relation.cardinality(), 10);
@@ -232,12 +193,9 @@ mod tests {
     fn test_determinism() {
         let rel_type = RelationType::new(TupleType::new().with_attribute("val", ScalarType::Float));
 
-        let rel1 = MockRelation::new(rel_type.clone())
-            .count(10)
-            .seed(42)
-            .generate();
+        let rel1 = MockRelation::new(rel_type.clone(), 10, Some(42)).generate();
 
-        let rel2 = MockRelation::new(rel_type).count(10).seed(42).generate();
+        let rel2 = MockRelation::new(rel_type, 10, Some(42)).generate();
 
         assert_eq!(rel1, rel2);
     }


### PR DESCRIPTION
## [Reduction]
**Bloat:** `KeyConstraints::would_violate_on_insert` was a zombie method only used in its own tests, while the actual validation logic in `ConstraintManager` used lower-level methods (`would_violate`). The method also returned a convoluted `Result<Option<Vec<String>>, KeyConstraintError>`.
**Cut:** Deleted `KeyConstraints::would_violate_on_insert` and its associated isolated tests.
**Saved:** Unnecessary abstraction layer and roughly 50 lines of zombie code and tests.

## [Reduction]
**Bloat:** `MockRelation` used a "Factory Factory" (Builder Pattern) merely to accept two simple configuration arguments (`count`, `seed`) alongside the mandatory `relation_type`.
**Cut:** Flattened the builder pattern by removing `count()` and `seed()` methods, and modified `MockRelation::new` to accept `(relation_type, count, seed)` directly.
**Saved:** Boilerplate builder pattern methods and simpler instantiation at call sites.

---
*PR created automatically by Jules for task [636156955936886673](https://jules.google.com/task/636156955936886673) started by @madmax983*