### PR TITLE
⚡ Bolt: [Remove clone during DML update operation]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -51,7 +51,7 @@
 ## 2026-05-01 - Avoided Arc clone in DML loop
 **Learning:** `Arc<TupleType>::clone()` incurs reference counting overhead and potential allocation overhead, taking around 14ms per 10k tuple creations as shown in `tuple_creation` bench.
 **Action:** Always borrow reference from wrapper container types instead of cloning Arc explicitly if the borrow lifetime spans the whole needed lifetime block, like `tuple.conforms_to(relation_type.tuple_type())` instead of `.clone()`ing `expected_type`.
-## $(date +%Y-%m-%d) - [HashSet Pre-Allocation in Relation::from_tuples_unchecked]
+## 2025-06-07 - [HashSet Pre-Allocation in Relation::from_tuples_unchecked]
 **Learning:** `Relation::from_tuples_unchecked` previously allocated a `HashSet` using the lower bound of an iterator's `size_hint`. For chained iterators like `.filter()`, the lower bound is often 0, leading to a zero-capacity `HashSet` allocation and repeated reallocation churn as elements are inserted.
 **Action:** Use `let capacity = upper.unwrap_or(lower);` to fall back on the upper bound when constructing the collection. While this can risk over-allocation in extreme filtered edge cases, it drastically reduces allocation overhead in the majority of relational algebra operations (like `restrict` and `semijoin`) where the filtered set size aligns closer to the original capacity.
 ## 2025-05-05 - Avoid .collect() into Vec<String> when yielding references
@@ -61,3 +61,6 @@
 ## 2024-05-20 - String Allocations in Iterators
 **Learning:** `rename_into` previously consumed a tuple's BTreeMap entirely to scalar values by calling `.into_values()`. However, BTreeMaps also implement `into_iter()` which yields owned `(K, V)` pairs. We were discarding the `K` (the original String key) and creating a brand new String key for every column of every tuple, even if the rename mapping didn't touch it.
 **Action:** Always check if we can reuse the owned strings from an input collection instead of reflexively throwing them away and re-allocating them in an iterator pipeline.
+## 2025-06-07 - [Allocation removal during DML UPDATE operation]
+**Learning:** `compute_relation_after_update` accumulated tuples into a `HashSet` before calling `Relation::from_body_unchecked`. However, it called `let relation_type = current_relation.relation_type().clone();` and iterated over the whole `Relation` with `into_iter()`, dropping the inner collection components.
+**Action:** Use `current_relation.into_parts()` to take ownership of the `RelationType` without cloning it (avoiding a heap allocation for the type information) while gaining access to the internal tuple collection.

--- a/pr.py
+++ b/pr.py
@@ -1,7 +1,10 @@
 import sys
 import os
 
-with open("pr_description.md") as f:
-    body = f.read()
+with open("pr_description.md", "r") as f:
+    lines = f.readlines()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+title = lines[0].strip()
+body = "".join(lines[1:]).strip()
+
+print(f"Submitting PR with title: {title}\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,13 @@
+⚡ Bolt: [Remove clone during DML update operation]
+
+💡 What:
+Introduced an `into_parts()` method to `Relation` that consumes it and returns its components (`RelationType` and `HashSet<Tuple>`). Used this new method in `compute_relation_after_update` within `relvar-core/src/database/dml.rs` to destructure the relation instead of cloning the `relation_type` before iterating.
+
+🎯 Why:
+The `compute_relation_after_update` method previously cloned the entire `RelationType` before calling `into_iter()` on the `Relation`. Since `into_iter()` drops the original `RelationType` within `Relation`, cloning it was an unnecessary heap allocation.
+
+📊 Impact:
+Removes 1 unnecessary clone of `RelationType` (which contains a `TupleType` with a dynamically allocated `BTreeMap` of attributes) for every single execution of a DML UPDATE statement.
+
+🔬 Measurement:
+Run `cargo bench --bench tuple_creation` and the standard `cargo test` suite to verify tests pass and no performance regressions exist.

--- a/relvar-core/src/database/dml.rs
+++ b/relvar-core/src/database/dml.rs
@@ -36,11 +36,11 @@ where
     F: Fn(&Tuple) -> bool,
     U: Fn(&Tuple) -> Tuple,
 {
-    let relation_type = current_relation.relation_type().clone();
-    let expected_type = relation_type.tuple_type(); // Borrow instead of cloning Arc<TupleType>
     let initial_cardinality = current_relation.cardinality();
+    let (relation_type, tuples) = current_relation.into_parts();
+    let expected_type = relation_type.tuple_type(); // Borrow instead of cloning Arc<TupleType>
 
-    let (body, update_count) = current_relation.into_iter().try_fold(
+    let (body, update_count) = tuples.into_iter().try_fold(
         (
             std::collections::HashSet::with_capacity(initial_cardinality),
             0,

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -164,6 +164,11 @@ impl IntoIterator for Relation {
 }
 
 impl Relation {
+    /// Consumes the relation, returning its type and its body as a HashSet.
+    pub fn into_parts(self) -> (RelationType, std::collections::HashSet<Tuple>) {
+        (self.relation_type, self.body)
+    }
+
     /// Creates a new empty relation with the given type.
     ///
     /// The relation starts with zero tuples but has a defined structure

--- a/submit_pr.py
+++ b/submit_pr.py
@@ -1,0 +1,14 @@
+import os
+
+with open("pr_description.md", "r") as f:
+    lines = f.readlines()
+
+title = lines[0].strip()
+body = "".join(lines[1:]).strip()
+
+with open("pr.py", "r") as f:
+    pr_script = f.read()
+
+# Replace hardcoded title if exists, otherwise assume it takes args or we need to modify it
+# The instructions say "rewrite it using a Python script to dynamically extract the title from the first line of pr_description.md and the body from the remaining lines before running it."
+# Let's see what pr.py actually looks like first.


### PR DESCRIPTION
💡 What:
Introduced an `into_parts()` method to `Relation` that consumes it and returns its components (`RelationType` and `HashSet<Tuple>`). Used this new method in `compute_relation_after_update` within `relvar-core/src/database/dml.rs` to destructure the relation instead of cloning the `relation_type` before iterating.

🎯 Why:
The `compute_relation_after_update` method previously cloned the entire `RelationType` before calling `into_iter()` on the `Relation`. Since `into_iter()` drops the original `RelationType` within `Relation`, cloning it was an unnecessary heap allocation.

📊 Impact:
Removes 1 unnecessary clone of `RelationType` (which contains a `TupleType` with a dynamically allocated `BTreeMap` of attributes) for every single execution of a DML UPDATE statement.

🔬 Measurement:
Run `cargo bench --bench tuple_creation` and the standard `cargo test` suite to verify tests pass and no performance regressions exist.

---
*PR created automatically by Jules for task [6535283095085338603](https://jules.google.com/task/6535283095085338603) started by @madmax983*