### PR TITLE
⚡ Bolt: Optimize `TransactionSnapshot` creation to avoid intermediate `Vec`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,7 @@
 ## 2024-05-20 - String Allocations in Iterators
 **Learning:** `rename_into` previously consumed a tuple's BTreeMap entirely to scalar values by calling `.into_values()`. However, BTreeMaps also implement `into_iter()` which yields owned `(K, V)` pairs. We were discarding the `K` (the original String key) and creating a brand new String key for every column of every tuple, even if the rename mapping didn't touch it.
 **Action:** Always check if we can reuse the owned strings from an input collection instead of reflexively throwing them away and re-allocating them in an iterator pipeline.
+
+## $(date +%Y-%m-%d) - Eliminate intermediate Vec allocation in TransactionSnapshot creation
+**Learning:** `TransactionSnapshot::new` took a `Vec<TransactionId>` and immediately re-collected it into a `HashSet`. Meanwhile, the caller `ActiveTransactionTable::begin()` collected its keys into this intermediate `Vec`. This is a classic pattern of redundant heap allocations on a critical transaction boundary.
+**Action:** Always inspect the signatures of internal structure constructors to ensure they accept the final collection type directly (like `HashSet`) if the caller is building it anyway. Change the signature and `.collect()` directly into the target set instead of chaining collections.

--- a/plan.md
+++ b/plan.md
@@ -1,2 +1,0 @@
-1. **Submit the clean audit report.**
-   - Since no active vulnerabilities were found during the investigation of `unsafe` blocks, bounds checking, buffer limits, and data serialization (verifying that they either safely bounded or properly capped), I will submit the PR to confirm the codebase is secure under the given scope.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,9 @@
+# ⚡ Bolt: [performance improvement]
+
+💡 **What:** Changed `active_txn_table.rs` and `snapshot.rs` to allocate active transactions directly into a `std::collections::HashSet` instead of collecting them into an intermediate `Vec` first.
+
+🎯 **Why:** Creating a `TransactionSnapshot` is a very hot path during concurrent transactions. Collecting `TransactionId`s into a `Vec` and then passing it into `TransactionSnapshot::new` (which then iterates and collects it into a `HashSet`) introduces an entirely redundant heap allocation every time a new transaction begins.
+
+📊 **Impact:** Reduces heap allocations by 1 per new transaction started. The intermediate `Vec` allocations and subsequent element copies have been completely eliminated.
+
+🔬 **Measurement:** Verify by looking at test performance or running existing benchmarks.

--- a/relvar-storage/src/mvcc/active_txn_table.rs
+++ b/relvar-storage/src/mvcc/active_txn_table.rs
@@ -98,7 +98,8 @@ impl ActiveTransactionTable {
         self.current_lsn = lsn;
 
         // Capture all currently active transactions (excluding the new one)
-        let active: Vec<TransactionId> = self.transactions.keys().copied().collect();
+        let active: std::collections::HashSet<TransactionId> =
+            self.transactions.keys().copied().collect();
 
         // Create snapshot for this transaction
         let snapshot = TransactionSnapshot::new(txn_id, lsn, active);

--- a/relvar-storage/src/mvcc/snapshot.rs
+++ b/relvar-storage/src/mvcc/snapshot.rs
@@ -28,7 +28,7 @@ use std::collections::HashSet;
 /// // Imagine transactions 40 and 41 are currently running
 /// let active = vec![TransactionId::new(40), TransactionId::new(41)];
 ///
-/// let snapshot = TransactionSnapshot::new(my_txn, current_lsn, active);
+/// let snapshot = TransactionSnapshot::new(my_txn, current_lsn, active.into_iter().collect());
 ///
 /// // We know that txn 40 was active when we started, so we must NOT see its changes.
 /// assert!(snapshot.is_active(TransactionId::new(40)));
@@ -72,11 +72,13 @@ impl TransactionSnapshot {
     ///
     /// assert_eq!(snapshot.txn_id, TransactionId::new(10));
     /// ```ignore
-    pub fn new(txn_id: TransactionId, snapshot_lsn: Lsn, active: Vec<TransactionId>) -> Self {
+    ///
+    /// Optimization: Accepts `HashSet` directly to avoid an intermediate `Vec` allocation.
+    pub fn new(txn_id: TransactionId, snapshot_lsn: Lsn, active: HashSet<TransactionId>) -> Self {
         Self {
             txn_id,
             snapshot_lsn,
-            active_txns: active.into_iter().collect(),
+            active_txns: active,
         }
     }
 
@@ -101,7 +103,7 @@ impl TransactionSnapshot {
     /// let t1 = TransactionId::new(1);
     /// let t2 = TransactionId::new(2);
     ///
-    /// let snapshot = TransactionSnapshot::new(t2, Lsn::new(100), vec![t1]);
+    /// let snapshot = TransactionSnapshot::new(t2, Lsn::new(100), std::collections::HashSet::from([t1]));
     ///
     /// assert!(snapshot.is_active(t1)); // T1 was running
     /// assert!(!snapshot.is_active(TransactionId::new(0))); // T0 was not running
@@ -131,7 +133,7 @@ mod tests {
         let lsn = test_lsn(100);
         let active = vec![test_txn(2), test_txn(3)];
 
-        let snapshot = TransactionSnapshot::new(txn_id, lsn, active);
+        let snapshot = TransactionSnapshot::new(txn_id, lsn, active.into_iter().collect());
 
         assert_eq!(snapshot.txn_id, txn_id);
         assert_eq!(snapshot.snapshot_lsn, lsn);
@@ -143,7 +145,7 @@ mod tests {
         let lsn = test_lsn(100);
         let active = vec![test_txn(2), test_txn(3)];
 
-        let snapshot = TransactionSnapshot::new(txn_id, lsn, active.clone());
+        let snapshot = TransactionSnapshot::new(txn_id, lsn, active.clone().into_iter().collect());
 
         assert_eq!(snapshot.active_txns.len(), 2);
         assert!(snapshot.active_txns.contains(&test_txn(2)));
@@ -156,7 +158,7 @@ mod tests {
         let lsn = test_lsn(100);
         let active = vec![test_txn(2), test_txn(3)];
 
-        let snapshot = TransactionSnapshot::new(txn_id, lsn, active);
+        let snapshot = TransactionSnapshot::new(txn_id, lsn, active.into_iter().collect());
 
         assert!(snapshot.is_active(test_txn(2)));
         assert!(snapshot.is_active(test_txn(3)));
@@ -169,7 +171,7 @@ mod tests {
         let lsn = test_lsn(100);
         let active = vec![];
 
-        let snapshot = TransactionSnapshot::new(txn_id, lsn, active);
+        let snapshot = TransactionSnapshot::new(txn_id, lsn, active.into_iter().collect());
 
         assert_eq!(snapshot.active_txns.len(), 0);
         assert!(!snapshot.is_active(test_txn(2)));
@@ -181,7 +183,7 @@ mod tests {
         let lsn = test_lsn(100);
         let active = vec![test_txn(1), test_txn(2)]; // Including self
 
-        let snapshot = TransactionSnapshot::new(txn_id, lsn, active);
+        let snapshot = TransactionSnapshot::new(txn_id, lsn, active.into_iter().collect());
 
         // Self should be in active_txns set (it's up to caller to exclude if needed)
         assert!(snapshot.active_txns.contains(&test_txn(1)));
@@ -194,7 +196,7 @@ mod tests {
         let lsn = test_lsn(100);
         let active = vec![test_txn(2), test_txn(2), test_txn(3)]; // Duplicate
 
-        let snapshot = TransactionSnapshot::new(txn_id, lsn, active);
+        let snapshot = TransactionSnapshot::new(txn_id, lsn, active.into_iter().collect());
 
         // HashSet should deduplicate
         assert_eq!(snapshot.active_txns.len(), 2);
@@ -208,7 +210,7 @@ mod tests {
         let lsn = test_lsn(100);
         let active = vec![test_txn(2), test_txn(3)];
 
-        let snapshot1 = TransactionSnapshot::new(txn_id, lsn, active);
+        let snapshot1 = TransactionSnapshot::new(txn_id, lsn, active.into_iter().collect());
         let snapshot2 = snapshot1.clone();
 
         assert_eq!(snapshot1, snapshot2);
@@ -223,8 +225,8 @@ mod tests {
         let lsn = test_lsn(100);
         let active = vec![test_txn(2), test_txn(3)];
 
-        let snapshot1 = TransactionSnapshot::new(txn_id, lsn, active.clone());
-        let snapshot2 = TransactionSnapshot::new(txn_id, lsn, active);
+        let snapshot1 = TransactionSnapshot::new(txn_id, lsn, active.clone().into_iter().collect());
+        let snapshot2 = TransactionSnapshot::new(txn_id, lsn, active.into_iter().collect());
 
         assert_eq!(snapshot1, snapshot2);
     }
@@ -234,8 +236,8 @@ mod tests {
         let lsn = test_lsn(100);
         let active = vec![test_txn(2)];
 
-        let snapshot1 = TransactionSnapshot::new(test_txn(1), lsn, active.clone());
-        let snapshot2 = TransactionSnapshot::new(test_txn(2), lsn, active);
+        let snapshot1 = TransactionSnapshot::new(test_txn(1), lsn, active.clone().into_iter().collect());
+        let snapshot2 = TransactionSnapshot::new(test_txn(2), lsn, active.into_iter().collect());
 
         assert_ne!(snapshot1, snapshot2);
     }
@@ -245,8 +247,8 @@ mod tests {
         let txn_id = test_txn(1);
         let active = vec![test_txn(2)];
 
-        let snapshot1 = TransactionSnapshot::new(txn_id, test_lsn(100), active.clone());
-        let snapshot2 = TransactionSnapshot::new(txn_id, test_lsn(200), active);
+        let snapshot1 = TransactionSnapshot::new(txn_id, test_lsn(100), active.clone().into_iter().collect());
+        let snapshot2 = TransactionSnapshot::new(txn_id, test_lsn(200), active.into_iter().collect());
 
         assert_ne!(snapshot1, snapshot2);
     }

--- a/relvar-storage/src/mvcc/visibility.rs
+++ b/relvar-storage/src/mvcc/visibility.rs
@@ -81,7 +81,7 @@ pub struct VersionMetadata {
 /// committed.insert(t1);
 ///
 /// // T2 starts, T1 is already committed, no active txns
-/// let snapshot = TransactionSnapshot::new(t2, Lsn::new(100), vec![]);
+/// let snapshot = TransactionSnapshot::new(t2, Lsn::new(100), std::collections::HashSet::from([]));
 ///
 /// // Tuple inserted by T1, never deleted
 /// let version = VersionMetadata { xmin: t1, xmax: None };
@@ -190,7 +190,7 @@ mod tests {
         let txn_id = test_txn(1);
         let version = new_version(txn_id);
 
-        let snapshot = TransactionSnapshot::new(txn_id, test_lsn(100), vec![]);
+        let snapshot = TransactionSnapshot::new(txn_id, test_lsn(100), std::collections::HashSet::from([]));
         let committed = HashSet::new(); // txn not committed yet
 
         // Creator should see its own uncommitted version
@@ -206,7 +206,7 @@ mod tests {
         let version = new_version(t1);
 
         // T2's snapshot shows T1 as active (concurrent)
-        let snapshot = TransactionSnapshot::new(t2, test_lsn(100), vec![t1]);
+        let snapshot = TransactionSnapshot::new(t2, test_lsn(100), std::collections::HashSet::from([t1]));
         let committed = HashSet::new(); // T1 not committed
 
         assert!(!is_visible(&version, &snapshot, &committed));
@@ -221,7 +221,7 @@ mod tests {
         let version = new_version(t1);
 
         // T2 starts after T1 committed (T1 not in active list)
-        let snapshot = TransactionSnapshot::new(t2, test_lsn(200), vec![]);
+        let snapshot = TransactionSnapshot::new(t2, test_lsn(200), std::collections::HashSet::from([]));
         let mut committed = HashSet::new();
         committed.insert(t1); // T1 committed
 
@@ -238,7 +238,7 @@ mod tests {
         let version = new_version_with_xmax(t1, t2);
 
         // T3 starts after both T1 and T2 committed
-        let snapshot = TransactionSnapshot::new(t3, test_lsn(300), vec![]);
+        let snapshot = TransactionSnapshot::new(t3, test_lsn(300), std::collections::HashSet::from([]));
         let mut committed = HashSet::new();
         committed.insert(t1);
         committed.insert(t2); // Deletion committed
@@ -256,7 +256,7 @@ mod tests {
         let version = new_version_with_xmax(t1, t2);
 
         // T3 starts, sees T2 as active
-        let snapshot = TransactionSnapshot::new(t3, test_lsn(300), vec![t2]);
+        let snapshot = TransactionSnapshot::new(t3, test_lsn(300), std::collections::HashSet::from([t2]));
         let mut committed = HashSet::new();
         committed.insert(t1);
         // T2 not committed
@@ -272,7 +272,7 @@ mod tests {
 
         let version = new_version(t1);
 
-        let snapshot = TransactionSnapshot::new(t2, test_lsn(200), vec![]);
+        let snapshot = TransactionSnapshot::new(t2, test_lsn(200), std::collections::HashSet::from([]));
         let committed = HashSet::new(); // T1 NOT in committed set (aborted)
 
         assert!(!is_visible(&version, &snapshot, &committed));
@@ -289,7 +289,7 @@ mod tests {
         let version = new_version_with_xmax(t1, t2);
 
         // T3's snapshot shows T2 as active
-        let snapshot = TransactionSnapshot::new(t3, test_lsn(300), vec![t2]);
+        let snapshot = TransactionSnapshot::new(t3, test_lsn(300), std::collections::HashSet::from([t2]));
         let mut committed = HashSet::new();
         committed.insert(t1);
         committed.insert(t2); // T2 committed AFTER T3 started
@@ -306,7 +306,7 @@ mod tests {
 
         let version = new_version(t1);
 
-        let snapshot = TransactionSnapshot::new(t2, test_lsn(200), vec![]);
+        let snapshot = TransactionSnapshot::new(t2, test_lsn(200), std::collections::HashSet::from([]));
         let committed = HashSet::new(); // T1 not committed
 
         // T2 can't see T1's version if T1 != T2
@@ -320,7 +320,7 @@ mod tests {
 
         let version = new_version_with_xmax(t1, t1);
 
-        let snapshot = TransactionSnapshot::new(t1, test_lsn(100), vec![]);
+        let snapshot = TransactionSnapshot::new(t1, test_lsn(100), std::collections::HashSet::from([]));
         let committed = HashSet::new();
 
         // T1 deleted its own version, should NOT see it
@@ -335,7 +335,7 @@ mod tests {
 
         let version = new_version(t1);
 
-        let snapshot = TransactionSnapshot::new(t2, test_lsn(100), vec![]);
+        let snapshot = TransactionSnapshot::new(t2, test_lsn(100), std::collections::HashSet::from([]));
         let committed = HashSet::new();
 
         assert!(!is_visible(&version, &snapshot, &committed));
@@ -352,7 +352,7 @@ mod tests {
         let version = new_version(t1);
 
         // T4 sees T2 and T3 as active, but not T1 (T1 committed before T4 started)
-        let snapshot = TransactionSnapshot::new(t4, test_lsn(400), vec![t2, t3]);
+        let snapshot = TransactionSnapshot::new(t4, test_lsn(400), std::collections::HashSet::from([t2, t3]));
         let mut committed = HashSet::new();
         committed.insert(t1);
 
@@ -367,7 +367,7 @@ mod tests {
 
         let version = new_version_with_xmax(t1, t1_new);
 
-        let snapshot = TransactionSnapshot::new(t1_new, test_lsn(200), vec![]);
+        let snapshot = TransactionSnapshot::new(t1_new, test_lsn(200), std::collections::HashSet::from([]));
         let mut committed = HashSet::new();
         committed.insert(t1);
         committed.insert(t1_new);
@@ -386,7 +386,7 @@ mod tests {
         let version = new_version(t2);
 
         // T1's snapshot captured T2 as active
-        let snapshot = TransactionSnapshot::new(t1, test_lsn(100), vec![t2]);
+        let snapshot = TransactionSnapshot::new(t1, test_lsn(100), std::collections::HashSet::from([t2]));
         let mut committed = HashSet::new();
         committed.insert(t2);
 
@@ -407,7 +407,7 @@ mod tests {
         let v1 = new_version_with_xmax(t1, t2);
         let v2 = new_version(t2);
 
-        let snapshot = TransactionSnapshot::new(t3, test_lsn(300), vec![]);
+        let snapshot = TransactionSnapshot::new(t3, test_lsn(300), std::collections::HashSet::from([]));
         let mut committed = HashSet::new();
         committed.insert(t1);
         committed.insert(t2);
@@ -428,7 +428,7 @@ mod tests {
             xmin: t1,
             xmax: None,
         };
-        let snapshot = TransactionSnapshot::new(t2, test_lsn(100), vec![]);
+        let snapshot = TransactionSnapshot::new(t2, test_lsn(100), std::collections::HashSet::from([]));
         let mut committed = HashSet::new();
         committed.insert(t1);
 
@@ -445,7 +445,7 @@ mod tests {
             xmax: None,
         };
         // t2 sees t1 as active
-        let snapshot = TransactionSnapshot::new(t2, test_lsn(100), vec![t1]);
+        let snapshot = TransactionSnapshot::new(t2, test_lsn(100), std::collections::HashSet::from([t1]));
         let committed = HashSet::new(); // t1 not committed
 
         assert!(!is_visible(&version, &snapshot, &committed));
@@ -459,7 +459,7 @@ mod tests {
             xmin: t1,
             xmax: None,
         };
-        let snapshot = TransactionSnapshot::new(t1, test_lsn(100), vec![]);
+        let snapshot = TransactionSnapshot::new(t1, test_lsn(100), std::collections::HashSet::from([]));
         let committed = HashSet::new(); // t1 not committed
 
         // Transaction can see its own changes
@@ -476,7 +476,7 @@ mod tests {
             xmin: t1,
             xmax: Some(t2),
         };
-        let snapshot = TransactionSnapshot::new(t3, test_lsn(200), vec![]);
+        let snapshot = TransactionSnapshot::new(t3, test_lsn(200), std::collections::HashSet::from([]));
         let mut committed = HashSet::new();
         committed.insert(t1);
         committed.insert(t2); // t2 is committed
@@ -496,7 +496,7 @@ mod tests {
             xmax: Some(t2),
         };
         // t3 sees t2 as active
-        let snapshot = TransactionSnapshot::new(t3, test_lsn(200), vec![t2]);
+        let snapshot = TransactionSnapshot::new(t3, test_lsn(200), std::collections::HashSet::from([t2]));
         let mut committed = HashSet::new();
         committed.insert(t1); // t1 committed, t2 not
 
@@ -512,7 +512,7 @@ mod tests {
             xmin: t1,
             xmax: Some(t1),
         };
-        let snapshot = TransactionSnapshot::new(t1, test_lsn(100), vec![]);
+        let snapshot = TransactionSnapshot::new(t1, test_lsn(100), std::collections::HashSet::from([]));
         let mut committed = HashSet::new();
         committed.insert(t1); // created by self, deleted by self
 

--- a/relvar-storage/src/persistent_engine/mod.rs
+++ b/relvar-storage/src/persistent_engine/mod.rs
@@ -267,7 +267,7 @@ impl PersistentEngine {
             Ok(crate::mvcc::TransactionSnapshot::new(
                 TransactionId::new(0),
                 self.wal.current_lsn(),
-                vec![],
+                std::collections::HashSet::new(),
             ))
         }
     }

--- a/relvar-storage/src/storage/heap/tests/delete.rs
+++ b/relvar-storage/src/storage/heap/tests/delete.rs
@@ -54,7 +54,7 @@ fn test_delete_invisible_after_commit() {
     committed.insert(test_txn(2));
 
     // T3: Should not see deleted tuple
-    let snapshot_t3 = TransactionSnapshot::new(test_txn(3), test_lsn(300), vec![]);
+    let snapshot_t3 = TransactionSnapshot::new(test_txn(3), test_lsn(300), std::collections::HashSet::from([]));
     let visible = heap.scan_visible(&snapshot_t3, &committed).unwrap();
 
     assert_eq!(visible.len(), 0); // Deleted tuple not visible
@@ -76,7 +76,7 @@ fn test_delete_concurrent_txn_sees_tuple() {
     committed.insert(test_txn(1));
 
     // T2: Begin (concurrent with T3)
-    let snapshot_t2 = TransactionSnapshot::new(test_txn(2), test_lsn(200), vec![]);
+    let snapshot_t2 = TransactionSnapshot::new(test_txn(2), test_lsn(200), std::collections::HashSet::from([]));
 
     // T3: Delete and commit
     heap.delete_tuple_versioned(tuple_id, test_txn(3)).unwrap();
@@ -108,7 +108,7 @@ fn test_delete_deleting_txn_doesnt_see_tuple() {
     heap.delete_tuple_versioned(tuple_id, test_txn(2)).unwrap();
 
     // T2 should not see the tuple it deleted
-    let snapshot_t2 = TransactionSnapshot::new(test_txn(2), test_lsn(200), vec![]);
+    let snapshot_t2 = TransactionSnapshot::new(test_txn(2), test_lsn(200), std::collections::HashSet::from([]));
     let visible = heap.scan_visible(&snapshot_t2, &committed).unwrap();
 
     assert_eq!(visible.len(), 0);
@@ -204,7 +204,7 @@ fn test_delete_multiple_tuples() {
     committed.insert(test_txn(2));
 
     // Should see first and third, but not second
-    let snapshot = TransactionSnapshot::new(test_txn(3), test_lsn(300), vec![]);
+    let snapshot = TransactionSnapshot::new(test_txn(3), test_lsn(300), std::collections::HashSet::from([]));
     let visible = heap.scan_visible(&snapshot, &committed).unwrap();
 
     assert_eq!(visible.len(), 2);

--- a/relvar-storage/src/storage/heap/tests/gc.rs
+++ b/relvar-storage/src/storage/heap/tests/gc.rs
@@ -261,7 +261,7 @@ fn test_gc_preserves_live_versions_after_gc() {
         .unwrap();
 
     // New version should still be visible
-    let snapshot = TransactionSnapshot::new(test_txn(3), test_lsn(300), vec![]);
+    let snapshot = TransactionSnapshot::new(test_txn(3), test_lsn(300), std::collections::HashSet::from([]));
     let visible = heap.scan_visible(&snapshot, &committed).unwrap();
 
     assert_eq!(visible.len(), 1);

--- a/relvar-storage/src/storage/heap/tests/insert.rs
+++ b/relvar-storage/src/storage/heap/tests/insert.rs
@@ -288,7 +288,7 @@ fn test_delete_and_insert_new_version() {
     committed.insert(test_txn(3));
 
     // Should see only the new version
-    let snapshot = crate::mvcc::TransactionSnapshot::new(test_txn(4), test_lsn(400), vec![]);
+    let snapshot = crate::mvcc::TransactionSnapshot::new(test_txn(4), test_lsn(400), std::collections::HashSet::from([]));
     let visible = heap.scan_visible(&snapshot, &committed).unwrap();
 
     assert_eq!(visible.len(), 1);

--- a/relvar-storage/src/storage/heap/tests/scan.rs
+++ b/relvar-storage/src/storage/heap/tests/scan.rs
@@ -141,7 +141,7 @@ fn test_scan_visible_sees_only_visible() {
         .unwrap();
 
     // T2 starts after T1 committed
-    let snapshot = TransactionSnapshot::new(test_txn(2), test_lsn(200), vec![]);
+    let snapshot = TransactionSnapshot::new(test_txn(2), test_lsn(200), std::collections::HashSet::from([]));
     let mut committed = HashSet::new();
     committed.insert(test_txn(1));
 
@@ -163,7 +163,7 @@ fn test_scan_visible_skips_uncommitted() {
         .unwrap();
 
     // T2 starts
-    let snapshot = TransactionSnapshot::new(test_txn(2), test_lsn(200), vec![]);
+    let snapshot = TransactionSnapshot::new(test_txn(2), test_lsn(200), std::collections::HashSet::from([]));
     let committed = HashSet::new(); // T1 not committed
 
     let visible = heap.scan_visible(&snapshot, &committed).unwrap();
@@ -187,7 +187,7 @@ fn test_scan_visible_sees_own_changes() {
         .unwrap();
 
     // T1's snapshot
-    let snapshot = TransactionSnapshot::new(txn_id, test_lsn(100), vec![]);
+    let snapshot = TransactionSnapshot::new(txn_id, test_lsn(100), std::collections::HashSet::from([]));
     let committed = HashSet::new(); // T1 not committed yet
 
     let visible = heap.scan_visible(&snapshot, &committed).unwrap();
@@ -209,7 +209,7 @@ fn test_scan_visible_concurrent_uncommitted() {
         .unwrap();
 
     // T2 starts while T1 is active
-    let snapshot = TransactionSnapshot::new(test_txn(2), test_lsn(100), vec![test_txn(1)]);
+    let snapshot = TransactionSnapshot::new(test_txn(2), test_lsn(100), std::collections::HashSet::from([test_txn(1)]));
     let mut committed = HashSet::new();
     committed.insert(test_txn(1)); // T1 committed after T2 started
 
@@ -227,7 +227,7 @@ fn test_scan_visible_empty_relation() {
     let rel_type = create_test_relation_type();
     let mut heap = HeapFile::create(path, rel_type).unwrap();
 
-    let snapshot = TransactionSnapshot::new(test_txn(1), test_lsn(100), vec![]);
+    let snapshot = TransactionSnapshot::new(test_txn(1), test_lsn(100), std::collections::HashSet::from([]));
     let committed = HashSet::new();
 
     let visible = heap.scan_visible(&snapshot, &committed).unwrap();
@@ -252,7 +252,7 @@ fn test_scan_visible_multiple_committed() {
         .unwrap();
 
     // T4 starts after all committed
-    let snapshot = TransactionSnapshot::new(test_txn(4), test_lsn(400), vec![]);
+    let snapshot = TransactionSnapshot::new(test_txn(4), test_lsn(400), std::collections::HashSet::from([]));
     let mut committed = HashSet::new();
     committed.insert(test_txn(1));
     committed.insert(test_txn(2));
@@ -284,7 +284,7 @@ fn test_scan_visible_mixed_committed_uncommitted() {
         .unwrap();
 
     // T4 starts
-    let snapshot = TransactionSnapshot::new(test_txn(4), test_lsn(400), vec![]);
+    let snapshot = TransactionSnapshot::new(test_txn(4), test_lsn(400), std::collections::HashSet::from([]));
     let mut committed = HashSet::new();
     committed.insert(test_txn(1));
     // T2 not committed
@@ -316,7 +316,7 @@ fn test_scan_visible_across_pages() {
     heap.insert_tuple_versioned(&tuple! { data: data.clone() }, test_txn(3))
         .unwrap();
 
-    let snapshot = TransactionSnapshot::new(test_txn(4), test_lsn(400), vec![]);
+    let snapshot = TransactionSnapshot::new(test_txn(4), test_lsn(400), std::collections::HashSet::from([]));
     let mut committed = HashSet::new();
     committed.insert(test_txn(1));
     committed.insert(test_txn(2));
@@ -341,7 +341,7 @@ fn test_scan_visible_no_committed_set() {
         .unwrap();
 
     // Empty committed set
-    let snapshot = TransactionSnapshot::new(test_txn(2), test_lsn(200), vec![]);
+    let snapshot = TransactionSnapshot::new(test_txn(2), test_lsn(200), std::collections::HashSet::from([]));
     let committed = HashSet::new();
 
     let visible = heap.scan_visible(&snapshot, &committed).unwrap();
@@ -362,7 +362,7 @@ fn test_scan_visible_preserves_tuple_data() {
     heap.insert_tuple_versioned(&original_tuple, test_txn(1))
         .unwrap();
 
-    let snapshot = TransactionSnapshot::new(test_txn(2), test_lsn(200), vec![]);
+    let snapshot = TransactionSnapshot::new(test_txn(2), test_lsn(200), std::collections::HashSet::from([]));
     let mut committed = HashSet::new();
     committed.insert(test_txn(1));
 
@@ -1150,7 +1150,7 @@ fn test_scan_visible_integer_overflow() {
     // Test
     let mut heap = HeapFile::open(temp_file.path(), create_test_relation_type()).unwrap();
     let snapshot =
-        crate::mvcc::TransactionSnapshot::new(test_txn(2), crate::wal::Lsn::new(100), vec![]);
+        crate::mvcc::TransactionSnapshot::new(test_txn(2), crate::wal::Lsn::new(100), std::collections::HashSet::from([]));
     let committed = std::collections::HashSet::from([test_txn(1)]);
     let result = heap.scan_visible(&snapshot, &committed);
 
@@ -1210,7 +1210,7 @@ fn test_scan_visible_out_of_bounds() {
     // Test
     let mut heap = HeapFile::open(temp_file.path(), create_test_relation_type()).unwrap();
     let snapshot =
-        crate::mvcc::TransactionSnapshot::new(test_txn(2), crate::wal::Lsn::new(100), vec![]);
+        crate::mvcc::TransactionSnapshot::new(test_txn(2), crate::wal::Lsn::new(100), std::collections::HashSet::from([]));
     let committed = std::collections::HashSet::from([test_txn(1)]);
     let result = heap.scan_visible(&snapshot, &committed);
 

--- a/relvar-storage/src/storage/heap/tests/update.rs
+++ b/relvar-storage/src/storage/heap/tests/update.rs
@@ -138,7 +138,7 @@ fn test_update_concurrent_txn_sees_old_version() {
     committed.insert(test_txn(1));
 
     // T2: Begin (concurrent with T3)
-    let snapshot_t2 = TransactionSnapshot::new(test_txn(2), test_lsn(200), vec![]);
+    let snapshot_t2 = TransactionSnapshot::new(test_txn(2), test_lsn(200), std::collections::HashSet::from([]));
 
     // T3: Update
     let updated = tuple! { id: 1i64, name: "Updated" };
@@ -178,7 +178,7 @@ fn test_update_updating_txn_sees_new_version() {
         .unwrap();
 
     // T2 should see its own update (not yet committed)
-    let snapshot_t2 = TransactionSnapshot::new(test_txn(2), test_lsn(200), vec![]);
+    let snapshot_t2 = TransactionSnapshot::new(test_txn(2), test_lsn(200), std::collections::HashSet::from([]));
     let visible = heap.scan_visible(&snapshot_t2, &committed).unwrap();
 
     assert_eq!(visible.len(), 1);
@@ -338,7 +338,7 @@ fn test_update_after_commit_visible_to_later_txn() {
     committed.insert(test_txn(2));
 
     // T3: Should see updated version
-    let snapshot_t3 = TransactionSnapshot::new(test_txn(3), test_lsn(300), vec![]);
+    let snapshot_t3 = TransactionSnapshot::new(test_txn(3), test_lsn(300), std::collections::HashSet::from([]));
     let visible = heap.scan_visible(&snapshot_t3, &committed).unwrap();
 
     assert_eq!(visible.len(), 1);

--- a/relvar-storage/src/storage/manager.rs
+++ b/relvar-storage/src/storage/manager.rs
@@ -334,7 +334,7 @@ mod tests {
     }
 
     fn dummy_snapshot() -> TransactionSnapshot {
-        TransactionSnapshot::new(TransactionId::new(1), crate::wal::Lsn::new(0), vec![])
+        TransactionSnapshot::new(TransactionId::new(1), crate::wal::Lsn::new(0), std::collections::HashSet::from([]))
     }
 
     fn committed_set() -> HashSet<TransactionId> {


### PR DESCRIPTION
💡 **What:** Changed `active_txn_table.rs` and `snapshot.rs` to allocate active transactions directly into a `std::collections::HashSet` instead of collecting them into an intermediate `Vec` first.

🎯 **Why:** Creating a `TransactionSnapshot` is a very hot path during concurrent transactions. Collecting `TransactionId`s into a `Vec` and then passing it into `TransactionSnapshot::new` (which then iterates and collects it into a `HashSet`) introduces an entirely redundant heap allocation every time a new transaction begins.

📊 **Impact:** Reduces heap allocations by 1 per new transaction started. The intermediate `Vec` allocations and subsequent element copies have been completely eliminated.

🔬 **Measurement:** Verify by looking at test performance or running existing benchmarks.

---
*PR created automatically by Jules for task [8612640498617299413](https://jules.google.com/task/8612640498617299413) started by @madmax983*