### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -33,3 +33,6 @@
 ## 2025-05-06 - [The Ghost Knowledge Graph]
 **Confusion:** The experimental `KnowledgeGraph` module was completely undocumented, leaving users to guess how it connects to the relational model.
 **Clarification:** Wrote comprehensive module-level documentation and executable doctests for `KnowledgeGraph` and `TriplePattern` explaining the "Relational Semantic Web" concept.
+## 2025-05-20 - The "Spreadsheet" Examples
+**Confusion:** The experimental `Spreadsheet` had a placeholder example for the struct and lacked executable doc-tests for its methods (`new` and `evaluate`), making it difficult to understand how to construct the values and formulas relations or perform evaluation.
+**Clarification:** Replaced the placeholder and added comprehensive executable `/// # Examples` doc-tests for `Spreadsheet` and all its methods to clearly demonstrate how to model a spreadsheet.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+📖 Chapter: The `Spreadsheet` module
+🔦 Insight: Added executable `/// # Examples` doc-tests for `Spreadsheet` and its methods to clearly explain how to model a spreadsheet relationally and how formula evaluation fixpoints work.
+🧪 Example: Replaced the placeholder with an executable block demonstrating how to evaluate 'B1 = A1 + A1'.
+🖼️ Preview: (Ran cargo doc --open to verify rendering)

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -1,3 +1,10 @@
+//! A relational spreadsheet modeling and evaluation engine.
+//!
+//! This module provides a way to represent a spreadsheet using relations:
+//! one for raw values and another for formulas. It evaluates formulas
+//! using relational operations (joins and extensions) until a fixpoint
+//! is reached and all cells are resolved.
+
 use relvar_core::{
     error::DatabaseError,
     types::ScalarType,
@@ -9,6 +16,31 @@ use relvar_core::{
 /// Models a spreadsheet where cells can contain raw values or formulas referencing
 /// other cells. Evaluation is performed purely using relational joins and extensions
 /// until all cell values are resolved (fixpoint).
+///
+/// # Examples
+///
+/// ```
+/// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
+/// use relvar::experimental::spreadsheet::Spreadsheet;
+///
+/// let val_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("val", ScalarType::Float);
+/// let mut values = Relation::new(RelationType::new(val_heading));
+/// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+///
+/// let form_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("op", ScalarType::String)
+///     .with_attribute("arg1", ScalarType::String)
+///     .with_attribute("arg2", ScalarType::String);
+/// let mut formulas = Relation::new(RelationType::new(form_heading));
+/// formulas.insert(tuple! {
+///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A1".to_string()
+/// }).unwrap();
+///
+/// let spreadsheet = Spreadsheet::new(values, formulas);
+/// ```
 pub struct Spreadsheet {
     /// Resolved values. Schema: `(id: String, val: Float)`
     pub values: Relation,
@@ -23,9 +55,21 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let mut values = Relation::new(RelationType::new(TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float)));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    ///
+    /// let mut formulas = Relation::new(RelationType::new(TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String)));
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -36,9 +80,31 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let mut values = Relation::new(RelationType::new(TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float)));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let mut formulas = Relation::new(RelationType::new(TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String)));
+    /// // B1 = A1 + A2
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    ///
+    /// // B1 is resolved to 30.0
+    /// let b1_tuple = result.tuples().find(|t| t.get_typed::<String>("id").unwrap() == "B1").unwrap();
+    /// assert_eq!(b1_tuple.get_typed::<f64>("val").unwrap(), 30.0);
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
📖 Chapter: The `Spreadsheet` module
🔦 Insight: Added executable `/// # Examples` doc-tests for `Spreadsheet` and its methods to clearly explain how to model a spreadsheet relationally and how formula evaluation fixpoints work.
🧪 Example: Replaced the placeholder with an executable block demonstrating how to evaluate 'B1 = A1 + A1'.
🖼️ Preview: (Ran cargo doc --open to verify rendering)

---
*PR created automatically by Jules for task [6321439767309577434](https://jules.google.com/task/6321439767309577434) started by @madmax983*