### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -132,3 +132,8 @@
 **Learning:** Missing coverage branches for specific operations involving database bulk constraints and cascading failure. `compute_relation_after_update` early exit logic via `?` unrolls some lines in `Database::update` if the logic before reaches an error state.
 
 **Action:** When adding tests for database constraints involving `update` and `delete`, ensure varying degrees of constraint violations such as duplicated primary keys after updates and violations on foreign keys mapped against parent relations to fully hit bulk checks.
+## 2025-05-22 - DML Logic Coverage
+
+**Learning:** Missing coverage branches for the pure inner modules handling DML functions `compute_relation_after_delete` and `compute_relation_after_update` within `relvar-core/src/database/dml.rs`. Specifically error paths when `updater` closures output invalid mismatched tuples, as well as the cardinality reduction behavior when an update modifies distinct tuples into identical values causing a set merge.
+
+**Action:** Whenever working on updating core database algebraic evaluation functions or testing their constraint layers, ensure comprehensive tests are placed in inner `mod tests` block specifically checking type mismatch Result failures and edge cases regarding cardinality.

--- a/pr.py
+++ b/pr.py
@@ -4,4 +4,4 @@ import os
 with open("pr_description.md") as f:
     body = f.read()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+print(f"Submitting PR with title: 🛡️ Sentry: [test coverage improvement]\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,10 @@
+🛡️ Sentry: [test coverage improvement]
+
+🎯 Target: `compute_relation_after_delete` and `compute_relation_after_update` in `relvar-core/src/database/dml.rs`.
+💣 Risk: Untested core data manipulation logic. Without coverage, changes to tuple reduction logic, type matching, or subset merging could introduce serious database inconsistencies or constraint bypasses without failing the build.
+🧪 Strategy: Added internal unit tests to verify:
+- Success paths for targeted deletes and updates.
+- Proper calculation of modified tuple counts.
+- `DatabaseError::TupleMismatch` when an updater returns a tuple that violates the schema constraints.
+- Correct set-theoretic behavior (cardinality reduction) when updating causes tuples to merge into identical entities.
+🔬 Verification: Run `cargo test -p relvar-core dml`

--- a/relvar-core/src/database/dml.rs
+++ b/relvar-core/src/database/dml.rs
@@ -69,3 +69,160 @@ where
 
     Ok((new_relation, update_count))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{RelationType, ScalarType, TupleType};
+    use crate::values::{Relation, ScalarValue, Tuple};
+    use std::collections::HashSet;
+
+    fn test_relation() -> Relation {
+        let rel_type = RelationType::new(
+            TupleType::new()
+                .with_attribute("id", ScalarType::Int)
+                .with_attribute("val", ScalarType::Int),
+        );
+        let mut body = HashSet::new();
+        let t1 = Tuple::new(
+            rel_type.tuple_type().clone(),
+            vec![
+                ("id".to_string(), ScalarValue::Int(1)),
+                ("val".to_string(), ScalarValue::Int(10)),
+            ],
+        )
+        .unwrap();
+        body.insert(t1);
+
+        let t2 = Tuple::new(
+            rel_type.tuple_type().clone(),
+            vec![
+                ("id".to_string(), ScalarValue::Int(2)),
+                ("val".to_string(), ScalarValue::Int(20)),
+            ],
+        )
+        .unwrap();
+        body.insert(t2);
+
+        let t3 = Tuple::new(
+            rel_type.tuple_type().clone(),
+            vec![
+                ("id".to_string(), ScalarValue::Int(3)),
+                ("val".to_string(), ScalarValue::Int(30)),
+            ],
+        )
+        .unwrap();
+        body.insert(t3);
+
+        Relation::from_body_unchecked(rel_type, body)
+    }
+
+    #[test]
+    fn test_compute_relation_after_delete() {
+        let rel = test_relation();
+        let (new_rel, count) = compute_relation_after_delete(rel, |t| {
+            t.get_typed::<i64>("id").unwrap() == 1 || t.get_typed::<i64>("id").unwrap() == 2
+        })
+        .unwrap();
+
+        assert_eq!(count, 2);
+        assert_eq!(new_rel.cardinality(), 1);
+
+        let remaining_tuple = new_rel.into_iter().next().unwrap();
+        assert_eq!(remaining_tuple.get_typed::<i64>("id").unwrap(), 3);
+    }
+
+    #[test]
+    fn test_compute_relation_after_delete_no_match() {
+        let rel = test_relation();
+        let (new_rel, count) =
+            compute_relation_after_delete(rel, |t| t.get_typed::<i64>("id").unwrap() == 99)
+                .unwrap();
+
+        assert_eq!(count, 0);
+        assert_eq!(new_rel.cardinality(), 3);
+    }
+
+    #[test]
+    fn test_compute_relation_after_update_success() {
+        let rel = test_relation();
+        let (new_rel, count) = compute_relation_after_update(
+            rel,
+            |t| t.get_typed::<i64>("id").unwrap() == 1 || t.get_typed::<i64>("id").unwrap() == 2,
+            |t| {
+                let mut new_t = t.clone();
+                let current_val = new_t.get_typed::<i64>("val").unwrap();
+                new_t
+                    .set("val".to_string(), ScalarValue::Int(current_val + 100))
+                    .unwrap();
+                new_t
+            },
+        )
+        .unwrap();
+
+        assert_eq!(count, 2);
+        assert_eq!(new_rel.cardinality(), 3);
+
+        // Verify updates
+        let mut ids_found = 0;
+        for t in new_rel.into_iter() {
+            let id = t.get_typed::<i64>("id").unwrap();
+            let val = t.get_typed::<i64>("val").unwrap();
+            if id == 1 {
+                assert_eq!(val, 110);
+                ids_found += 1;
+            } else if id == 2 {
+                assert_eq!(val, 120);
+                ids_found += 1;
+            } else if id == 3 {
+                assert_eq!(val, 30);
+                ids_found += 1;
+            }
+        }
+        assert_eq!(ids_found, 3);
+    }
+
+    #[test]
+    fn test_compute_relation_after_update_merge_identical_tuples() {
+        let rel = test_relation();
+        // Update tuple with id 2 to be identical to tuple with id 1
+        let (new_rel, count) = compute_relation_after_update(
+            rel,
+            |t| t.get_typed::<i64>("id").unwrap() == 2,
+            |t| {
+                let mut new_t = t.clone();
+                new_t.set("id".to_string(), ScalarValue::Int(1)).unwrap();
+                new_t.set("val".to_string(), ScalarValue::Int(10)).unwrap();
+                new_t
+            },
+        )
+        .unwrap();
+
+        assert_eq!(count, 1);
+        // Cardinality should reduce by 1 because the updated tuple merges with an existing one
+        assert_eq!(new_rel.cardinality(), 2);
+    }
+
+    #[test]
+    fn test_compute_relation_after_update_mismatch() {
+        let rel = test_relation();
+        let expected_type = rel.relation_type().tuple_type().clone();
+        let res = compute_relation_after_update(
+            rel,
+            |t| t.get_typed::<i64>("id").unwrap() == 1,
+            |_| {
+                // Manually create a tuple with wrong type that bypasses the normal setter checks
+                // just to test compute_relation_after_update's check
+                crate::values::Tuple::new_unchecked(
+                    expected_type.clone().into(),
+                    std::collections::BTreeMap::from([
+                        ("id".to_string(), ScalarValue::Int(1)),
+                        ("val".to_string(), ScalarValue::Float(100.0)),
+                    ]),
+                )
+            },
+        );
+
+        assert!(matches!(res, Err(DatabaseError::TupleMismatch)));
+    }
+}


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target: `compute_relation_after_delete` and `compute_relation_after_update` in `relvar-core/src/database/dml.rs`.
💣 Risk: Untested core data manipulation logic. Without coverage, changes to tuple reduction logic, type matching, or subset merging could introduce serious database inconsistencies or constraint bypasses without failing the build.
🧪 Strategy: Added internal unit tests to verify:
- Success paths for targeted deletes and updates.
- Proper calculation of modified tuple counts.
- `DatabaseError::TupleMismatch` when an updater returns a tuple that violates the schema constraints.
- Correct set-theoretic behavior (cardinality reduction) when updating causes tuples to merge into identical entities.
🔬 Verification: Run `cargo test -p relvar-core dml`

---
*PR created automatically by Jules for task [8204236336815217681](https://jules.google.com/task/8204236336815217681) started by @madmax983*