### PR TITLE
⚒️ Forge: Refactor God Functions in Physics and Benchmarks

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,6 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+## 2024-06-07 - Refactor God Functions in Physics and Database Benchmarks
+**Learning:** `compute_pairwise_forces` in `relvar/src/experimental/physics.rs` and `bench_insert_with_check_constraint` in `benches/database.rs` were lengthy God Functions containing mixed operations.
+**Action:** Applied the 'Three-Phase Operator' pattern to `compute_pairwise_forces` by extracting interaction pair computation and force extension into separate helpers. In `benches/database.rs`, extracted reusable database setup logic for simple and complex check constraints into cleanly named helper functions.

--- a/benches/database.rs
+++ b/benches/database.rs
@@ -477,6 +477,40 @@ fn bench_virtual_relvar_query(c: &mut Criterion) {
     group.finish();
 }
 
+fn setup_simple_check_db() -> (TempDir, Database) {
+    let (temp_dir, mut db) = create_database_with_relvar();
+    let constraints = CheckConstraints::new().with_constraint(CheckConstraint::from_expression(
+        "positive_salary",
+        "Salary must be positive",
+        ConstraintExpression::Gt(
+            "salary".to_string(),
+            ValueOrRef::Value(ScalarValue::Float(0.0)),
+        ),
+    ));
+    db.set_check_constraints("EMP", constraints).unwrap();
+    (temp_dir, db)
+}
+
+fn setup_complex_check_db() -> (TempDir, Database) {
+    let (temp_dir, mut db) = create_database_with_relvar();
+    let constraints = CheckConstraints::new().with_constraint(CheckConstraint::from_expression(
+        "valid_salary_range",
+        "Salary must be between 0 and 1,000,000",
+        ConstraintExpression::And(
+            Box::new(ConstraintExpression::Gt(
+                "salary".to_string(),
+                ValueOrRef::Value(ScalarValue::Float(0.0)),
+            )),
+            Box::new(ConstraintExpression::Lt(
+                "salary".to_string(),
+                ValueOrRef::Value(ScalarValue::Float(1000000.0)),
+            )),
+        ),
+    ));
+    db.set_check_constraints("EMP", constraints).unwrap();
+    (temp_dir, db)
+}
+
 // CHECK constraint benchmarks (TTM RM Prescription 9)
 fn bench_insert_with_check_constraint(c: &mut Criterion) {
     let mut group = c.benchmark_group("insert_with_check_constraint");
@@ -484,28 +518,7 @@ fn bench_insert_with_check_constraint(c: &mut Criterion) {
     // Benchmark: Simple CHECK constraint (single comparison)
     group.bench_function("simple_check", |b| {
         b.iter_batched(
-            || {
-                // Setup: create database with CHECK constraint
-                let temp_dir = TempDir::new().unwrap();
-                let mut db = Database::open(temp_dir.path()).unwrap();
-                let emp_type = create_employee_type();
-                db.create_relvar("EMP", emp_type).unwrap();
-
-                // Add CHECK constraint: salary > 0
-                let constraints = CheckConstraints::new().with_constraint(
-                    CheckConstraint::from_expression(
-                        "positive_salary",
-                        "Salary must be positive",
-                        ConstraintExpression::Gt(
-                            "salary".to_string(),
-                            ValueOrRef::Value(ScalarValue::Float(0.0)),
-                        ),
-                    ),
-                );
-                db.set_check_constraints("EMP", constraints).unwrap();
-
-                (temp_dir, db)
-            },
+            setup_simple_check_db,
             |(_temp_dir, mut db)| {
                 // Measured: insert with CHECK constraint
                 let tuple = tuple! {
@@ -524,33 +537,7 @@ fn bench_insert_with_check_constraint(c: &mut Criterion) {
     // Benchmark: Complex CHECK constraint (multiple conditions)
     group.bench_function("complex_check", |b| {
         b.iter_batched(
-            || {
-                let temp_dir = TempDir::new().unwrap();
-                let mut db = Database::open(temp_dir.path()).unwrap();
-                let emp_type = create_employee_type();
-                db.create_relvar("EMP", emp_type).unwrap();
-
-                // Add CHECK constraint: salary > 0 AND salary < 1000000
-                let constraints = CheckConstraints::new().with_constraint(
-                    CheckConstraint::from_expression(
-                        "valid_salary_range",
-                        "Salary must be between 0 and 1,000,000",
-                        ConstraintExpression::And(
-                            Box::new(ConstraintExpression::Gt(
-                                "salary".to_string(),
-                                ValueOrRef::Value(ScalarValue::Float(0.0)),
-                            )),
-                            Box::new(ConstraintExpression::Lt(
-                                "salary".to_string(),
-                                ValueOrRef::Value(ScalarValue::Float(1000000.0)),
-                            )),
-                        ),
-                    ),
-                );
-                db.set_check_constraints("EMP", constraints).unwrap();
-
-                (temp_dir, db)
-            },
+            setup_complex_check_db,
             |(_temp_dir, mut db)| {
                 let tuple = tuple! {
                     emp_id: 1i64,
@@ -568,13 +555,7 @@ fn bench_insert_with_check_constraint(c: &mut Criterion) {
     // Benchmark: Comparison baseline (no constraints)
     group.bench_function("no_check", |b| {
         b.iter_batched(
-            || {
-                let temp_dir = TempDir::new().unwrap();
-                let mut db = Database::open(temp_dir.path()).unwrap();
-                let emp_type = create_employee_type();
-                db.create_relvar("EMP", emp_type).unwrap();
-                (temp_dir, db)
-            },
+            create_database_with_relvar,
             |(_temp_dir, mut db)| {
                 let tuple = tuple! {
                     emp_id: 1i64,

--- a/pr.py
+++ b/pr.py
@@ -2,6 +2,9 @@ import sys
 import os
 
 with open("pr_description.md") as f:
-    body = f.read()
+    lines = f.readlines()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+title = lines[0].strip()
+body = ''.join(lines[1:]).strip()
+
+print(f"Submitting PR with title: {title}\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+⚒️ Forge: Refactor God Functions in Physics and Benchmarks
+
+🚮 Smell: `compute_pairwise_forces` in `relvar/src/experimental/physics.rs` (81 lines) and `bench_insert_with_check_constraint` in `benches/database.rs` (113 lines) were lengthy God Functions containing mixed setup, logic, and formatting operations. This harmed readability and violated the 'Three-Phase Operator' pattern.
+✨ Solution: Applied the 'Three-Phase Operator' pattern to `compute_pairwise_forces` by extracting `compute_interaction_pairs` and `extend_with_forces` into separate private helper functions. In `benches/database.rs`, extracted reusable database setup logic for simple and complex check constraints into cleanly named helper functions `setup_simple_check_db` and `setup_complex_check_db`.
+🧼 Benefit: Significantly flattens the execution flow and improves readability by isolating relational operations into distinct, logically bounded helpers without changing underlying behavior or performance semantics.
+🛡️ Verification: Tests passed (`cargo test`). No logic changed. Checked with `cargo check`, `cargo fmt`, and `cargo clippy`.

--- a/relvar/src/experimental/physics.rs
+++ b/relvar/src/experimental/physics.rs
@@ -59,6 +59,11 @@ impl PhysicsEngine {
     }
 
     fn compute_pairwise_forces(&self) -> Result<Relation, DatabaseError> {
+        let interactions = self.compute_interaction_pairs()?;
+        self.extend_with_forces(&interactions)
+    }
+
+    fn compute_interaction_pairs(&self) -> Result<Relation, DatabaseError> {
         // 1. Cross join particles with themselves to compute pairwise forces.
         // Rename attributes to distinguish particle 1 and particle 2.
         let p1 = self.particles.rename(&[
@@ -82,12 +87,14 @@ impl PhysicsEngine {
         let pairs = p1.join(&p2)?;
 
         // 2. Filter out self-interactions (id1 == id2)
-        let interactions = pairs.restrict(|t| {
+        Ok(pairs.restrict(|t| {
             let id1 = t.get_typed::<i64>("id1").unwrap();
             let id2 = t.get_typed::<i64>("id2").unwrap();
             id1 != id2
-        });
+        }))
+    }
 
+    fn extend_with_forces(&self, interactions: &Relation) -> Result<Relation, DatabaseError> {
         // 3. Compute forces for each pair
         let g = self.g;
         interactions


### PR DESCRIPTION
🚮 Smell: `compute_pairwise_forces` in `relvar/src/experimental/physics.rs` (81 lines) and `bench_insert_with_check_constraint` in `benches/database.rs` (113 lines) were lengthy God Functions containing mixed setup, logic, and formatting operations. This harmed readability and violated the 'Three-Phase Operator' pattern.
✨ Solution: Applied the 'Three-Phase Operator' pattern to `compute_pairwise_forces` by extracting `compute_interaction_pairs` and `extend_with_forces` into separate private helper functions. In `benches/database.rs`, extracted reusable database setup logic for simple and complex check constraints into cleanly named helper functions `setup_simple_check_db` and `setup_complex_check_db`.
🧼 Benefit: Significantly flattens the execution flow and improves readability by isolating relational operations into distinct, logically bounded helpers without changing underlying behavior or performance semantics.
🛡️ Verification: Tests passed (`cargo test`). No logic changed. Checked with `cargo check`, `cargo fmt`, and `cargo clippy`.

---
*PR created automatically by Jules for task [10122173783920551964](https://jules.google.com/task/10122173783920551964) started by @madmax983*