### PR TITLE
🎻 Bard: Spreadsheet documentation update

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -33,3 +33,6 @@
 ## 2025-05-06 - [The Ghost Knowledge Graph]
 **Confusion:** The experimental `KnowledgeGraph` module was completely undocumented, leaving users to guess how it connects to the relational model.
 **Clarification:** Wrote comprehensive module-level documentation and executable doctests for `KnowledgeGraph` and `TriplePattern` explaining the "Relational Semantic Web" concept.
+## 2024-05-29 - Spreadsheet Examples
+**Confusion:** The experimental spreadsheet module only had placeholder examples in its docstrings, leaving users confused about how to actually instantiate and evaluate a spreadsheet.
+**Clarification:** Added executable doc-tests demonstrating the schema creation, relation insertion, and evaluation loop.

--- a/plan.md
+++ b/plan.md
@@ -1,2 +1,12 @@
-1. **Submit the clean audit report.**
-   - Since no active vulnerabilities were found during the investigation of `unsafe` blocks, bounds checking, buffer limits, and data serialization (verifying that they either safely bounded or properly capped), I will submit the PR to confirm the codebase is secure under the given scope.
+1. **Document `Spreadsheet` struct in `relvar/src/experimental/spreadsheet.rs`**
+   - Replace the missing example in `Spreadsheet` with an executable doctest showing how to use the spreadsheet engine.
+   - Update `Spreadsheet::new` to have an executable doctest.
+   - Update `Spreadsheet::evaluate` to have an executable doctest.
+2. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+   - Run `cargo fmt --all`.
+   - Run `cargo clippy --all-targets --all-features -- -D warnings`.
+   - Run `cargo test`.
+   - Run `cargo doc --open`.
+   - Add journal entry to `.jules/bard.md`.
+3. **Submit the PR**
+   - Use `pr.py` script via `run_in_bash_session` to create PR with the title "🎻 Bard: [documentation update]".

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+📖 **Chapter:** The `Spreadsheet` engine module.
+🔦 **Insight:** Clarified usage of `Spreadsheet` by replacing placeholder comments with executable doctests.
+🧪 **Example:** Added 3 executable doctests showing initialization and relation-based evaluation.
+🖼️ **Preview:** Validated successful visual render using `cargo doc`.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -9,6 +9,38 @@ use relvar_core::{
 /// Models a spreadsheet where cells can contain raw values or formulas referencing
 /// other cells. Evaluation is performed purely using relational joins and extensions
 /// until all cell values are resolved (fixpoint).
+///
+/// # Examples
+///
+/// ```
+/// use relvar_core::{tuple, Relation, RelationType, ScalarType, TupleType};
+/// use relvar::experimental::spreadsheet::Spreadsheet;
+///
+/// let val_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("val", ScalarType::Float);
+/// let mut values = Relation::new(RelationType::new(val_heading));
+///
+/// // A1 = 10, A2 = 20
+/// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+/// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+///
+/// let form_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("op", ScalarType::String)
+///     .with_attribute("arg1", ScalarType::String)
+///     .with_attribute("arg2", ScalarType::String);
+/// let mut formulas = Relation::new(RelationType::new(form_heading));
+///
+/// // B1 = A1 + A2
+/// formulas.insert(tuple! {
+///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+/// }).unwrap();
+///
+/// let spreadsheet = Spreadsheet { values, formulas };
+/// let result = spreadsheet.evaluate().unwrap();
+/// assert_eq!(result.cardinality(), 3); // A1, A2, and B1
+/// ```
 pub struct Spreadsheet {
     /// Resolved values. Schema: `(id: String, val: Float)`
     pub values: Relation,
@@ -23,9 +55,22 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar_core::{Relation, RelationType, ScalarType, TupleType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let values = Relation::new(RelationType::new(val_heading));
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let formulas = Relation::new(RelationType::new(form_heading));
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -36,9 +81,30 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar_core::{tuple, Relation, RelationType, ScalarType, TupleType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_heading));
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    ///
+    /// assert_eq!(result.cardinality(), 3); // A1, A2, and evaluated B1
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
📖 **Chapter:** The `Spreadsheet` engine module.
🔦 **Insight:** Clarified usage of `Spreadsheet` by replacing placeholder comments with executable doctests.
🧪 **Example:** Added 3 executable doctests showing initialization and relation-based evaluation.
🖼️ **Preview:** Validated successful visual render using `cargo doc`.

---
*PR created automatically by Jules for task [13031384593024303782](https://jules.google.com/task/13031384593024303782) started by @madmax983*