### PR TITLE
⚒️ Forge: Refactor Spreadsheet God Function

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,6 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+## 2024-06-04 - Refactor God Function in Spreadsheet
+**Learning:** The `evaluate` method in `relvar/src/experimental/spreadsheet.rs` was a long "God Function" (66 lines) that mixed identifying unresolved formulas, resolving arguments via joins, and evaluating operations.
+**Action:** Applied the "Three-Phase Operator" pattern by extracting `get_unresolved_formulas`, `resolve_formula_arguments`, and `evaluate_resolved_formulas` into separate private helper functions to drastically improve readability without changing behavior.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,9 @@
+Title: ⚒️ Forge: Refactor Spreadsheet God Function
+
+🚮 Smell: The `evaluate` method in `Spreadsheet` (`relvar/src/experimental/spreadsheet.rs`) was a massive "God Function" (66 lines). It mixed multiple distinct phases of relational algebra evaluation into a single unstructured loop, harming readability.
+
+✨ Solution: Refactored `evaluate` using the "Three-Phase Operator" pattern. Extracted `get_unresolved_formulas`, `resolve_formula_arguments`, and `evaluate_resolved_formulas` into strictly-typed private helper methods.
+
+🧼 Benefit: Drastically flattens the execution flow of the main evaluation loop. Each relational algebraic step is now explicitly named, scoped, and separated into discrete operations, improving both documentation and maintainability without changing runtime behavior.
+
+🛡️ Verification: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all` completed successfully. No logic was altered.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -46,55 +46,11 @@ impl Spreadsheet {
         loop {
             let initial_count = current_values.cardinality();
 
-            // Find unresolved formulas by antijoining/difference with resolved values
-            // We only want formulas whose 'id' is NOT yet in current_values
-            let resolved_ids = current_values.project(&["id"]);
-            let formula_ids = self.formulas.project(&["id"]);
+            let unresolved_formulas = self.get_unresolved_formulas(&current_values)?;
+            let fully_resolved_args =
+                Self::resolve_formula_arguments(&unresolved_formulas, &current_values)?;
+            let new_values = Self::evaluate_resolved_formulas(&fully_resolved_args)?;
 
-            let unresolved_ids = formula_ids
-                .difference(&resolved_ids)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            let unresolved_formulas = self.formulas.join(&unresolved_ids)?;
-
-            // Rename current_values for arg1
-            let values_arg1 = current_values.rename(&[("id", "arg1"), ("val", "val1")]);
-            // Rename current_values for arg2
-            let values_arg2 = current_values.rename(&[("id", "arg2"), ("val", "val2")]);
-
-            // Join unresolved formulas with arg1 values
-            let with_arg1 = unresolved_formulas.join(&values_arg1)?;
-            // Join with arg2 values
-            let fully_resolved_args = with_arg1.join(&values_arg2)?;
-
-            // Evaluate the formula
-            let evaluated = fully_resolved_args
-                .extend("val", ScalarType::Float, |t| {
-                    let op = t.get_typed::<String>("op").unwrap();
-                    let val1 = t.get_typed::<f64>("val1").unwrap();
-                    let val2 = t.get_typed::<f64>("val2").unwrap();
-
-                    let result = match op.as_str() {
-                        "ADD" => val1 + val2,
-                        "SUB" => val1 - val2,
-                        "MUL" => val1 * val2,
-                        "DIV" => {
-                            if val2 != 0.0 {
-                                val1 / val2
-                            } else {
-                                f64::NAN
-                            }
-                        }
-                        _ => f64::NAN,
-                    };
-                    ScalarValue::Float(result)
-                })
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            // Project back to (id, val)
-            let new_values = evaluated.project(&["id", "val"]);
-
-            // Union with current values
             current_values = current_values
                 .union(&new_values)
                 .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
@@ -105,6 +61,67 @@ impl Spreadsheet {
         }
 
         Ok(current_values)
+    }
+
+    /// Finds formulas whose target `id` is not yet present in `current_values`.
+    fn get_unresolved_formulas(
+        &self,
+        current_values: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        let resolved_ids = current_values.project(&["id"]);
+        let formula_ids = self.formulas.project(&["id"]);
+
+        let unresolved_ids = formula_ids
+            .difference(&resolved_ids)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        self.formulas.join(&unresolved_ids)
+    }
+
+    /// Resolves `arg1` and `arg2` by joining the unresolved formulas against `current_values`.
+    fn resolve_formula_arguments(
+        unresolved_formulas: &Relation,
+        current_values: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        // Rename current_values for arg1
+        let values_arg1 = current_values.rename(&[("id", "arg1"), ("val", "val1")]);
+        // Rename current_values for arg2
+        let values_arg2 = current_values.rename(&[("id", "arg2"), ("val", "val2")]);
+
+        // Join unresolved formulas with arg1 values
+        let with_arg1 = unresolved_formulas.join(&values_arg1)?;
+        // Join with arg2 values
+        with_arg1.join(&values_arg2)
+    }
+
+    /// Evaluates fully resolved arguments to compute the final `val` and projects `(id, val)`.
+    fn evaluate_resolved_formulas(
+        fully_resolved_args: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        let evaluated = fully_resolved_args
+            .extend("val", ScalarType::Float, |t| {
+                let op = t.get_typed::<String>("op").unwrap();
+                let val1 = t.get_typed::<f64>("val1").unwrap();
+                let val2 = t.get_typed::<f64>("val2").unwrap();
+
+                let result = match op.as_str() {
+                    "ADD" => val1 + val2,
+                    "SUB" => val1 - val2,
+                    "MUL" => val1 * val2,
+                    "DIV" => {
+                        if val2 != 0.0 {
+                            val1 / val2
+                        } else {
+                            f64::NAN
+                        }
+                    }
+                    _ => f64::NAN,
+                };
+                ScalarValue::Float(result)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        Ok(evaluated.project(&["id", "val"]))
     }
 }
 


### PR DESCRIPTION
Title: ⚒️ Forge: Refactor Spreadsheet God Function

🚮 Smell: The `evaluate` method in `Spreadsheet` (`relvar/src/experimental/spreadsheet.rs`) was a massive "God Function" (66 lines). It mixed multiple distinct phases of relational algebra evaluation into a single unstructured loop, harming readability.

✨ Solution: Refactored `evaluate` using the "Three-Phase Operator" pattern. Extracted `get_unresolved_formulas`, `resolve_formula_arguments`, and `evaluate_resolved_formulas` into strictly-typed private helper methods.

🧼 Benefit: Drastically flattens the execution flow of the main evaluation loop. Each relational algebraic step is now explicitly named, scoped, and separated into discrete operations, improving both documentation and maintainability without changing runtime behavior.

🛡️ Verification: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all` completed successfully. No logic was altered.

---
*PR created automatically by Jules for task [466007752309254608](https://jules.google.com/task/466007752309254608) started by @madmax983*