### PR TITLE
⚒️ Forge: Refactor Spreadsheet Evaluation God Function

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,7 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+
+## 2026-05-20 - Extract God Function in Spreadsheet Evaluation
+**Learning:** The `evaluate` function in `relvar/src/experimental/spreadsheet.rs` was an overly long "God Function" that grouped multiple relational logic phases together: finding unresolved formulas, resolving arguments, and mathematically evaluating the operations inside a fixpoint loop.
+**Action:** Applied the 'Three-Phase Operator' pattern, breaking out unresolved formulas calculation, joining arguments, and mathematically evaluating formulas into focused, descriptive helper functions.

--- a/pr.py
+++ b/pr.py
@@ -2,6 +2,9 @@ import sys
 import os
 
 with open("pr_description.md") as f:
-    body = f.read()
+    lines = f.readlines()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+title = lines[0].strip()
+body = "".join(lines[1:]).strip()
+
+print(f"Submitting PR with title: {title}\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+⚒️ Forge: Refactor Spreadsheet Evaluation God Function
+
+🚮 Smell: The `evaluate` method inside `relvar/src/experimental/spreadsheet.rs` was an overly long "God Function" (66 lines) that combined filtering unresolved formulas, joining arguments, mathematically evaluating the resolved results, and managing the fixpoint loop in a single block.
+✨ Solution: Applied the 'Three-Phase Operator' pattern by extracting the inner workings of the loop into three cleanly typed private helper functions: `get_unresolved_formulas`, `resolve_arguments`, and `evaluate_formulas`.
+🧼 Benefit: Flattens the main evaluation loop, reducing cognitive load and dramatically improving code readability by abstracting the relational steps into descriptively named helpers.
+🛡️ Verification: Tests passed (`cargo test --package relvar spreadsheet`). No logic changed.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -46,55 +46,11 @@ impl Spreadsheet {
         loop {
             let initial_count = current_values.cardinality();
 
-            // Find unresolved formulas by antijoining/difference with resolved values
-            // We only want formulas whose 'id' is NOT yet in current_values
-            let resolved_ids = current_values.project(&["id"]);
-            let formula_ids = self.formulas.project(&["id"]);
+            let unresolved_formulas = self.get_unresolved_formulas(&current_values)?;
+            let fully_resolved_args =
+                self.resolve_arguments(&unresolved_formulas, &current_values)?;
+            let new_values = self.evaluate_formulas(&fully_resolved_args)?;
 
-            let unresolved_ids = formula_ids
-                .difference(&resolved_ids)
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            let unresolved_formulas = self.formulas.join(&unresolved_ids)?;
-
-            // Rename current_values for arg1
-            let values_arg1 = current_values.rename(&[("id", "arg1"), ("val", "val1")]);
-            // Rename current_values for arg2
-            let values_arg2 = current_values.rename(&[("id", "arg2"), ("val", "val2")]);
-
-            // Join unresolved formulas with arg1 values
-            let with_arg1 = unresolved_formulas.join(&values_arg1)?;
-            // Join with arg2 values
-            let fully_resolved_args = with_arg1.join(&values_arg2)?;
-
-            // Evaluate the formula
-            let evaluated = fully_resolved_args
-                .extend("val", ScalarType::Float, |t| {
-                    let op = t.get_typed::<String>("op").unwrap();
-                    let val1 = t.get_typed::<f64>("val1").unwrap();
-                    let val2 = t.get_typed::<f64>("val2").unwrap();
-
-                    let result = match op.as_str() {
-                        "ADD" => val1 + val2,
-                        "SUB" => val1 - val2,
-                        "MUL" => val1 * val2,
-                        "DIV" => {
-                            if val2 != 0.0 {
-                                val1 / val2
-                            } else {
-                                f64::NAN
-                            }
-                        }
-                        _ => f64::NAN,
-                    };
-                    ScalarValue::Float(result)
-                })
-                .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-            // Project back to (id, val)
-            let new_values = evaluated.project(&["id", "val"]);
-
-            // Union with current values
             current_values = current_values
                 .union(&new_values)
                 .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
@@ -105,6 +61,59 @@ impl Spreadsheet {
         }
 
         Ok(current_values)
+    }
+
+    fn get_unresolved_formulas(
+        &self,
+        current_values: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        let resolved_ids = current_values.project(&["id"]);
+        let formula_ids = self.formulas.project(&["id"]);
+
+        let unresolved_ids = formula_ids
+            .difference(&resolved_ids)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        self.formulas.join(&unresolved_ids)
+    }
+
+    fn resolve_arguments(
+        &self,
+        unresolved_formulas: &Relation,
+        current_values: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        let values_arg1 = current_values.rename(&[("id", "arg1"), ("val", "val1")]);
+        let values_arg2 = current_values.rename(&[("id", "arg2"), ("val", "val2")]);
+
+        let with_arg1 = unresolved_formulas.join(&values_arg1)?;
+        with_arg1.join(&values_arg2)
+    }
+
+    fn evaluate_formulas(&self, fully_resolved_args: &Relation) -> Result<Relation, DatabaseError> {
+        let evaluated = fully_resolved_args
+            .extend("val", ScalarType::Float, |t| {
+                let op = t.get_typed::<String>("op").unwrap();
+                let val1 = t.get_typed::<f64>("val1").unwrap();
+                let val2 = t.get_typed::<f64>("val2").unwrap();
+
+                let result = match op.as_str() {
+                    "ADD" => val1 + val2,
+                    "SUB" => val1 - val2,
+                    "MUL" => val1 * val2,
+                    "DIV" => {
+                        if val2 != 0.0 {
+                            val1 / val2
+                        } else {
+                            f64::NAN
+                        }
+                    }
+                    _ => f64::NAN,
+                };
+                ScalarValue::Float(result)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+        Ok(evaluated.project(&["id", "val"]))
     }
 }
 


### PR DESCRIPTION
🚮 Smell: The `evaluate` method inside `relvar/src/experimental/spreadsheet.rs` was an overly long "God Function" (66 lines) that combined filtering unresolved formulas, joining arguments, mathematically evaluating the resolved results, and managing the fixpoint loop in a single block.
✨ Solution: Applied the 'Three-Phase Operator' pattern by extracting the inner workings of the loop into three cleanly typed private helper functions: `get_unresolved_formulas`, `resolve_arguments`, and `evaluate_formulas`.
🧼 Benefit: Flattens the main evaluation loop, reducing cognitive load and dramatically improving code readability by abstracting the relational steps into descriptively named helpers.
🛡️ Verification: Tests passed (`cargo test --package relvar spreadsheet`). No logic changed.

---
*PR created automatically by Jules for task [4642530710943613603](https://jules.google.com/task/4642530710943613603) started by @madmax983*