### PR TITLE
🔒 Warden: Prevent Stack Overflow DoS in Serde Deserialization

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -9,3 +9,6 @@
 ## 2026-04-24 - [Unsafe unwrap in StorageManager]
 **Threat:** Potential panic and crash if `get_or_open_heap_file` fails to retrieve or map a file correctly, resulting in an unhandled `.unwrap()` failure.
 **Defense:** Replaced `.unwrap()` with `HashMap::entry` to ensure safe, graceful error propagation rather than crashing the system without unreachable branches.
+## 2024-06-07 - Prevent Stack Overflow DoS in Serde Deserialization
+**Threat:** Unbounded recursive types (like `Query` and `ConstraintExpression`) allow stack overflow Denial of Service attacks when parsed with depth-unlimited formats like Postcard.
+**Defense:** Added `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` to the `Box` fields of recursive enum variants to safely enforce a max recursion depth during parsing.

--- a/fix_pr.py
+++ b/fix_pr.py
@@ -1,0 +1,16 @@
+with open("pr_description.md", "r") as f:
+    lines = f.readlines()
+
+title = lines[0].strip()
+body = "".join(lines[1:]).strip()
+body = body.replace('"', '\\"').replace('\n', '\\n')
+
+with open("pr.py", "w") as f:
+    f.write(f"""
+def submit_pr():
+    print("Submitting PR with title: {title}\\n")
+    print("{body}")
+
+if __name__ == '__main__':
+    submit_pr()
+""")

--- a/pr.py
+++ b/pr.py
@@ -1,7 +1,7 @@
-import sys
-import os
 
-with open("pr_description.md") as f:
-    body = f.read()
+def submit_pr():
+    print("Submitting PR with title: 🔒 Warden: Prevent Stack Overflow DoS in Serde Deserialization\n")
+    print("🦠 Threat: Unbounded recursive types (like `Query` and `ConstraintExpression`) allow stack overflow Denial of Service attacks when parsed with depth-unlimited formats like Postcard. A maliciously crafted deep payload could crash the entire application process.\n🛡️ Defense: Added `#[serde(deserialize_with = \"crate::utils::recursion::deserialize_guarded\")]` to the `Box` fields of recursive enum variants in `Query` and `ConstraintExpression`. This enforces a hard limit of `MAX_RECURSION_DEPTH` (64) during parsing, safely rejecting overly deep payloads before a stack overflow can occur.\n💥 Severity: Critical - could cause remote crash/DoS.\n🧪 Verification: Wrote test exploits simulating deep recursive payloads via `postcard::from_bytes`. Verified that the updated code gracefully returns an error instead of aborting the process due to stack exhaustion.")
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+if __name__ == '__main__':
+    submit_pr()

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🔒 Warden: Prevent Stack Overflow DoS in Serde Deserialization
+
+🦠 Threat: Unbounded recursive types (like `Query` and `ConstraintExpression`) allow stack overflow Denial of Service attacks when parsed with depth-unlimited formats like Postcard. A maliciously crafted deep payload could crash the entire application process.
+🛡️ Defense: Added `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` to the `Box` fields of recursive enum variants in `Query` and `ConstraintExpression`. This enforces a hard limit of `MAX_RECURSION_DEPTH` (64) during parsing, safely rejecting overly deep payloads before a stack overflow can occur.
+💥 Severity: Critical - could cause remote crash/DoS.
+🧪 Verification: Wrote test exploits simulating deep recursive payloads via `postcard::from_bytes`. Verified that the updated code gracefully returns an error instead of aborting the process due to stack exhaustion.

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -102,11 +102,24 @@ pub enum ConstraintExpression {
     },
 
     /// Logical AND: both expressions must be true
-    And(Box<ConstraintExpression>, Box<ConstraintExpression>),
+    And(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
     /// Logical OR: at least one expression must be true
-    Or(Box<ConstraintExpression>, Box<ConstraintExpression>),
+    Or(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
     /// Logical NOT: inverts the expression
-    Not(Box<ConstraintExpression>),
+    Not(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
 
     /// Set membership: attribute IN (value1, value2, ...)
     In(String, std::collections::HashSet<ScalarValue>),

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -76,6 +76,7 @@ pub enum Query {
     /// relation where the `predicate` evaluates to true.
     Restrict {
         /// The input query to filter.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// The predicate condition.
         predicate: ConstraintExpression,
@@ -87,6 +88,7 @@ pub enum Query {
     /// the specified attributes.
     Project {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// The list of attribute names to keep.
         attributes: Vec<String>,
@@ -99,6 +101,7 @@ pub enum Query {
     /// self-join.
     Rename {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// Mapping of (old_name, new_name).
         mappings: Vec<(String, String)>,
@@ -111,8 +114,10 @@ pub enum Query {
     /// this becomes a Cartesian product.
     Join {
         /// The left relation.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         left: Box<Query>,
         /// The right relation.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         right: Box<Query>,
     },
 
@@ -122,6 +127,7 @@ pub enum Query {
     /// values (Sum, Count, Avg, Min, Max) for each group.
     Summarize {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// Attributes to group by.
         group_by: Vec<String>,


### PR DESCRIPTION
🦠 Threat: Unbounded recursive types (like `Query` and `ConstraintExpression`) allow stack overflow Denial of Service attacks when parsed with depth-unlimited formats like Postcard. A maliciously crafted deep payload could crash the entire application process.
🛡️ Defense: Added `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` to the `Box` fields of recursive enum variants in `Query` and `ConstraintExpression`. This enforces a hard limit of `MAX_RECURSION_DEPTH` (64) during parsing, safely rejecting overly deep payloads before a stack overflow can occur.
💥 Severity: Critical - could cause remote crash/DoS.
🧪 Verification: Wrote test exploits simulating deep recursive payloads via `postcard::from_bytes`. Verified that the updated code gracefully returns an error instead of aborting the process due to stack exhaustion.

---
*PR created automatically by Jules for task [4922979723544236661](https://jules.google.com/task/4922979723544236661) started by @madmax983*