### PR TITLE
🔒 Warden: [security fix]

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -9,3 +9,7 @@
 ## 2026-04-24 - [Unsafe unwrap in StorageManager]
 **Threat:** Potential panic and crash if `get_or_open_heap_file` fails to retrieve or map a file correctly, resulting in an unhandled `.unwrap()` failure.
 **Defense:** Replaced `.unwrap()` with `HashMap::entry` to ensure safe, graceful error propagation rather than crashing the system without unreachable branches.
+
+## 2026-04-25 - [Prevent DoS in AST Deserialization]
+**Threat:** Stack overflow Denial of Service (DoS) vulnerability via deeply nested recursive types (`Query` and `ConstraintExpression` ASTs) when deserialized by unbounded parsers like `postcard`.
+**Defense:** Added `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` directly to recursive `Box` fields to enforce a maximum recursion depth and safely return an error instead of crashing.

--- a/pr.py
+++ b/pr.py
@@ -1,7 +1,25 @@
 import sys
-import os
+import argparse
 
-with open("pr_description.md") as f:
-    body = f.read()
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--title", required=False)
+    parser.add_argument("--body-file", required=False)
+    args = parser.parse_args()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+    if args.title and args.body_file:
+        with open(args.body_file, 'r') as f:
+            body = f.read()
+        print(f"Submitting PR with title: {args.title}\n\n{body}")
+    else:
+        try:
+            with open("pr_description.md", 'r') as f:
+                lines = f.readlines()
+            title = lines[0].strip()
+            body = "".join(lines[1:]).strip()
+            print(f"Submitting PR with title: {title}\n\n{body}")
+        except Exception as e:
+            print(f"Failed to submit: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🔒 Warden: [security fix]
+
+🦠 Threat: Stack overflow Denial of Service (DoS) vulnerability. Deeply nested recursive AST elements (such as `Query` and `ConstraintExpression`) were being deserialized by `postcard` without any default depth limit, which allowed an attacker to craft deeply nested tree structures to crash the program by exhausting stack space.
+🛡️ Defense: Applied `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` directly to the recursive `Box` fields for both the `Query` and `ConstraintExpression` enums. This correctly enforces the `MAX_RECURSION_DEPTH` check during deserialization, securely returning an error instead of causing a stack overflow panic.
+💥 Severity: High - Unauthenticated crash via DoS.
+🧪 Verification: Created `test_query_recursion` and `test_constraint_recursion` that generate inputs exceeding the recursion limit, and assert that deserialization gracefully returns a `Result::Err` instead of crashing.

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -102,11 +102,24 @@ pub enum ConstraintExpression {
     },
 
     /// Logical AND: both expressions must be true
-    And(Box<ConstraintExpression>, Box<ConstraintExpression>),
+    And(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
     /// Logical OR: at least one expression must be true
-    Or(Box<ConstraintExpression>, Box<ConstraintExpression>),
+    Or(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
     /// Logical NOT: inverts the expression
-    Not(Box<ConstraintExpression>),
+    Not(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
 
     /// Set membership: attribute IN (value1, value2, ...)
     In(String, std::collections::HashSet<ScalarValue>),

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -76,6 +76,7 @@ pub enum Query {
     /// relation where the `predicate` evaluates to true.
     Restrict {
         /// The input query to filter.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// The predicate condition.
         predicate: ConstraintExpression,
@@ -87,6 +88,7 @@ pub enum Query {
     /// the specified attributes.
     Project {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// The list of attribute names to keep.
         attributes: Vec<String>,
@@ -99,6 +101,7 @@ pub enum Query {
     /// self-join.
     Rename {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// Mapping of (old_name, new_name).
         mappings: Vec<(String, String)>,
@@ -111,8 +114,10 @@ pub enum Query {
     /// this becomes a Cartesian product.
     Join {
         /// The left relation.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         left: Box<Query>,
         /// The right relation.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         right: Box<Query>,
     },
 
@@ -122,6 +127,7 @@ pub enum Query {
     /// values (Sum, Count, Avg, Min, Max) for each group.
     Summarize {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// Attributes to group by.
         group_by: Vec<String>,

--- a/relvar-core/src/query/tests/mod.rs
+++ b/relvar-core/src/query/tests/mod.rs
@@ -1,2 +1,4 @@
 pub mod basic;
 pub mod common;
+pub mod test_recursion;
+pub mod test_recursion_constraint;

--- a/relvar-core/src/query/tests/test_recursion.rs
+++ b/relvar-core/src/query/tests/test_recursion.rs
@@ -1,0 +1,26 @@
+use crate::query::Query;
+use crate::{CmpOp, ConstraintExpression, ScalarValue, ValueOrRef};
+
+#[test]
+fn test_query_recursion() {
+    let mut query = Query::Scan("A".to_string());
+    for _ in 0..100 {
+        // Exceeds MAX_RECURSION_DEPTH of 64
+        query = Query::Restrict {
+            input: Box::new(query),
+            predicate: ConstraintExpression::Cmp {
+                left: "A".to_string(),
+                op: CmpOp::Eq,
+                right: ValueOrRef::Value(ScalarValue::Int(1)),
+            },
+        };
+    }
+
+    let bytes = postcard::to_stdvec(&query).unwrap();
+    let result: Result<Query, _> = postcard::from_bytes(&bytes);
+
+    assert!(
+        result.is_err(),
+        "Deserialization should fail due to recursion limit"
+    );
+}

--- a/relvar-core/src/query/tests/test_recursion_constraint.rs
+++ b/relvar-core/src/query/tests/test_recursion_constraint.rs
@@ -1,0 +1,22 @@
+use crate::{CmpOp, ConstraintExpression, ScalarValue, ValueOrRef};
+
+#[test]
+fn test_constraint_recursion() {
+    let mut expr = ConstraintExpression::Cmp {
+        left: "A".to_string(),
+        op: CmpOp::Eq,
+        right: ValueOrRef::Value(ScalarValue::Int(1)),
+    };
+    for _ in 0..100 {
+        // Exceeds MAX_RECURSION_DEPTH of 64
+        expr = ConstraintExpression::Not(Box::new(expr));
+    }
+
+    let bytes = postcard::to_stdvec(&expr).unwrap();
+    let result: Result<ConstraintExpression, _> = postcard::from_bytes(&bytes);
+
+    assert!(
+        result.is_err(),
+        "Deserialization should fail due to recursion limit"
+    );
+}

--- a/run_pr.py
+++ b/run_pr.py
@@ -1,0 +1,16 @@
+import subprocess
+
+def main():
+    with open('pr_description.md', 'r') as f:
+        lines = f.readlines()
+
+    title = lines[0].strip()
+    description = "".join(lines[1:]).strip()
+
+    with open('temp_pr_body.md', 'w') as f:
+        f.write(description)
+
+    subprocess.run(['python3', 'pr.py', '--title', title, '--body-file', 'temp_pr_body.md'])
+
+if __name__ == "__main__":
+    main()

--- a/temp_pr_body.md
+++ b/temp_pr_body.md
@@ -1,0 +1,4 @@
+🦠 Threat: Stack overflow Denial of Service (DoS) vulnerability. Deeply nested recursive AST elements (such as `Query` and `ConstraintExpression`) were being deserialized by `postcard` without any default depth limit, which allowed an attacker to craft deeply nested tree structures to crash the program by exhausting stack space.
+🛡️ Defense: Applied `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` directly to the recursive `Box` fields for both the `Query` and `ConstraintExpression` enums. This correctly enforces the `MAX_RECURSION_DEPTH` check during deserialization, securely returning an error instead of causing a stack overflow panic.
+💥 Severity: High - Unauthenticated crash via DoS.
+🧪 Verification: Created `test_query_recursion` and `test_constraint_recursion` that generate inputs exceeding the recursion limit, and assert that deserialization gracefully returns a `Result::Err` instead of crashing.


### PR DESCRIPTION
🦠 Threat: Stack overflow Denial of Service (DoS) vulnerability. Deeply nested recursive AST elements (such as `Query` and `ConstraintExpression`) were being deserialized by `postcard` without any default depth limit, which allowed an attacker to craft deeply nested tree structures to crash the program by exhausting stack space.
🛡️ Defense: Applied `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` directly to the recursive `Box` fields for both the `Query` and `ConstraintExpression` enums. This correctly enforces the `MAX_RECURSION_DEPTH` check during deserialization, securely returning an error instead of causing a stack overflow panic.
💥 Severity: High - Unauthenticated crash via DoS.
🧪 Verification: Created `test_query_recursion` and `test_constraint_recursion` that generate inputs exceeding the recursion limit, and assert that deserialization gracefully returns a `Result::Err` instead of crashing.

---
*PR created automatically by Jules for task [14714975645009059917](https://jules.google.com/task/14714975645009059917) started by @madmax983*