### PR TITLE
⚒️ Forge: Refactor compute_pairwise_forces

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,7 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+
+## 2024-06-11 - Extract God Function in Physics compute_pairwise_forces
+**Learning:** The `compute_pairwise_forces` function in `relvar/src/experimental/physics.rs` embedded complex distance and force math directly within `.extend()` closures, leading to massive duplication and decreased readability.
+**Action:** Extracted the repetitive mathematical logic into a dedicated private helper function `compute_force_component` that takes a `&Tuple`, flattening the main function and drastically improving readability without altering logic.

--- a/plan.md
+++ b/plan.md
@@ -1,2 +1,47 @@
-1. **Submit the clean audit report.**
-   - Since no active vulnerabilities were found during the investigation of `unsafe` blocks, bounds checking, buffer limits, and data serialization (verifying that they either safely bounded or properly capped), I will submit the PR to confirm the codebase is secure under the given scope.
+1. **Refactor `compute_pairwise_forces` in `relvar/src/experimental/physics.rs`:**
+   - The `compute_pairwise_forces` function is currently 81 lines long. It performs three main tasks: cross-joining the particles, filtering self-interactions, and calculating the forces for each pair in x and y components.
+   - The force calculation logic for `fx` and `fy` is largely duplicated in the two `.extend()` calls.
+   - I will apply the "Three-Phase Operator" pattern to extract logic out into well-named private helper functions.
+   - I'll create a `calculate_pairwise_force_component` helper function to handle the core logic of calculating a specific force component, which can be called by `extend`. Wait, since `.extend` takes a closure, maybe it's better to just extract the creation of the interactions relation into a helper and the force calculation into another. Or I can extract the closure logic into a helper method `calculate_force_component(t: &Tuple, g: f64, is_x: bool) -> ScalarValue`.
+   - Actually, a simpler way is:
+     ```rust
+     fn cross_join_particles(&self) -> Result<Relation, DatabaseError>
+     fn calculate_forces(&self, interactions: Relation) -> Result<Relation, DatabaseError>
+     ```
+     But `compute_pairwise_forces` *is* calculating forces.
+     Let's look at `calculate_pairwise_force_component` or `compute_force_component`:
+     ```rust
+     fn compute_force_component(t: &Tuple, g: f64, component: &str) -> ScalarValue {
+         let x1 = t.get_typed::<f64>("x1").unwrap();
+         // ...
+         let dx = x2 - x1;
+         let dy = y2 - y1;
+         let dist_sq = dx * dx + dy * dy;
+         if dist_sq < 1e-10 { return ScalarValue::Float(0.0); }
+         let dist = dist_sq.sqrt();
+         let f = g * m1 * m2 / dist_sq;
+         if component == "x" {
+             ScalarValue::Float(f * (dx / dist))
+         } else {
+             ScalarValue::Float(f * (dy / dist))
+         }
+     }
+     ```
+   - Let's read `compute_pairwise_forces` again to see what is best.
+   - Wait, `compute_pairwise_forces` has 3 distinct steps: 1) Cross join, 2) Filter self-interactions, 3) Compute forces.
+   - Let's extract:
+     1. `generate_particle_pairs(&self) -> Result<Relation, DatabaseError>`
+     2. `compute_force_component(t: &Tuple, g: f64, is_x: bool) -> ScalarValue`
+   - Actually, `compute_force_component` takes `&Tuple` directly, resolving the "God Function" issue as mentioned in the memories for `relvar-core/src/experimental/...`.
+   - The Forge journal states: `Avoid embedding complex mathematical or logical operations directly within .extend() closures in relvar and relvar-core. Refactor these 'God Functions' by extracting the logic into well-named private helper functions that take a &Tuple argument to improve readability and flatten structure.`
+
+2. **Add a journal entry to `.jules/forge.md`:**
+   - I'll document that I extracted the force calculation from `compute_pairwise_forces` using a helper function taking a `&Tuple` to avoid large inline `.extend()` closures.
+
+3. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done:**
+   - Run `cargo fmt --all`
+   - Run `cargo clippy --all-targets --all-features -- -D warnings`
+   - Run `cargo test`
+
+4. **Submit the PR:**
+   - Create `pr_description.md` and run `pr.py` via `run_in_bash_session`.

--- a/pr.py
+++ b/pr.py
@@ -2,6 +2,9 @@ import sys
 import os
 
 with open("pr_description.md") as f:
-    body = f.read()
+    lines = f.readlines()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+title = lines[0].strip()
+body = "".join(lines[1:]).strip()
+
+print(f"Submitting PR with title: {title}\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,5 @@
+⚒️ Forge: Refactor compute_pairwise_forces
+🚮 Smell: `compute_pairwise_forces` was 81 lines long with duplicated math inline.
+✨ Solution: Extracted `generate_particle_pairs` and `compute_force_component` helper functions.
+🧼 Benefit: Reduces cognitive load, flattens closures, increases clarity.
+🛡️ Verification: Tests passed. No logic changed.

--- a/relvar/src/experimental/physics.rs
+++ b/relvar/src/experimental/physics.rs
@@ -10,7 +10,7 @@ use relvar_core::{
     algebra::Aggregation,
     error::DatabaseError,
     types::ScalarType,
-    values::{Relation, ScalarValue},
+    values::{Relation, ScalarValue, Tuple},
 };
 
 /// A relational N-Body Physics Simulation.
@@ -59,6 +59,22 @@ impl PhysicsEngine {
     }
 
     fn compute_pairwise_forces(&self) -> Result<Relation, DatabaseError> {
+        let interactions = self.generate_particle_pairs()?;
+
+        // 3. Compute forces for each pair
+        let g = self.g;
+        interactions
+            .extend("fx", ScalarType::Float, move |t| {
+                Self::compute_force_component(t, g, true)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
+            .extend("fy", ScalarType::Float, move |t| {
+                Self::compute_force_component(t, g, false)
+            })
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
+
+    fn generate_particle_pairs(&self) -> Result<Relation, DatabaseError> {
         // 1. Cross join particles with themselves to compute pairwise forces.
         // Rename attributes to distinguish particle 1 and particle 2.
         let p1 = self.particles.rename(&[
@@ -82,62 +98,38 @@ impl PhysicsEngine {
         let pairs = p1.join(&p2)?;
 
         // 2. Filter out self-interactions (id1 == id2)
-        let interactions = pairs.restrict(|t| {
+        Ok(pairs.restrict(|t| {
             let id1 = t.get_typed::<i64>("id1").unwrap();
             let id2 = t.get_typed::<i64>("id2").unwrap();
             id1 != id2
-        });
+        }))
+    }
 
-        // 3. Compute forces for each pair
-        let g = self.g;
-        interactions
-            .extend("fx", ScalarType::Float, move |t| {
-                let x1 = t.get_typed::<f64>("x1").unwrap();
-                let y1 = t.get_typed::<f64>("y1").unwrap();
-                let x2 = t.get_typed::<f64>("x2").unwrap();
-                let y2 = t.get_typed::<f64>("y2").unwrap();
-                let m1 = t.get_typed::<f64>("m1").unwrap();
-                let m2 = t.get_typed::<f64>("m2").unwrap();
+    fn compute_force_component(t: &Tuple, g: f64, is_x: bool) -> ScalarValue {
+        let x1 = t.get_typed::<f64>("x1").unwrap();
+        let y1 = t.get_typed::<f64>("y1").unwrap();
+        let x2 = t.get_typed::<f64>("x2").unwrap();
+        let y2 = t.get_typed::<f64>("y2").unwrap();
+        let m1 = t.get_typed::<f64>("m1").unwrap();
+        let m2 = t.get_typed::<f64>("m2").unwrap();
 
-                let dx = x2 - x1;
-                let dy = y2 - y1;
-                let dist_sq = dx * dx + dy * dy;
+        let dx = x2 - x1;
+        let dy = y2 - y1;
+        let dist_sq = dx * dx + dy * dy;
 
-                // Avoid division by zero
-                if dist_sq < 1e-10 {
-                    return ScalarValue::Float(0.0);
-                }
+        // Avoid division by zero
+        if dist_sq < 1e-10 {
+            return ScalarValue::Float(0.0);
+        }
 
-                let dist = dist_sq.sqrt();
-                let f = g * m1 * m2 / dist_sq;
-                let fx = f * (dx / dist);
+        let dist = dist_sq.sqrt();
+        let f = g * m1 * m2 / dist_sq;
 
-                ScalarValue::Float(fx)
-            })
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
-            .extend("fy", ScalarType::Float, move |t| {
-                let x1 = t.get_typed::<f64>("x1").unwrap();
-                let y1 = t.get_typed::<f64>("y1").unwrap();
-                let x2 = t.get_typed::<f64>("x2").unwrap();
-                let y2 = t.get_typed::<f64>("y2").unwrap();
-                let m1 = t.get_typed::<f64>("m1").unwrap();
-                let m2 = t.get_typed::<f64>("m2").unwrap();
-
-                let dx = x2 - x1;
-                let dy = y2 - y1;
-                let dist_sq = dx * dx + dy * dy;
-
-                if dist_sq < 1e-10 {
-                    return ScalarValue::Float(0.0);
-                }
-
-                let dist = dist_sq.sqrt();
-                let f = g * m1 * m2 / dist_sq;
-                let fy = f * (dy / dist);
-
-                ScalarValue::Float(fy)
-            })
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+        if is_x {
+            ScalarValue::Float(f * (dx / dist))
+        } else {
+            ScalarValue::Float(f * (dy / dist))
+        }
     }
 
     fn summarize_net_forces(&self, with_forces: &Relation) -> Result<Relation, DatabaseError> {


### PR DESCRIPTION
🚮 Smell: `compute_pairwise_forces` was 81 lines long with duplicated math inline.
✨ Solution: Extracted `generate_particle_pairs` and `compute_force_component` helper functions.
🧼 Benefit: Reduces cognitive load, flattens closures, increases clarity.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [5132373463956497117](https://jules.google.com/task/5132373463956497117) started by @madmax983*