### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -33,3 +33,6 @@
 ## 2025-05-06 - [The Ghost Knowledge Graph]
 **Confusion:** The experimental `KnowledgeGraph` module was completely undocumented, leaving users to guess how it connects to the relational model.
 **Clarification:** Wrote comprehensive module-level documentation and executable doctests for `KnowledgeGraph` and `TriplePattern` explaining the "Relational Semantic Web" concept.
+## 2025-05-20 - The "Spreadsheet" Examples
+**Confusion:** The experimental `Spreadsheet` engine had placeholder examples for the main struct and its methods (`new` and `evaluate`), making it unclear how to initialize the `values` and `formulas` relations and how to resolve the spreadsheet's formulas to a fixpoint.
+**Clarification:** Added comprehensive executable `/// # Examples` doc-tests to `Spreadsheet` and its methods, clearly demonstrating how to construct the initial state and trigger the evaluation of formulas using relational algebra operations.

--- a/pr.py
+++ b/pr.py
@@ -2,6 +2,9 @@ import sys
 import os
 
 with open("pr_description.md") as f:
-    body = f.read()
+    lines = f.readlines()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+title = lines[0].strip()
+body = "".join(lines[1:]).strip()
+
+print(f"Submitting PR with title: {title}\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,15 @@
+🎻 Bard: [documentation update]
+
+📖 Chapter: The `Spreadsheet` Module
+🔦 Insight: The experimental `Spreadsheet` engine had placeholder examples for the main struct and its methods (`new` and `evaluate`), making it unclear how to initialize the `values` and `formulas` relations and how to resolve the spreadsheet's formulas to a fixpoint. Added comprehensive executable `/// # Examples` doc-tests to `Spreadsheet` and its methods, clearly demonstrating how to construct the initial state and trigger the evaluation of formulas using relational algebra operations.
+🧪 Example: Added 3 executable doctests showing initialization and evaluation.
+🖼️ Preview:
+```rust
+let val_type = TupleType::new()
+    .with_attribute("id", ScalarType::String)
+    .with_attribute("val", ScalarType::Float);
+let mut values = Relation::new(RelationType::new(val_type));
+values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+
+let spreadsheet = Spreadsheet { values, formulas };
+```

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -9,6 +9,40 @@ use relvar_core::{
 /// Models a spreadsheet where cells can contain raw values or formulas referencing
 /// other cells. Evaluation is performed purely using relational joins and extensions
 /// until all cell values are resolved (fixpoint).
+///
+/// # Examples
+///
+/// ```
+/// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
+/// use relvar::experimental::spreadsheet::Spreadsheet;
+///
+/// // 1. Define the Values relation
+/// let val_type = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("val", ScalarType::Float);
+/// let mut values = Relation::new(RelationType::new(val_type));
+///
+/// // Cell A1 = 10.0
+/// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+///
+/// // 2. Define the Formulas relation
+/// let form_type = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("op", ScalarType::String)
+///     .with_attribute("arg1", ScalarType::String)
+///     .with_attribute("arg2", ScalarType::String);
+/// let mut formulas = Relation::new(RelationType::new(form_type));
+///
+/// // Cell B1 = A1 + A1
+/// formulas.insert(tuple! {
+///     id: "B1".to_string(),
+///     op: "ADD".to_string(),
+///     arg1: "A1".to_string(),
+///     arg2: "A1".to_string()
+/// }).unwrap();
+///
+/// let spreadsheet = Spreadsheet { values, formulas };
+/// ```
 pub struct Spreadsheet {
     /// Resolved values. Schema: `(id: String, val: Float)`
     pub values: Relation,
@@ -23,9 +57,22 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_type = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let values = Relation::new(RelationType::new(val_type));
+    ///
+    /// let form_type = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let formulas = Relation::new(RelationType::new(form_type));
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -36,9 +83,35 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_type = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_type));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let form_type = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_type));
+    ///
+    /// // B1 = A1 + A2
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(),
+    ///     op: "ADD".to_string(),
+    ///     arg1: "A1".to_string(),
+    ///     arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    ///
+    /// assert_eq!(result.cardinality(), 3);
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
📖 Chapter: The `Spreadsheet` Module
🔦 Insight: The experimental `Spreadsheet` engine had placeholder examples for the main struct and its methods (`new` and `evaluate`), making it unclear how to initialize the `values` and `formulas` relations and how to resolve the spreadsheet's formulas to a fixpoint. Added comprehensive executable `/// # Examples` doc-tests to `Spreadsheet` and its methods, clearly demonstrating how to construct the initial state and trigger the evaluation of formulas using relational algebra operations.
🧪 Example: Added 3 executable doctests showing initialization and evaluation.

---
*PR created automatically by Jules for task [12037341072902447267](https://jules.google.com/task/12037341072902447267) started by @madmax983*