### PR TITLE
⚒️ Forge: Extract `compute_pairwise_forces` God Function

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,6 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+## 2024-06-01 - Extract God Function in Physics
+**Learning:** The compute_pairwise_forces function was a God Function mixing join, filter, and extension logic.
+**Action:** Applied the Three-Phase Operator pattern to extract generate_particle_pairs, filter_self_interactions, and calculate_forces.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+🚮 Smell: `compute_pairwise_forces` in `relvar/src/experimental/physics.rs` was an overly long "God Function" (81 lines) mixing distinct logical phases: joining, restricting, and extending logic.
+✨ Solution: Applied the "Three-Phase Operator" pattern. Extracted logic into three properly scoped private helper methods: `generate_particle_pairs`, `filter_self_interactions`, and `calculate_forces`.
+🧼 Benefit: Significantly improves clarity, modularity, and readability. Reduces cognitive load by separating the generation of pairs, filtering out self-interactions, and performing force calculations.
+🛡️ Verification: Extracted code runs exactly the same as before. Cargo tests, clippy, and formatting passed successfully.

--- a/relvar/src/experimental/physics.rs
+++ b/relvar/src/experimental/physics.rs
@@ -59,6 +59,12 @@ impl PhysicsEngine {
     }
 
     fn compute_pairwise_forces(&self) -> Result<Relation, DatabaseError> {
+        let pairs = self.generate_particle_pairs()?;
+        let interactions = self.filter_self_interactions(pairs);
+        self.calculate_forces(interactions)
+    }
+
+    fn generate_particle_pairs(&self) -> Result<Relation, DatabaseError> {
         // 1. Cross join particles with themselves to compute pairwise forces.
         // Rename attributes to distinguish particle 1 and particle 2.
         let p1 = self.particles.rename(&[
@@ -79,15 +85,19 @@ impl PhysicsEngine {
             ("mass", "m2"),
         ]);
 
-        let pairs = p1.join(&p2)?;
+        p1.join(&p2)
+    }
 
+    fn filter_self_interactions(&self, pairs: Relation) -> Relation {
         // 2. Filter out self-interactions (id1 == id2)
-        let interactions = pairs.restrict(|t| {
+        pairs.restrict(|t| {
             let id1 = t.get_typed::<i64>("id1").unwrap();
             let id2 = t.get_typed::<i64>("id2").unwrap();
             id1 != id2
-        });
+        })
+    }
 
+    fn calculate_forces(&self, interactions: Relation) -> Result<Relation, DatabaseError> {
         // 3. Compute forces for each pair
         let g = self.g;
         interactions


### PR DESCRIPTION
🚮 Smell: `compute_pairwise_forces` in `relvar/src/experimental/physics.rs` was an overly long "God Function" (81 lines) mixing distinct logical phases: joining, restricting, and extending logic.
✨ Solution: Applied the "Three-Phase Operator" pattern. Extracted logic into three properly scoped private helper methods: `generate_particle_pairs`, `filter_self_interactions`, and `calculate_forces`.
🧼 Benefit: Significantly improves clarity, modularity, and readability. Reduces cognitive load by separating the generation of pairs, filtering out self-interactions, and performing force calculations.
🛡️ Verification: Extracted code runs exactly the same as before. Cargo tests, clippy, and formatting passed successfully.

---
*PR created automatically by Jules for task [15408149625102805946](https://jules.google.com/task/15408149625102805946) started by @madmax983*