### PR TITLE
⚒️ Forge: Refactor compute_pairwise_forces

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,6 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+## 2024-05-24 - Relational Algebra God Functions
+**Learning:** In relational algebra pipelines (like `compute_pairwise_forces`), combining renaming, joining, restricting, and extending logic creates dense "God Functions" that are hard to read.
+**Action:** Consistently apply the Three-Phase Operator pattern by extracting pure relational operations (joining, restricting, extending) into distinct, well-named helper functions.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+Title: ⚒️ Forge: Refactor compute_pairwise_forces
+
+🚮 Smell: `compute_pairwise_forces` is an 81-line God Function that mixes renaming, joining, restricting, and extending logic.
+✨ Solution: Extracted the logic into `cross_join_particles`, `restrict_self_interactions`, and `compute_force_components`.
+🧼 Benefit: Reduces cognitive load and adheres to the Three-Phase Operator pattern for relational algebra.
+🛡️ Verification: Tests passed. No logic changed.

--- a/relvar/src/experimental/physics.rs
+++ b/relvar/src/experimental/physics.rs
@@ -59,8 +59,12 @@ impl PhysicsEngine {
     }
 
     fn compute_pairwise_forces(&self) -> Result<Relation, DatabaseError> {
-        // 1. Cross join particles with themselves to compute pairwise forces.
-        // Rename attributes to distinguish particle 1 and particle 2.
+        let pairs = self.cross_join_particles()?;
+        let interactions = self.restrict_self_interactions(&pairs);
+        self.compute_force_components(&interactions)
+    }
+
+    fn cross_join_particles(&self) -> Result<Relation, DatabaseError> {
         let p1 = self.particles.rename(&[
             ("id", "id1"),
             ("x", "x1"),
@@ -79,16 +83,18 @@ impl PhysicsEngine {
             ("mass", "m2"),
         ]);
 
-        let pairs = p1.join(&p2)?;
+        p1.join(&p2)
+    }
 
-        // 2. Filter out self-interactions (id1 == id2)
-        let interactions = pairs.restrict(|t| {
+    fn restrict_self_interactions(&self, pairs: &Relation) -> Relation {
+        pairs.restrict(|t| {
             let id1 = t.get_typed::<i64>("id1").unwrap();
             let id2 = t.get_typed::<i64>("id2").unwrap();
             id1 != id2
-        });
+        })
+    }
 
-        // 3. Compute forces for each pair
+    fn compute_force_components(&self, interactions: &Relation) -> Result<Relation, DatabaseError> {
         let g = self.g;
         interactions
             .extend("fx", ScalarType::Float, move |t| {
@@ -103,7 +109,6 @@ impl PhysicsEngine {
                 let dy = y2 - y1;
                 let dist_sq = dx * dx + dy * dy;
 
-                // Avoid division by zero
                 if dist_sq < 1e-10 {
                     return ScalarValue::Float(0.0);
                 }


### PR DESCRIPTION
⚒️ Forge: Refactor compute_pairwise_forces

🚮 Smell: `compute_pairwise_forces` is an 81-line God Function that mixes renaming, joining, restricting, and extending logic.
✨ Solution: Extracted the logic into `cross_join_particles`, `restrict_self_interactions`, and `compute_force_components`.
🧼 Benefit: Reduces cognitive load and adheres to the Three-Phase Operator pattern for relational algebra.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [5946640304454288798](https://jules.google.com/task/5946640304454288798) started by @madmax983*