### PR TITLE
⚡ Bolt: Remove RelationType allocation in DML Update

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,6 @@
 ## 2024-05-20 - String Allocations in Iterators
 **Learning:** `rename_into` previously consumed a tuple's BTreeMap entirely to scalar values by calling `.into_values()`. However, BTreeMaps also implement `into_iter()` which yields owned `(K, V)` pairs. We were discarding the `K` (the original String key) and creating a brand new String key for every column of every tuple, even if the rename mapping didn't touch it.
 **Action:** Always check if we can reuse the owned strings from an input collection instead of reflexively throwing them away and re-allocating them in an iterator pipeline.
+## 2025-05-24 - [Remove RelationType allocation in DML Update]
+**Learning:** When consuming a `Relation` to process its tuples during operations like DML updates, calling `.relation_type().clone()` to keep the type information before calling `.into_iter()` introduces an unnecessary heap allocation because `RelationType` internally manages an `Arc` that gets cloned.
+**Action:** Use `into_parts(self) -> (RelationType, HashSet<Tuple>)` on `Relation` to deconstruct it into its components. This safely extracts both the `RelationType` and the body by value without performing any heap allocations or reference count increments.

--- a/relvar-core/src/database/dml.rs
+++ b/relvar-core/src/database/dml.rs
@@ -36,11 +36,11 @@ where
     F: Fn(&Tuple) -> bool,
     U: Fn(&Tuple) -> Tuple,
 {
-    let relation_type = current_relation.relation_type().clone();
-    let expected_type = relation_type.tuple_type(); // Borrow instead of cloning Arc<TupleType>
     let initial_cardinality = current_relation.cardinality();
+    let (relation_type, body) = current_relation.into_parts();
+    let expected_type = relation_type.tuple_type(); // Borrow instead of cloning Arc<TupleType>
 
-    let (body, update_count) = current_relation.into_iter().try_fold(
+    let (body, update_count) = body.into_iter().try_fold(
         (
             std::collections::HashSet::with_capacity(initial_cardinality),
             0,

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -633,6 +633,12 @@ impl Relation {
         self.body.is_empty()
     }
 
+    /// Deconstructs the `Relation` into its underlying `RelationType` and `HashSet<Tuple>`,
+    /// avoiding allocations that would be required to clone the `RelationType`.
+    pub fn into_parts(self) -> (RelationType, std::collections::HashSet<Tuple>) {
+        (self.relation_type, self.body)
+    }
+
     /// Restricts this relation by filtering tuples in-place.
     ///
     /// This consumes the relation and modifies it, avoiding allocations for a new relation


### PR DESCRIPTION
Added `into_parts()` to `Relation` and used it in `compute_relation_after_update` in `dml.rs` to replace `.relation_type().clone()` when consuming the relation. Consuming a `Relation` to process its tuples during operations like DML updates and calling `.relation_type().clone()` to keep the type information before calling `.into_iter()` introduces an unnecessary heap allocation and atomic reference count increment because `RelationType` internally manages an `Arc` that gets cloned. Reduces one heap allocation per updated tuple set during DML.

---
*PR created automatically by Jules for task [4126683002760129192](https://jules.google.com/task/4126683002760129192) started by @madmax983*