### PR TITLE
🔒 Warden: Prevent stack overflow DoS in recursive AST types

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -9,3 +9,6 @@
 ## 2026-04-24 - [Unsafe unwrap in StorageManager]
 **Threat:** Potential panic and crash if `get_or_open_heap_file` fails to retrieve or map a file correctly, resulting in an unhandled `.unwrap()` failure.
 **Defense:** Replaced `.unwrap()` with `HashMap::entry` to ensure safe, graceful error propagation rather than crashing the system without unreachable branches.
+## 2024-06-05 - Prevent stack overflow DoS in recursive AST types
+**Threat:** Unbounded recursion in `Query` and `ConstraintExpression` enums allows deep deserialization to cause stack overflow DoS via POSTCARD.
+**Defense:** Applied `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` directly to recursive `Box` fields.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,11 @@
+# Title
+🔒 Warden: Prevent stack overflow DoS in recursive AST types
+
+# Description
+🦠 **Threat:** Unbounded recursion in `Query` and `ConstraintExpression` enums allowed deeply nested structures to cause stack overflow Denial of Service (DoS) during POSTCARD deserialization.
+
+🛡️ **Defense:** Applied `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` directly to the recursive `Box` fields in both enums, enforcing a maximum recursion depth of 64 limits and safely returning an error on deeply nested inputs.
+
+💥 **Severity:** High - Attackers could crash the application by sending malicious, deeply nested payloads.
+
+🧪 **Verification:** Added fuzzing-style test cases (`tests/warden_exploit_query_recursion.rs`) verifying that deserialization fails cleanly without overflowing the stack. Also ran `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings`.

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -102,11 +102,24 @@ pub enum ConstraintExpression {
     },
 
     /// Logical AND: both expressions must be true
-    And(Box<ConstraintExpression>, Box<ConstraintExpression>),
+    And(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
     /// Logical OR: at least one expression must be true
-    Or(Box<ConstraintExpression>, Box<ConstraintExpression>),
+    Or(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
     /// Logical NOT: inverts the expression
-    Not(Box<ConstraintExpression>),
+    Not(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
 
     /// Set membership: attribute IN (value1, value2, ...)
     In(String, std::collections::HashSet<ScalarValue>),

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -76,6 +76,7 @@ pub enum Query {
     /// relation where the `predicate` evaluates to true.
     Restrict {
         /// The input query to filter.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// The predicate condition.
         predicate: ConstraintExpression,
@@ -87,6 +88,7 @@ pub enum Query {
     /// the specified attributes.
     Project {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// The list of attribute names to keep.
         attributes: Vec<String>,
@@ -99,6 +101,7 @@ pub enum Query {
     /// self-join.
     Rename {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// Mapping of (old_name, new_name).
         mappings: Vec<(String, String)>,
@@ -111,8 +114,10 @@ pub enum Query {
     /// this becomes a Cartesian product.
     Join {
         /// The left relation.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         left: Box<Query>,
         /// The right relation.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         right: Box<Query>,
     },
 
@@ -122,6 +127,7 @@ pub enum Query {
     /// values (Sum, Count, Avg, Min, Max) for each group.
     Summarize {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// Attributes to group by.
         group_by: Vec<String>,

--- a/relvar-core/tests/warden_exploit_query_recursion.rs
+++ b/relvar-core/tests/warden_exploit_query_recursion.rs
@@ -1,0 +1,34 @@
+use relvar_core::constraints::{CmpOp, ConstraintExpression, ValueOrRef};
+use relvar_core::query::Query;
+use relvar_core::values::ScalarValue;
+
+#[test]
+fn test_query_overflow() {
+    let mut query = Query::Scan("A".to_string());
+    for _ in 0..1000 {
+        query = Query::Project {
+            input: Box::new(query),
+            attributes: vec!["A".to_string()],
+        };
+    }
+
+    let encoded = postcard::to_stdvec(&query).unwrap();
+    let decoded: Result<Query, _> = postcard::from_bytes(&encoded);
+    assert!(decoded.is_err(), "Expected recursion limit error");
+}
+
+#[test]
+fn test_constraint_overflow() {
+    let mut expr = ConstraintExpression::Cmp {
+        left: "A".to_string(),
+        op: CmpOp::Eq,
+        right: ValueOrRef::Value(ScalarValue::Int(1)),
+    };
+    for _ in 0..1000 {
+        expr = ConstraintExpression::Not(Box::new(expr));
+    }
+
+    let encoded = postcard::to_stdvec(&expr).unwrap();
+    let decoded: Result<ConstraintExpression, _> = postcard::from_bytes(&encoded);
+    assert!(decoded.is_err(), "Expected recursion limit error");
+}


### PR DESCRIPTION
🦠 **Threat:** Unbounded recursion in `Query` and `ConstraintExpression` enums allowed deeply nested structures to cause stack overflow Denial of Service (DoS) during POSTCARD deserialization.

🛡️ **Defense:** Applied `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` directly to the recursive `Box` fields in both enums, enforcing a maximum recursion depth of 64 limits and safely returning an error on deeply nested inputs.

💥 **Severity:** High - Attackers could crash the application by sending malicious, deeply nested payloads.

🧪 **Verification:** Added fuzzing-style test cases (`tests/warden_exploit_query_recursion.rs`) verifying that deserialization fails cleanly without overflowing the stack. Also ran `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings`.

---
*PR created automatically by Jules for task [4465568958301144945](https://jules.google.com/task/4465568958301144945) started by @madmax983*