### PR TITLE
🔒 Warden: Fix Stack Overflow DoS in Serde Deserialization

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -9,3 +9,6 @@
 ## 2026-04-24 - [Unsafe unwrap in StorageManager]
 **Threat:** Potential panic and crash if `get_or_open_heap_file` fails to retrieve or map a file correctly, resulting in an unhandled `.unwrap()` failure.
 **Defense:** Replaced `.unwrap()` with `HashMap::entry` to ensure safe, graceful error propagation rather than crashing the system without unreachable branches.
+## 2025-02-15 - Serde Recursion Guard for ASTs
+**Threat:** The `Query` and `ConstraintExpression` enums are recursive and use `postcard` for deserialization without a depth limit, which enables DoS attacks via stack overflows.
+**Defense:** Created intermediate unchecked enums (`QueryUnchecked` and `ConstraintExpressionUnchecked`) and applied `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` to their `Box`ed fields. Mapped them to the actual ASTs via `#[serde(try_from = "QueryUnchecked")]` and `#[serde(try_from = "ConstraintExpressionUnchecked")]`.

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -90,6 +90,7 @@ pub enum CmpOp {
 /// - **Set membership**: In
 /// - **Pattern matching**: Like
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(try_from = "ConstraintExpressionUnchecked")]
 pub enum ConstraintExpression {
     /// Comparison: left_attr op right_value_or_ref
     Cmp {
@@ -139,6 +140,59 @@ pub enum ConstraintExpression {
     /// assert!(!case_expr.evaluate(&tuple! { code: "abc" }).unwrap());
     /// ```
     Like(String, String),
+}
+
+#[derive(Deserialize)]
+enum ConstraintExpressionUnchecked {
+    Cmp {
+        left: String,
+        op: CmpOp,
+        right: ValueOrRef,
+    },
+    And(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpressionUnchecked>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpressionUnchecked>,
+    ),
+    Or(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpressionUnchecked>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpressionUnchecked>,
+    ),
+    Not(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpressionUnchecked>,
+    ),
+    In(String, std::collections::HashSet<ScalarValue>),
+    Like(String, String),
+}
+
+impl TryFrom<ConstraintExpressionUnchecked> for ConstraintExpression {
+    type Error = String;
+
+    fn try_from(unchecked: ConstraintExpressionUnchecked) -> Result<Self, Self::Error> {
+        let e = match unchecked {
+            ConstraintExpressionUnchecked::Cmp { left, op, right } => {
+                ConstraintExpression::Cmp { left, op, right }
+            }
+            ConstraintExpressionUnchecked::And(l, r) => ConstraintExpression::And(
+                Box::new(ConstraintExpression::try_from(*l)?),
+                Box::new(ConstraintExpression::try_from(*r)?),
+            ),
+            ConstraintExpressionUnchecked::Or(l, r) => ConstraintExpression::Or(
+                Box::new(ConstraintExpression::try_from(*l)?),
+                Box::new(ConstraintExpression::try_from(*r)?),
+            ),
+            ConstraintExpressionUnchecked::Not(inner) => {
+                ConstraintExpression::Not(Box::new(ConstraintExpression::try_from(*inner)?))
+            }
+            ConstraintExpressionUnchecked::In(s, set) => ConstraintExpression::In(s, set),
+            ConstraintExpressionUnchecked::Like(s1, s2) => ConstraintExpression::Like(s1, s2),
+        };
+        Ok(e)
+    }
 }
 
 impl ConstraintExpression {

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -63,6 +63,7 @@ use thiserror::Error;
 /// let q = Query::scan("users");
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "QueryUnchecked")]
 pub enum Query {
     /// Scan a relation variable (base table).
     ///
@@ -128,6 +129,74 @@ pub enum Query {
         /// Aggregations to perform.
         aggregations: Vec<Aggregation>,
     },
+}
+
+#[derive(Deserialize)]
+enum QueryUnchecked {
+    Scan(String),
+    Restrict {
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        input: Box<QueryUnchecked>,
+        predicate: ConstraintExpression,
+    },
+    Project {
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        input: Box<QueryUnchecked>,
+        attributes: Vec<String>,
+    },
+    Rename {
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        input: Box<QueryUnchecked>,
+        mappings: Vec<(String, String)>,
+    },
+    Join {
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        left: Box<QueryUnchecked>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        right: Box<QueryUnchecked>,
+    },
+    Summarize {
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        input: Box<QueryUnchecked>,
+        group_by: Vec<String>,
+        aggregations: Vec<Aggregation>,
+    },
+}
+
+impl TryFrom<QueryUnchecked> for Query {
+    type Error = String;
+
+    fn try_from(unchecked: QueryUnchecked) -> Result<Self, Self::Error> {
+        let q = match unchecked {
+            QueryUnchecked::Scan(s) => Query::Scan(s),
+            QueryUnchecked::Restrict { input, predicate } => Query::Restrict {
+                input: Box::new(Query::try_from(*input)?),
+                predicate,
+            },
+            QueryUnchecked::Project { input, attributes } => Query::Project {
+                input: Box::new(Query::try_from(*input)?),
+                attributes,
+            },
+            QueryUnchecked::Rename { input, mappings } => Query::Rename {
+                input: Box::new(Query::try_from(*input)?),
+                mappings,
+            },
+            QueryUnchecked::Join { left, right } => Query::Join {
+                left: Box::new(Query::try_from(*left)?),
+                right: Box::new(Query::try_from(*right)?),
+            },
+            QueryUnchecked::Summarize {
+                input,
+                group_by,
+                aggregations,
+            } => Query::Summarize {
+                input: Box::new(Query::try_from(*input)?),
+                group_by,
+                aggregations,
+            },
+        };
+        Ok(q)
+    }
 }
 
 /// Errors that can occur during query execution.

--- a/relvar-core/tests/warden_exploit_serde_stack_overflow.rs
+++ b/relvar-core/tests/warden_exploit_serde_stack_overflow.rs
@@ -35,3 +35,34 @@ fn test_serde_depth_check() {
         }
     }
 }
+
+use relvar_core::constraints::ConstraintExpression;
+use relvar_core::query::Query;
+
+#[test]
+fn test_query_recursion_dos() {
+    let mut query = Query::Scan("test".to_string());
+    for _ in 0..100 {
+        query = Query::Restrict {
+            input: Box::new(query),
+            predicate: ConstraintExpression::Not(Box::new(ConstraintExpression::Like(
+                "a".to_string(),
+                "b".to_string(),
+            ))),
+        };
+    }
+    let data = postcard::to_allocvec(&query).unwrap();
+    let decoded: Result<Query, _> = postcard::from_bytes(&data);
+    assert!(decoded.is_err());
+}
+
+#[test]
+fn test_constraint_expression_recursion_dos() {
+    let mut expr = ConstraintExpression::Like("a".to_string(), "b".to_string());
+    for _ in 0..100 {
+        expr = ConstraintExpression::Not(Box::new(expr));
+    }
+    let data = postcard::to_allocvec(&expr).unwrap();
+    let decoded: Result<ConstraintExpression, _> = postcard::from_bytes(&data);
+    assert!(decoded.is_err());
+}


### PR DESCRIPTION
🔒 Warden: Fix Stack Overflow DoS in Serde Deserialization

🦠 **Threat**: The `Query` and `ConstraintExpression` AST enums use unbounded recursive references (`Box<Query>` and `Box<ConstraintExpression>`). Since we deserialize these from network and disk using `postcard` (which has no default recursion depth limit unlike `serde_json`), an attacker could craft an artificially deep tree payload that exhausts the process stack during deserialization, resulting in a Denial of Service (DoS) crash.

🛡️ **Defense**: Created intermediate unchecked struct enums (`QueryUnchecked` and `ConstraintExpressionUnchecked`) and decorated all recursive `Box` fields with `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]`. Applied `#[serde(try_from = "QueryUnchecked")]` and `#[serde(try_from = "ConstraintExpressionUnchecked")]` to map them safely to the fully typed enums, thus ensuring recursion is guarded safely at parsing time before stack overflow can occur. 

💥 **Severity**: High - Could crash the server via malicious payload.

🧪 **Verification**: Appended `test_query_recursion_dos` and `test_constraint_expression_recursion_dos` to the existing `warden_exploit_serde_stack_overflow.rs` to verify the exploit safely errors out rather than crashing. Ran cargo check, test, and clippy to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [14108009567981862558](https://jules.google.com/task/14108009567981862558) started by @madmax983*