### PR TITLE
🗺️ Atlas: [HeapFile Extracted Page Format]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -27,3 +27,6 @@
 ## 2024-05-19 - Fixing Public Module Leaks
 **Tangle:** Broad visibility (`pub mod`) across many test and internal modules leaked implementation details and complicated the dependency graph.
 **Blueprint:** Converted most top-level internal module definitions in `relvar-core` and `relvar-storage` and `relvar` to `pub(crate) mod` where appropriate, and fixed some lingering pub use statements.
+## 2023-10-27 - [HeapFile Extracted Page Format]
+**Tangle:** The HeapFile module had grown into a Blob, mixing data formats and operations.
+**Blueprint:** Extracted pure data structures (like page formats) and their serialization logic into a dedicated internal submodule (`page_format.rs`), re-exporting them in the parent `mod.rs` to flatten boundaries while isolating data from operational implementations.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,16 @@
+# 🗺️ Atlas: [HeapFile Extracted Page Format]
+
+**🕸️ Tangle:**
+The `HeapFile` module in `relvar-storage/src/storage/heap/mod.rs` had grown into a God Module (Blob anti-pattern) exceeding 1,500 lines. It mixed the pure data structures (like page formats and their serialization bounds) alongside the operational logic (inserting tuples, maintaining files, and scanning), violating the Single Responsibility Principle and muddling dependencies.
+
+**📐 Blueprint:**
+Extracted the pure data structures (`TupleId`, `SlotEntry`, `VersionedSlotEntry`, `SlottedPage`, `VersionedSlottedPage`), serialization constants, and formatting helper functions into a dedicated internal submodule `page_format.rs`. These are re-exported using `pub(crate) mod page_format` and `pub(crate) use page_format::*` within the `mod.rs` file. This flattens the boundaries while isolating data representation from the operational storage implementation.
+
+**🧱 Stability:**
+This decoupling drastically improves modularity. The operational `HeapFile` implementation is now less cluttered, and the page format can be extended independently of physical disk operations. We avoid compilation issues by leaving all components marked `pub(crate)` allowing seamless internal accessibility.
+
+**🔬 Verification:**
+- Executed `cargo check` to verify the module boundaries and crate visibility.
+- Ran `cargo test` to ensure that standard serialization testing and data consistency are unaffected by the separation.
+- Verified successful extraction with `cargo clippy --all-targets --all-features -- -D warnings`.
+- Documented in `.jules/atlas.md`.

--- a/relvar-storage/src/storage/heap/mod.rs
+++ b/relvar-storage/src/storage/heap/mod.rs
@@ -23,38 +23,11 @@
 use super::page::{PAGE_SIZE, Page, PageError, PageFile, PageId};
 use relvar_core::types::RelationType;
 use relvar_core::values::{Relation, Tuple};
-use serde::{Deserialize, Serialize};
 use std::path::Path;
 use thiserror::Error;
 
-/// Helper for bounded deserialization to prevent allocation bombs.
-/// Limits allocation size to PAGE_SIZE (4KB), preventing DoS from malicious length prefixes.
-fn deserialize_bounded<'a, T>(data: &'a [u8]) -> Result<T, HeapError>
-where
-    T: Deserialize<'a>,
-{
-    postcard::from_bytes(data).map_err(|e| HeapError::Serialization(e.to_string()))
-}
-
-/// Helper for consistent serialization matching `deserialize_bounded`.
-fn serialize_compat<T: Serialize>(value: &T) -> Result<Vec<u8>, HeapError> {
-    postcard::to_allocvec(value).map_err(|e| HeapError::Serialization(e.to_string()))
-}
-
-/// Helper for calculating serialized size matching `serialize_compat`.
-fn serialized_size_compat<T: Serialize>(value: &T) -> Result<u64, HeapError> {
-    postcard::to_allocvec(value)
-        .map(|v| v.len() as u64)
-        .map_err(|e| HeapError::Serialization(e.to_string()))
-}
-
-/// Tuple ID: (page_id, slot_number)
-/// Internal to storage layer only (TTM Proscription 6)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub(crate) struct TupleId {
-    pub(crate) page_id: PageId,
-    pub(crate) slot: u32,
-}
+pub(crate) mod page_format;
+pub(crate) use page_format::*;
 
 /// Errors that can occur during heap file operations.
 #[derive(Debug, Error)]
@@ -132,91 +105,6 @@ pub struct HeapFile {
     /// The type of tuples stored in this heap file.
     relation_type: RelationType,
 }
-
-/// Slot directory entry
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct SlotEntry {
-    offset: u32,
-    length: u32,
-}
-
-/// Versioned slot directory entry for MVCC.
-///
-/// Extends SlotEntry with transaction version metadata to support
-/// Multi-Version Concurrency Control (MVCC).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct VersionedSlotEntry {
-    /// Offset of tuple data in page
-    offset: u32,
-    /// Length of tuple data
-    length: u32,
-    /// Transaction that created this version
-    xmin: crate::wal::TransactionId,
-    /// Transaction that deleted/updated this version (None = still visible)
-    xmax: Option<crate::wal::TransactionId>,
-    /// Previous version in the version chain (for undo)
-    prev_version: Option<TupleId>,
-}
-
-impl SlotEntry {
-    fn offset(&self) -> u32 {
-        self.offset
-    }
-
-    fn length(&self) -> u32 {
-        self.length
-    }
-
-    fn set_offset(&mut self, offset: u32) {
-        self.offset = offset;
-    }
-
-    fn set_length(&mut self, length: u32) {
-        self.length = length;
-    }
-}
-
-impl VersionedSlotEntry {
-    fn offset(&self) -> u32 {
-        self.offset
-    }
-
-    fn length(&self) -> u32 {
-        self.length
-    }
-
-    fn set_offset(&mut self, offset: u32) {
-        self.offset = offset;
-    }
-
-    fn set_length(&mut self, length: u32) {
-        self.length = length;
-    }
-}
-
-/// Page layout: `[slot_count (4 bytes)] [slot_entries...] [free_space] [...tuple_data]`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct SlottedPage {
-    slot_count: u32,
-    slots: Vec<Option<SlotEntry>>,
-}
-
-/// Versioned page layout for MVCC
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct VersionedSlottedPage {
-    magic: u32, // Magic number to distinguish from SlottedPage: 0x4D564343 ("MVCC")
-    slot_count: u32,
-    slots: Vec<Option<VersionedSlotEntry>>,
-}
-
-const VERSIONED_PAGE_MAGIC: u32 = 0x4D564343; // "MVCC" in ASCII
-
-// Page format version to handle serialization changes
-const PAGE_FORMAT_VERSION: u8 = 2; // Version 2: length-prefixed slot directory
-
-const USABLE_PAGE_SIZE_V1: usize = PAGE_SIZE - 8;
-const USABLE_PAGE_SIZE_V2: usize = PAGE_SIZE - 8;
-const V2_HEADER_SIZE: usize = 5; // 1 byte version + 4 bytes length
 
 impl HeapFile {
     /// Creates a new heap file, truncating any existing file.

--- a/relvar-storage/src/storage/heap/page_format.rs
+++ b/relvar-storage/src/storage/heap/page_format.rs
@@ -1,0 +1,117 @@
+use super::HeapError;
+use crate::storage::page::{PAGE_SIZE, PageId};
+use serde::{Deserialize, Serialize};
+
+/// Helper for bounded deserialization to prevent allocation bombs.
+/// Limits allocation size to PAGE_SIZE (4KB), preventing DoS from malicious length prefixes.
+pub(crate) fn deserialize_bounded<'a, T>(data: &'a [u8]) -> Result<T, HeapError>
+where
+    T: Deserialize<'a>,
+{
+    postcard::from_bytes(data).map_err(|e| HeapError::Serialization(e.to_string()))
+}
+
+/// Helper for consistent serialization matching `deserialize_bounded`.
+pub(crate) fn serialize_compat<T: Serialize>(value: &T) -> Result<Vec<u8>, HeapError> {
+    postcard::to_allocvec(value).map_err(|e| HeapError::Serialization(e.to_string()))
+}
+
+/// Helper for calculating serialized size matching `serialize_compat`.
+pub(crate) fn serialized_size_compat<T: Serialize>(value: &T) -> Result<u64, HeapError> {
+    postcard::to_allocvec(value)
+        .map(|v| v.len() as u64)
+        .map_err(|e| HeapError::Serialization(e.to_string()))
+}
+
+/// Tuple ID: (page_id, slot_number)
+/// Internal to storage layer only (TTM Proscription 6)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct TupleId {
+    pub(crate) page_id: PageId,
+    pub(crate) slot: u32,
+}
+
+/// Slot directory entry
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SlotEntry {
+    pub(crate) offset: u32,
+    pub(crate) length: u32,
+}
+
+/// Versioned slot directory entry for MVCC.
+///
+/// Extends SlotEntry with transaction version metadata to support
+/// Multi-Version Concurrency Control (MVCC).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct VersionedSlotEntry {
+    /// Offset of tuple data in page
+    pub(crate) offset: u32,
+    /// Length of tuple data
+    pub(crate) length: u32,
+    /// Transaction that created this version
+    pub(crate) xmin: crate::wal::TransactionId,
+    /// Transaction that deleted/updated this version (None = still visible)
+    pub(crate) xmax: Option<crate::wal::TransactionId>,
+    /// Previous version in the version chain (for undo)
+    pub(crate) prev_version: Option<TupleId>,
+}
+
+impl SlotEntry {
+    pub(crate) fn offset(&self) -> u32 {
+        self.offset
+    }
+
+    pub(crate) fn length(&self) -> u32 {
+        self.length
+    }
+
+    pub(crate) fn set_offset(&mut self, offset: u32) {
+        self.offset = offset;
+    }
+
+    pub(crate) fn set_length(&mut self, length: u32) {
+        self.length = length;
+    }
+}
+
+impl VersionedSlotEntry {
+    pub(crate) fn offset(&self) -> u32 {
+        self.offset
+    }
+
+    pub(crate) fn length(&self) -> u32 {
+        self.length
+    }
+
+    pub(crate) fn set_offset(&mut self, offset: u32) {
+        self.offset = offset;
+    }
+
+    pub(crate) fn set_length(&mut self, length: u32) {
+        self.length = length;
+    }
+}
+
+/// Page layout: `[slot_count (4 bytes)] [slot_entries...] [free_space] [...tuple_data]`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SlottedPage {
+    pub(crate) slot_count: u32,
+    pub(crate) slots: Vec<Option<SlotEntry>>,
+}
+
+/// Versioned page layout for MVCC
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct VersionedSlottedPage {
+    pub(crate) magic: u32, // Magic number to distinguish from SlottedPage: 0x4D564343 ("MVCC")
+    pub(crate) slot_count: u32,
+    pub(crate) slots: Vec<Option<VersionedSlotEntry>>,
+}
+
+pub(crate) const VERSIONED_PAGE_MAGIC: u32 = 0x4D564343; // "MVCC" in ASCII
+
+// Page format version to handle serialization changes
+pub(crate) const PAGE_FORMAT_VERSION: u8 = 2; // Version 2: length-prefixed slot directory
+
+pub(crate) const USABLE_PAGE_SIZE_V1: usize = PAGE_SIZE - 8;
+pub(crate) const USABLE_PAGE_SIZE_V2: usize = PAGE_SIZE - 8;
+pub(crate) const V2_HEADER_SIZE: usize = 5; // 1 byte version + 4 bytes length


### PR DESCRIPTION
# 🗺️ Atlas: [HeapFile Extracted Page Format]

**🕸️ Tangle:** 
The `HeapFile` module in `relvar-storage/src/storage/heap/mod.rs` had grown into a God Module (Blob anti-pattern) exceeding 1,500 lines. It mixed the pure data structures (like page formats and their serialization bounds) alongside the operational logic (inserting tuples, maintaining files, and scanning), violating the Single Responsibility Principle and muddling dependencies.

**📐 Blueprint:** 
Extracted the pure data structures (`TupleId`, `SlotEntry`, `VersionedSlotEntry`, `SlottedPage`, `VersionedSlottedPage`), serialization constants, and formatting helper functions into a dedicated internal submodule `page_format.rs`. These are re-exported using `pub(crate) mod page_format` and `pub(crate) use page_format::*` within the `mod.rs` file. This flattens the boundaries while isolating data representation from the operational storage implementation.

**🧱 Stability:** 
This decoupling drastically improves modularity. The operational `HeapFile` implementation is now less cluttered, and the page format can be extended independently of physical disk operations. We avoid compilation issues by leaving all components marked `pub(crate)` allowing seamless internal accessibility.

**🔬 Verification:** 
- Executed `cargo check` to verify the module boundaries and crate visibility.
- Ran `cargo test` to ensure that standard serialization testing and data consistency are unaffected by the separation.
- Verified successful extraction with `cargo clippy --all-targets --all-features -- -D warnings`.
- Documented in `.jules/atlas.md`.

---
*PR created automatically by Jules for task [12852450490536811525](https://jules.google.com/task/12852450490536811525) started by @madmax983*