### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -132,3 +132,7 @@
 **Learning:** Missing coverage branches for specific operations involving database bulk constraints and cascading failure. `compute_relation_after_update` early exit logic via `?` unrolls some lines in `Database::update` if the logic before reaches an error state.
 
 **Action:** When adding tests for database constraints involving `update` and `delete`, ensure varying degrees of constraint violations such as duplicated primary keys after updates and violations on foreign keys mapped against parent relations to fully hit bulk checks.
+
+## 2024-06-13 - [Database Integrity Error Paths Coverage]
+**Learning:** Found uncovered error branches in `Database::delete` (foreign key violations), `Database::update` (type and check constraints), and `Database::create_relvar` (virtual relvar naming conflict) because error paths are often neglected during standard API usage tests.
+**Action:** Always create dedicated integration tests focusing purely on triggering specific error scenarios to ensure full branch coverage of validation logic.

--- a/pr.py
+++ b/pr.py
@@ -1,7 +1,7 @@
 import sys
-import os
+import subprocess
 
-with open("pr_description.md") as f:
-    body = f.read()
+title = '🛡️ Sentry: [test coverage improvement]'
+body = '🎯 Target: `Database::delete`, `Database::update`, `Database::create_relvar` error paths.\n💣 Risk: Missing test coverage for error conditions like foreign key violation during delete, type constraint and check constraint violations during update, and naming conflict when creating a virtual relvar. This lack of coverage creates a risk where regression in constraint validation might go unnoticed.\n🧪 Strategy: Added integration tests `test_delete_foreign_key_violation`, `test_update_check_constraint_violation`, `test_update_type_constraint_violation`, and `test_create_relvar_virtual_exists` to comprehensively verify these error scenarios.\n🔬 Verification: Run `cargo test --manifest-path relvar-core/Cargo.toml --test sentry_database_missing_coverage` to verify the tests.'
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+subprocess.run(["git", "commit", "-am", f"{title}\n\n{body}"])

--- a/relvar-core/tests/sentry_database_missing_coverage.rs
+++ b/relvar-core/tests/sentry_database_missing_coverage.rs
@@ -1,0 +1,123 @@
+#[cfg(test)]
+mod tests {
+    use relvar_core::constraints::{
+        AttributeConstraints, CheckConstraint, CheckConstraints, CmpOp, ConstraintExpression,
+        ForeignKey, ForeignKeyConstraints, KeyConstraints, PrimaryKey, TypeConstraint, ValueOrRef,
+    };
+    use relvar_core::database::Database;
+    use relvar_core::storage_engine::InMemoryEngine;
+    use relvar_core::tuple;
+    use relvar_core::types::{RelationType, ScalarType, TupleType};
+    use relvar_core::values::ScalarValue;
+
+    #[test]
+    fn test_delete_foreign_key_violation() {
+        let mut db = Database::new(InMemoryEngine::new());
+        let dept_type =
+            RelationType::new(TupleType::new().with_attribute("dept_id", ScalarType::Int));
+        let emp_type =
+            RelationType::new(TupleType::new().with_attribute("dept_id", ScalarType::Int));
+
+        db.create_relvar("DEPT", dept_type).unwrap();
+        db.create_relvar("EMP", emp_type).unwrap();
+
+        db.set_key_constraints(
+            "DEPT",
+            KeyConstraints::new()
+                .with_primary_key(PrimaryKey::new(vec!["dept_id".to_string()]).unwrap()),
+        )
+        .unwrap();
+
+        let fk = ForeignKey::new(
+            vec!["dept_id".to_string()],
+            "DEPT".to_string(),
+            vec!["dept_id".to_string()],
+        )
+        .unwrap();
+        db.set_foreign_key_constraints("EMP", ForeignKeyConstraints::new().with_foreign_key(fk))
+            .unwrap();
+
+        db.insert("DEPT", tuple! { dept_id: 1i64 }).unwrap();
+        db.insert("EMP", tuple! { dept_id: 1i64 }).unwrap();
+
+        // This should fail because EMP references DEPT
+        let res = db.delete("DEPT", |t| t.get_typed::<i64>("dept_id").unwrap() == 1);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_update_check_constraint_violation() {
+        let mut db = Database::new(InMemoryEngine::new());
+        let rel_type = RelationType::new(TupleType::new().with_attribute("age", ScalarType::Int));
+        db.create_relvar("PEOPLE", rel_type).unwrap();
+
+        let constraints = CheckConstraints::new().with_constraint(CheckConstraint::new(
+            "valid_age",
+            "Age must be non-negative",
+            ConstraintExpression::Cmp {
+                left: "age".to_string(),
+                op: CmpOp::Gt,
+                right: ValueOrRef::Value(ScalarValue::Int(-1)),
+            },
+        ));
+
+        db.set_check_constraints("PEOPLE", constraints).unwrap();
+
+        db.insert("PEOPLE", tuple! { age: 10i64 }).unwrap();
+
+        let res = db.update(
+            "PEOPLE",
+            |t| t.get_typed::<i64>("age").unwrap() == 10,
+            |_| {
+                tuple! { age: -5i64 }
+            },
+        );
+
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_update_type_constraint_violation() {
+        let mut db = Database::new(InMemoryEngine::new());
+        let rel_type = RelationType::new(TupleType::new().with_attribute("count", ScalarType::Int));
+        db.create_relvar("TEST", rel_type).unwrap();
+
+        let attr_constraints = AttributeConstraints::new("count".to_string(), ScalarType::Int)
+            .with_constraint(TypeConstraint::Range {
+                min: ScalarValue::Int(1),
+                max: ScalarValue::Int(100),
+            });
+
+        db.set_type_constraints("TEST", "count", attr_constraints)
+            .unwrap();
+
+        db.insert("TEST", tuple! { count: 50i64 }).unwrap();
+
+        let res = db.update(
+            "TEST",
+            |t| t.get_typed::<i64>("count").unwrap() == 50,
+            |_| {
+                tuple! { count: 150i64 }
+            },
+        );
+
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_create_relvar_virtual_exists() {
+        let mut db = Database::new(InMemoryEngine::new());
+        let rel_type = RelationType::new(TupleType::new().with_attribute("id", ScalarType::Int));
+
+        db.define_virtual_relvar("MY_VIEW", rel_type.clone(), |_| {
+            Ok(relvar_core::values::Relation::new(
+                relvar_core::types::RelationType::new(relvar_core::types::TupleType::new()),
+            ))
+        })
+        .unwrap();
+
+        // Should fail because a virtual relvar with this name already exists
+        let res = db.create_relvar("MY_VIEW", rel_type);
+        assert!(res.is_err());
+    }
+}


### PR DESCRIPTION
🎯 Target: `Database::delete`, `Database::update`, `Database::create_relvar` error paths.
💣 Risk: Missing test coverage for error conditions like foreign key violation during delete, type constraint and check constraint violations during update, and naming conflict when creating a virtual relvar. This lack of coverage creates a risk where regression in constraint validation might go unnoticed.
🧪 Strategy: Added integration tests `test_delete_foreign_key_violation`, `test_update_check_constraint_violation`, `test_update_type_constraint_violation`, and `test_create_relvar_virtual_exists` to comprehensively verify these error scenarios.
🔬 Verification: Run `cargo test --manifest-path relvar-core/Cargo.toml --test sentry_database_missing_coverage` to verify the tests.

---
*PR created automatically by Jules for task [17328280070288382095](https://jules.google.com/task/17328280070288382095) started by @madmax983*