### PR TITLE
🎻 Bard: [document Spreadsheet examples]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -33,3 +33,6 @@
 ## 2025-05-06 - [The Ghost Knowledge Graph]
 **Confusion:** The experimental `KnowledgeGraph` module was completely undocumented, leaving users to guess how it connects to the relational model.
 **Clarification:** Wrote comprehensive module-level documentation and executable doctests for `KnowledgeGraph` and `TriplePattern` explaining the "Relational Semantic Web" concept.
+## 2025-06-06 - The "Spreadsheet" Examples
+**Confusion:** The experimental `Spreadsheet` module had placeholder examples for its struct and methods (`new` and `evaluate`). This lack of examples made it confusing to understand how to instantiate the values and formulas relations, or execute evaluation step to compute the spreadsheet.
+**Clarification:** Added executable `/// # Examples` doc-tests for `Spreadsheet` and its methods, demonstrating how to construct a spreadsheet relation with cells and formulas and properly evaluate it to reach fixed point.

--- a/pr.py
+++ b/pr.py
@@ -2,6 +2,8 @@ import sys
 import os
 
 with open("pr_description.md") as f:
-    body = f.read()
+    lines = f.readlines()
+    title = lines[0].strip()
+    body = "".join(lines[1:]).strip()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+print(f"Submitting PR with title: {title}\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🎻 Bard: [document Spreadsheet examples]
+
+📖 Chapter: The `Spreadsheet` module
+🔦 Insight: Added missing executable doc-tests (`/// # Examples`) to the experimental `Spreadsheet` struct, `new()`, and `evaluate()` methods, explaining how to use relational operators for cell resolution to reach fixed point.
+🧪 Example: Added 3 executable doctests in `relvar/src/experimental/spreadsheet.rs`.
+🖼️ Preview: Documentation examples now correctly instruct on how to initialize values, formulas, and execute evaluation.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -9,6 +9,35 @@ use relvar_core::{
 /// Models a spreadsheet where cells can contain raw values or formulas referencing
 /// other cells. Evaluation is performed purely using relational joins and extensions
 /// until all cell values are resolved (fixpoint).
+///
+/// # Examples
+///
+/// ```
+/// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
+/// use relvar::experimental::spreadsheet::Spreadsheet;
+///
+/// let val_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("val", ScalarType::Float);
+/// let mut values = Relation::new(RelationType::new(val_heading));
+/// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+/// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+///
+/// let form_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("op", ScalarType::String)
+///     .with_attribute("arg1", ScalarType::String)
+///     .with_attribute("arg2", ScalarType::String);
+/// let mut formulas = Relation::new(RelationType::new(form_heading));
+/// formulas.insert(tuple! {
+///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+/// }).unwrap();
+///
+/// let spreadsheet = Spreadsheet::new(values, formulas);
+/// let result = spreadsheet.evaluate().unwrap();
+///
+/// assert_eq!(result.cardinality(), 3);
+/// ```
 pub struct Spreadsheet {
     /// Resolved values. Schema: `(id: String, val: Float)`
     pub values: Relation,
@@ -23,9 +52,23 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let formulas = Relation::new(RelationType::new(form_heading));
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -36,9 +79,30 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_heading));
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    ///
+    /// assert_eq!(result.cardinality(), 3);
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();

--- a/submit_pr.py
+++ b/submit_pr.py
@@ -1,0 +1,14 @@
+import subprocess
+
+with open('pr_description.md', 'r') as f:
+    lines = f.readlines()
+
+title = lines[0].strip()
+body = ''.join(lines[1:]).strip()
+
+with open('pr_description.md', 'w') as f:
+    f.write(body)
+
+# Run pr.py and provide the title
+process = subprocess.Popen(['python3', 'pr.py'], stdin=subprocess.PIPE, text=True)
+process.communicate(input=f"{title}\n")


### PR DESCRIPTION
📖 Chapter: The `Spreadsheet` module
🔦 Insight: Added missing executable doc-tests (`/// # Examples`) to the experimental `Spreadsheet` struct, `new()`, and `evaluate()` methods, explaining how to use relational operators for cell resolution to reach fixed point.
🧪 Example: Added 3 executable doctests in `relvar/src/experimental/spreadsheet.rs`.
🖼️ Preview: Documentation examples now correctly instruct on how to initialize values, formulas, and execute evaluation.

---
*PR created automatically by Jules for task [1673954869555796031](https://jules.google.com/task/1673954869555796031) started by @madmax983*