### PR TITLE
🗺️ Atlas: [Extract HeapFile Page Formats]

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🗺️ Atlas: [Extract HeapFile Page Formats]
+
+🕸️ Tangle: The `relvar-storage/src/storage/heap/mod.rs` file had grown into a massive Blob, mixing functional logic with purely structural data format definitions (`SlottedPage`, etc.).
+📐 Blueprint: Extracted page format structures and constants into a new internal submodule `page_format.rs` and re-exported them, separating data layout from heap operational logic.
+🧱 Stability: No change to logic, just better structural separation.
+🔬 Verification: All tests and linters pass.

--- a/relvar-storage/src/storage/heap/mod.rs
+++ b/relvar-storage/src/storage/heap/mod.rs
@@ -133,86 +133,8 @@ pub struct HeapFile {
     relation_type: RelationType,
 }
 
-/// Slot directory entry
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct SlotEntry {
-    offset: u32,
-    length: u32,
-}
-
-/// Versioned slot directory entry for MVCC.
-///
-/// Extends SlotEntry with transaction version metadata to support
-/// Multi-Version Concurrency Control (MVCC).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct VersionedSlotEntry {
-    /// Offset of tuple data in page
-    offset: u32,
-    /// Length of tuple data
-    length: u32,
-    /// Transaction that created this version
-    xmin: crate::wal::TransactionId,
-    /// Transaction that deleted/updated this version (None = still visible)
-    xmax: Option<crate::wal::TransactionId>,
-    /// Previous version in the version chain (for undo)
-    prev_version: Option<TupleId>,
-}
-
-impl SlotEntry {
-    fn offset(&self) -> u32 {
-        self.offset
-    }
-
-    fn length(&self) -> u32 {
-        self.length
-    }
-
-    fn set_offset(&mut self, offset: u32) {
-        self.offset = offset;
-    }
-
-    fn set_length(&mut self, length: u32) {
-        self.length = length;
-    }
-}
-
-impl VersionedSlotEntry {
-    fn offset(&self) -> u32 {
-        self.offset
-    }
-
-    fn length(&self) -> u32 {
-        self.length
-    }
-
-    fn set_offset(&mut self, offset: u32) {
-        self.offset = offset;
-    }
-
-    fn set_length(&mut self, length: u32) {
-        self.length = length;
-    }
-}
-
-/// Page layout: `[slot_count (4 bytes)] [slot_entries...] [free_space] [...tuple_data]`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct SlottedPage {
-    slot_count: u32,
-    slots: Vec<Option<SlotEntry>>,
-}
-
-/// Versioned page layout for MVCC
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct VersionedSlottedPage {
-    magic: u32, // Magic number to distinguish from SlottedPage: 0x4D564343 ("MVCC")
-    slot_count: u32,
-    slots: Vec<Option<VersionedSlotEntry>>,
-}
-
-const VERSIONED_PAGE_MAGIC: u32 = 0x4D564343; // "MVCC" in ASCII
-
-// Page format version to handle serialization changes
-const PAGE_FORMAT_VERSION: u8 = 2; // Version 2: length-prefixed slot directory
+pub(crate) mod page_format;
+pub(crate) use page_format::*;
 
 const USABLE_PAGE_SIZE_V1: usize = PAGE_SIZE - 8;
 const USABLE_PAGE_SIZE_V2: usize = PAGE_SIZE - 8;

--- a/relvar-storage/src/storage/heap/page_format.rs
+++ b/relvar-storage/src/storage/heap/page_format.rs
@@ -1,0 +1,83 @@
+use super::TupleId;
+use serde::{Deserialize, Serialize};
+
+/// Slot directory entry
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SlotEntry {
+    pub(crate) offset: u32,
+    pub(crate) length: u32,
+}
+
+/// Versioned slot directory entry for MVCC.
+///
+/// Extends SlotEntry with transaction version metadata to support
+/// Multi-Version Concurrency Control (MVCC).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct VersionedSlotEntry {
+    /// Offset of tuple data in page
+    pub(crate) offset: u32,
+    /// Length of tuple data
+    pub(crate) length: u32,
+    /// Transaction that created this version
+    pub(crate) xmin: crate::wal::TransactionId,
+    /// Transaction that deleted/updated this version (None = still visible)
+    pub(crate) xmax: Option<crate::wal::TransactionId>,
+    /// Previous version in the version chain (for undo)
+    pub(crate) prev_version: Option<TupleId>,
+}
+
+impl SlotEntry {
+    pub(crate) fn offset(&self) -> u32 {
+        self.offset
+    }
+
+    pub(crate) fn length(&self) -> u32 {
+        self.length
+    }
+
+    pub(crate) fn set_offset(&mut self, offset: u32) {
+        self.offset = offset;
+    }
+
+    pub(crate) fn set_length(&mut self, length: u32) {
+        self.length = length;
+    }
+}
+
+impl VersionedSlotEntry {
+    pub(crate) fn offset(&self) -> u32 {
+        self.offset
+    }
+
+    pub(crate) fn length(&self) -> u32 {
+        self.length
+    }
+
+    pub(crate) fn set_offset(&mut self, offset: u32) {
+        self.offset = offset;
+    }
+
+    pub(crate) fn set_length(&mut self, length: u32) {
+        self.length = length;
+    }
+}
+
+/// Page layout: `[slot_count (4 bytes)] [slot_entries...] [free_space] [...tuple_data]`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SlottedPage {
+    pub(crate) slot_count: u32,
+    pub(crate) slots: Vec<Option<SlotEntry>>,
+}
+
+/// Versioned page layout for MVCC
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct VersionedSlottedPage {
+    pub(crate) magic: u32, // Magic number to distinguish from SlottedPage: 0x4D564343 ("MVCC")
+    pub(crate) slot_count: u32,
+    pub(crate) slots: Vec<Option<VersionedSlotEntry>>,
+}
+
+pub(crate) const VERSIONED_PAGE_MAGIC: u32 = 0x4D564343; // "MVCC" in ASCII
+
+// Page format version to handle serialization changes
+pub(crate) const PAGE_FORMAT_VERSION: u8 = 2; // Version 2: length-prefixed slot directory


### PR DESCRIPTION
🗺️ Atlas: [Extract HeapFile Page Formats]

🕸️ Tangle: The `relvar-storage/src/storage/heap/mod.rs` file had grown into a massive Blob, mixing functional logic with purely structural data format definitions (`SlottedPage`, etc.).
📐 Blueprint: Extracted page format structures and constants into a new internal submodule `page_format.rs` and re-exported them, separating data layout from heap operational logic.
🧱 Stability: No change to logic, just better structural separation.
🔬 Verification: All tests and linters pass.

---
*PR created automatically by Jules for task [7629686839512149206](https://jules.google.com/task/7629686839512149206) started by @madmax983*