### PR TITLE
🔒 Warden: Prevent Stack Overflow DoS in Query and ConstraintExpression Deserialization

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -9,3 +9,7 @@
 ## 2026-04-24 - [Unsafe unwrap in StorageManager]
 **Threat:** Potential panic and crash if `get_or_open_heap_file` fails to retrieve or map a file correctly, resulting in an unhandled `.unwrap()` failure.
 **Defense:** Replaced `.unwrap()` with `HashMap::entry` to ensure safe, graceful error propagation rather than crashing the system without unreachable branches.
+
+## 2024-06-04 - Unbounded Recursion DoS
+**Threat:** Stack overflow DoS via deeply nested Postcard payloads in Query and ConstraintExpression enums.
+**Defense:** Applied deserialize_with recursion guards directly to recursive Box fields.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,9 @@
+Title: 🔒 Warden: Prevent Stack Overflow DoS in Query and ConstraintExpression Deserialization
+
+🦠 **Threat**: Stack overflow Denial of Service (DoS). The `Query` and `ConstraintExpression` enums contained recursive `Box` fields (`input`, `left`, `right`, `And`, `Or`, `Not`) that were deserialized directly using `serde`. While `serde_json` has a safe default recursion limit, the `postcard` format used by the engine has no such limit, allowing an attacker to submit deeply-nested structures that crash the database process via a stack overflow.
+
+🛡️ **Defense**: Applied `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` to all recursive `Box` fields in `Query` and `ConstraintExpression` to track and safely cap deserialization depth, returning an error when the limit is breached.
+
+💥 **Severity**: Critical. Exploitation takes minimal effort and leads to an immediate crash of the database process (Availability impact).
+
+🧪 **Verification**: Added `warden_exploit_query_recursion` and `warden_exploit_constraint_recursion` tests that build deeply nested structures and ensure `postcard` deserialization gracefully returns a recursion limit error rather than overflowing the stack. All tests pass and `cargo clippy --all-targets --all-features -- -D warnings` reports no warnings.

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -102,11 +102,24 @@ pub enum ConstraintExpression {
     },
 
     /// Logical AND: both expressions must be true
-    And(Box<ConstraintExpression>, Box<ConstraintExpression>),
+    And(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
     /// Logical OR: at least one expression must be true
-    Or(Box<ConstraintExpression>, Box<ConstraintExpression>),
+    Or(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
     /// Logical NOT: inverts the expression
-    Not(Box<ConstraintExpression>),
+    Not(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
 
     /// Set membership: attribute IN (value1, value2, ...)
     In(String, std::collections::HashSet<ScalarValue>),

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -76,6 +76,7 @@ pub enum Query {
     /// relation where the `predicate` evaluates to true.
     Restrict {
         /// The input query to filter.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// The predicate condition.
         predicate: ConstraintExpression,
@@ -87,6 +88,7 @@ pub enum Query {
     /// the specified attributes.
     Project {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// The list of attribute names to keep.
         attributes: Vec<String>,
@@ -99,6 +101,7 @@ pub enum Query {
     /// self-join.
     Rename {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// Mapping of (old_name, new_name).
         mappings: Vec<(String, String)>,
@@ -111,8 +114,10 @@ pub enum Query {
     /// this becomes a Cartesian product.
     Join {
         /// The left relation.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         left: Box<Query>,
         /// The right relation.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         right: Box<Query>,
     },
 
@@ -122,6 +127,7 @@ pub enum Query {
     /// values (Sum, Count, Avg, Min, Max) for each group.
     Summarize {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// Attributes to group by.
         group_by: Vec<String>,

--- a/relvar-core/tests/warden_exploit_constraint_recursion.rs
+++ b/relvar-core/tests/warden_exploit_constraint_recursion.rs
@@ -1,0 +1,59 @@
+use relvar_core::constraints::ConstraintExpression;
+
+#[test]
+fn test_constraint_recursion_limit_postcard() {
+    let depth = 80;
+
+    let mut current = ConstraintExpression::Cmp {
+        left: "id".to_string(),
+        op: relvar_core::constraints::CmpOp::Eq,
+        right: relvar_core::constraints::ValueOrRef::Value(relvar_core::values::ScalarValue::Int(
+            1,
+        )),
+    };
+
+    for _ in 0..depth {
+        current = ConstraintExpression::Not(Box::new(current));
+    }
+
+    let serialized = postcard::to_allocvec(&current).expect("Serialization failed");
+    let result: Result<ConstraintExpression, _> = postcard::from_bytes(&serialized);
+
+    assert!(result.is_err(), "Deserialization should have failed");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Recursion limit exceeded")
+            || err_msg.contains("Serde Deserialization Error"),
+        "Unexpected error: '{}'. Should contain recursion limit error",
+        err_msg
+    );
+}
+
+#[test]
+fn test_constraint_recursion_limit_json() {
+    let depth = 80;
+
+    let mut current = ConstraintExpression::Cmp {
+        left: "id".to_string(),
+        op: relvar_core::constraints::CmpOp::Eq,
+        right: relvar_core::constraints::ValueOrRef::Value(relvar_core::values::ScalarValue::Int(
+            1,
+        )),
+    };
+
+    for _ in 0..depth {
+        current = ConstraintExpression::Not(Box::new(current));
+    }
+
+    let serialized = serde_json::to_string(&current).expect("Serialization failed");
+    let result: Result<ConstraintExpression, _> = serde_json::from_str(&serialized);
+
+    assert!(result.is_err(), "Deserialization should have failed");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Recursion limit exceeded")
+            || err_msg.contains("recursion limit exceeded"),
+        "Unexpected error: '{}'. Should contain recursion limit error",
+        err_msg
+    );
+}

--- a/relvar-core/tests/warden_exploit_query_recursion.rs
+++ b/relvar-core/tests/warden_exploit_query_recursion.rs
@@ -1,0 +1,63 @@
+use relvar_core::constraints::{CmpOp, ConstraintExpression, ValueOrRef};
+use relvar_core::query::Query;
+use relvar_core::values::ScalarValue;
+
+#[test]
+fn test_query_recursion_limit_postcard() {
+    let depth = 80;
+
+    let mut current = Query::Scan("USERS".to_string());
+
+    for _ in 0..depth {
+        current = Query::Restrict {
+            input: Box::new(current),
+            predicate: ConstraintExpression::Cmp {
+                left: "id".to_string(),
+                op: CmpOp::Eq,
+                right: ValueOrRef::Value(ScalarValue::Int(1)),
+            },
+        };
+    }
+
+    let serialized = postcard::to_allocvec(&current).expect("Serialization failed");
+    let result: Result<Query, _> = postcard::from_bytes(&serialized);
+
+    assert!(result.is_err(), "Deserialization should have failed");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Recursion limit exceeded")
+            || err_msg.contains("Serde Deserialization Error"),
+        "Unexpected error: '{}'. Should contain recursion limit error",
+        err_msg
+    );
+}
+
+#[test]
+fn test_query_recursion_limit_json() {
+    let depth = 80;
+
+    let mut current = Query::Scan("USERS".to_string());
+
+    for _ in 0..depth {
+        current = Query::Restrict {
+            input: Box::new(current),
+            predicate: ConstraintExpression::Cmp {
+                left: "id".to_string(),
+                op: CmpOp::Eq,
+                right: ValueOrRef::Value(ScalarValue::Int(1)),
+            },
+        };
+    }
+
+    let serialized = serde_json::to_string(&current).expect("Serialization failed");
+    let result: Result<Query, _> = serde_json::from_str(&serialized);
+
+    assert!(result.is_err(), "Deserialization should have failed");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Recursion limit exceeded")
+            || err_msg.contains("recursion limit exceeded"),
+        "Unexpected error: '{}'. Should contain recursion limit error",
+        err_msg
+    );
+}


### PR DESCRIPTION
Title: 🔒 Warden: Prevent Stack Overflow DoS in Query and ConstraintExpression Deserialization

🦠 **Threat**: Stack overflow Denial of Service (DoS). The `Query` and `ConstraintExpression` enums contained recursive `Box` fields (`input`, `left`, `right`, `And`, `Or`, `Not`) that were deserialized directly using `serde`. While `serde_json` has a safe default recursion limit, the `postcard` format used by the engine has no such limit, allowing an attacker to submit deeply-nested structures that crash the database process via a stack overflow.

🛡️ **Defense**: Applied `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` to all recursive `Box` fields in `Query` and `ConstraintExpression` to track and safely cap deserialization depth, returning an error when the limit is breached.

💥 **Severity**: Critical. Exploitation takes minimal effort and leads to an immediate crash of the database process (Availability impact).

🧪 **Verification**: Added `warden_exploit_query_recursion` and `warden_exploit_constraint_recursion` tests that build deeply nested structures and ensure `postcard` deserialization gracefully returns a recursion limit error rather than overflowing the stack. All tests pass and `cargo clippy --all-targets --all-features -- -D warnings` reports no warnings.

---
*PR created automatically by Jules for task [9246179033424101065](https://jules.google.com/task/9246179033424101065) started by @madmax983*