### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -132,3 +132,6 @@
 **Learning:** Missing coverage branches for specific operations involving database bulk constraints and cascading failure. `compute_relation_after_update` early exit logic via `?` unrolls some lines in `Database::update` if the logic before reaches an error state.
 
 **Action:** When adding tests for database constraints involving `update` and `delete`, ensure varying degrees of constraint violations such as duplicated primary keys after updates and violations on foreign keys mapped against parent relations to fully hit bulk checks.
+## 2025-05-24 - Coverage Improvement for Relation::extend_into
+**Learning:** Found uncovered logic in `extend.rs` for `extend_into` when attributes already exist or when the provided closure returns a type that mismatches the provided type. The logic in `extend` was covered, but `extend_into` lacked this coverage.
+**Action:** Added tests to cover these missing error paths for `extend_into`.

--- a/pr.py
+++ b/pr.py
@@ -4,4 +4,4 @@ import os
 with open("pr_description.md") as f:
     body = f.read()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+print(f"Submitting PR with title: 🛡️ Sentry: [test coverage improvement]\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,11 @@
+🎯 Target:
+`Relation::extend_into` error conditions in `relvar-core/src/algebra/extend.rs`.
+
+💣 Risk:
+Unexercised error paths when `extend_into` receives an existing attribute name or when the computed value has an incorrect scalar type compared to the declared target type, leading to possible untested failures in consuming-mode logic.
+
+🧪 Strategy:
+Added explicit unit tests mirroring `extend` coverage by passing invalid inputs to `extend_into` and correctly unwrapping/matching the `ExtendError::AttributeExists` and `ExtendError::TupleCreation` enumerations.
+
+🔬 Verification:
+Run `cargo test --test sentry_extend_into_coverage` and verify coverage metrics for `extend_into` have improved.

--- a/relvar-core/tests/sentry_extend_into_coverage.rs
+++ b/relvar-core/tests/sentry_extend_into_coverage.rs
@@ -1,0 +1,50 @@
+use relvar_core::algebra::ExtendError;
+use relvar_core::tuple;
+use relvar_core::types::{RelationType, ScalarType, TupleType};
+use relvar_core::values::{Relation, ScalarValue};
+
+#[test]
+fn test_extend_into_fails_if_attribute_exists() {
+    let heading = TupleType::new()
+        .with_attribute("emp_id".to_string(), ScalarType::Int)
+        .with_attribute("name".to_string(), ScalarType::String);
+
+    let rel_type = RelationType::new(heading);
+    let mut relation = Relation::new(rel_type);
+
+    relation
+        .insert(tuple! { emp_id: 1i64, name: "Alice" })
+        .unwrap();
+
+    let result = relation.extend_into("name", ScalarType::String, |t| {
+        t.get("name").unwrap().clone()
+    });
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        ExtendError::AttributeExists(_)
+    ));
+}
+
+#[test]
+fn test_extend_into_type_mismatch() {
+    let heading = TupleType::new().with_attribute("emp_id".to_string(), ScalarType::Int);
+
+    let rel_type = RelationType::new(heading);
+    let mut relation = Relation::new(rel_type);
+
+    relation.insert(tuple! { emp_id: 1i64 }).unwrap();
+
+    let result = relation.extend_into("name_length", ScalarType::String, |_| ScalarValue::Int(10));
+
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        ExtendError::TupleCreation(msg) => {
+            assert!(msg.contains("Type mismatch"));
+            assert!(msg.contains("expected String"));
+            assert!(msg.contains("got Int"));
+        }
+        _ => panic!("Expected TupleCreation error"),
+    }
+}


### PR DESCRIPTION
🎯 Target:
`Relation::extend_into` error conditions in `relvar-core/src/algebra/extend.rs`.

💣 Risk:
Unexercised error paths when `extend_into` receives an existing attribute name or when the computed value has an incorrect scalar type compared to the declared target type, leading to possible untested failures in consuming-mode logic.

🧪 Strategy:
Added explicit unit tests mirroring `extend` coverage by passing invalid inputs to `extend_into` and correctly unwrapping/matching the `ExtendError::AttributeExists` and `ExtendError::TupleCreation` enumerations.

🔬 Verification:
Run `cargo test --test sentry_extend_into_coverage` and verify coverage metrics for `extend_into` have improved.

---
*PR created automatically by Jules for task [7720484726519294896](https://jules.google.com/task/7720484726519294896) started by @madmax983*