### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -33,3 +33,6 @@
 ## 2025-05-06 - [The Ghost Knowledge Graph]
 **Confusion:** The experimental `KnowledgeGraph` module was completely undocumented, leaving users to guess how it connects to the relational model.
 **Clarification:** Wrote comprehensive module-level documentation and executable doctests for `KnowledgeGraph` and `TriplePattern` explaining the "Relational Semantic Web" concept.
+## 2025-06-09 - The "Spreadsheet" Examples
+**Confusion:** The experimental `Spreadsheet` module had a placeholder example for the struct and lacked executable doc-tests for its methods (`new` and `evaluate`), making it difficult to understand how to initialize values and formulas, and how spreadsheet evaluation relies on relational operations.
+**Clarification:** Added comprehensive executable `/// # Examples` doc-tests for `Spreadsheet` and its methods to clearly demonstrate how to construct the initial state and how relational joins and differences compute the final evaluated cells.

--- a/fix_pr.py
+++ b/fix_pr.py
@@ -1,0 +1,15 @@
+import sys
+import os
+
+with open("pr_description.md", "r") as f:
+    body = f.read()
+
+with open("pr.py", "w") as f:
+    f.write(f"""import sys
+import os
+
+with open("pr_description.md") as f:
+    body = f.read()
+
+print(f"Submitting PR with title: 🎻 Bard: [documentation update]\\n\\n{{body}}")
+""")

--- a/pr.py
+++ b/pr.py
@@ -4,4 +4,4 @@ import os
 with open("pr_description.md") as f:
     body = f.read()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+print(f"Submitting PR with title: 🎻 Bard: [documentation update]\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+📖 Chapter: The `Spreadsheet` module
+🔦 Insight: Clarified how the experimental spreadsheet uses relational algebra purely through joins and extensions, and provided concrete doctests showing state initialization and evaluation.
+🧪 Example: Added 3 executable doctests for `Spreadsheet`, `new`, and `evaluate`.
+🖼️ Preview: Documentation renders successfully.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -9,6 +9,29 @@ use relvar_core::{
 /// Models a spreadsheet where cells can contain raw values or formulas referencing
 /// other cells. Evaluation is performed purely using relational joins and extensions
 /// until all cell values are resolved (fixpoint).
+///
+/// # Examples
+///
+/// ```
+/// use relvar::{Relation, RelationType, ScalarType, TupleType};
+/// use relvar::experimental::spreadsheet::Spreadsheet;
+/// use relvar_core::tuple;
+///
+/// let val_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("val", ScalarType::Float);
+/// let mut values = Relation::new(RelationType::new(val_heading));
+/// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+///
+/// let form_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("op", ScalarType::String)
+///     .with_attribute("arg1", ScalarType::String)
+///     .with_attribute("arg2", ScalarType::String);
+/// let formulas = Relation::new(RelationType::new(form_heading));
+///
+/// let spreadsheet = Spreadsheet::new(values, formulas);
+/// ```
 pub struct Spreadsheet {
     /// Resolved values. Schema: `(id: String, val: Float)`
     pub values: Relation,
@@ -25,7 +48,22 @@ impl Spreadsheet {
     /// ```
     /// use relvar::{Relation, RelationType, ScalarType, TupleType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    /// use relvar_core::tuple;
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let formulas = Relation::new(RelationType::new(form_heading));
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -38,7 +76,29 @@ impl Spreadsheet {
     /// ```
     /// use relvar::{Relation, RelationType, ScalarType, TupleType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    /// use relvar_core::tuple;
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_heading));
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    ///
+    /// assert_eq!(result.cardinality(), 3); // A1, A2, and B1
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
📖 Chapter: The `Spreadsheet` module
🔦 Insight: Clarified how the experimental spreadsheet uses relational algebra purely through joins and extensions, and provided concrete doctests showing state initialization and evaluation.
🧪 Example: Added 3 executable doctests for `Spreadsheet`, `new`, and `evaluate`.
🖼️ Preview: Documentation renders successfully.

---
*PR created automatically by Jules for task [7929423101319236493](https://jules.google.com/task/7929423101319236493) started by @madmax983*