### PR TITLE
⚡ Bolt: Use into_parts to avoid relation type cloning during DML updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,6 @@
 ## 2024-05-20 - String Allocations in Iterators
 **Learning:** `rename_into` previously consumed a tuple's BTreeMap entirely to scalar values by calling `.into_values()`. However, BTreeMaps also implement `into_iter()` which yields owned `(K, V)` pairs. We were discarding the `K` (the original String key) and creating a brand new String key for every column of every tuple, even if the rename mapping didn't touch it.
 **Action:** Always check if we can reuse the owned strings from an input collection instead of reflexively throwing them away and re-allocating them in an iterator pipeline.
+## 2025-05-18 - Avoid RelationType Cloning via Deconstruction
+**Learning:** DML update iteration in `relvar-core` unnecessarily clones `RelationType` to capture it, creating repeated heap allocations (`Arc` clones). Attempting to replace references or clones deeply embedded in algebra operations often causes lifetime conflicts, but consuming the outer struct safely bypasses this.
+**Action:** Implemented `Relation::into_parts(self) -> (RelationType, HashSet<Tuple>)` to dismantle the relation by value. This allows the inner fields to be owned without `relation_type.clone()`, providing a cleaner, zero-cost memory optimization in hot DML loops.

--- a/pr.py
+++ b/pr.py
@@ -1,7 +1,9 @@
 import sys
 import os
 
-with open("pr_description.md") as f:
-    body = f.read()
+print(f"""Submitting PR with title: ⚡ Bolt: Use into_parts to avoid relation type cloning during DML updates
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+💡 What: Added `into_parts()` to `Relation` and utilized it in DML updates.
+🎯 Why: DML update iteration was unnecessarily cloning the `RelationType` to capture it, creating heap allocations (specifically Arc clones within relation_type.clone()) on each update operation.
+📊 Impact: Removes `RelationType` cloning during `UPDATE`s by deconstructing the existing `Relation` via `into_parts`, optimizing memory usage inside hot DML loops without lifetime headaches.
+🔬 Measurement: Verify tests run fine using `cargo test` and `cargo bench --bench database`.""")

--- a/relvar-core/src/database/dml.rs
+++ b/relvar-core/src/database/dml.rs
@@ -36,11 +36,11 @@ where
     F: Fn(&Tuple) -> bool,
     U: Fn(&Tuple) -> Tuple,
 {
-    let relation_type = current_relation.relation_type().clone();
-    let expected_type = relation_type.tuple_type(); // Borrow instead of cloning Arc<TupleType>
     let initial_cardinality = current_relation.cardinality();
+    let (relation_type, old_body) = current_relation.into_parts();
+    let expected_type = relation_type.tuple_type();
 
-    let (body, update_count) = current_relation.into_iter().try_fold(
+    let (body, update_count) = old_body.into_iter().try_fold(
         (
             std::collections::HashSet::with_capacity(initial_cardinality),
             0,

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -164,6 +164,27 @@ impl IntoIterator for Relation {
 }
 
 impl Relation {
+    /// Consumes the relation, returning its underlying type and body (tuples).
+    ///
+    /// This prevents unnecessary heap allocations by avoiding the need to
+    /// clone the `RelationType` when breaking apart a relation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use relvar_core::types::{RelationType, TupleType, ScalarType};
+    /// use relvar_core::values::Relation;
+    ///
+    /// let heading = TupleType::new().with_attribute("id", ScalarType::Int);
+    /// let relation = Relation::new(RelationType::new(heading));
+    ///
+    /// let (rel_type, tuples) = relation.into_parts();
+    /// assert!(tuples.is_empty());
+    /// ```
+    pub fn into_parts(self) -> (RelationType, HashSet<Tuple>) {
+        (self.relation_type, self.body)
+    }
+
     /// Creates a new empty relation with the given type.
     ///
     /// The relation starts with zero tuples but has a defined structure


### PR DESCRIPTION
💡 What: Added `into_parts()` to `Relation` and utilized it in DML updates.
🎯 Why: DML update iteration was unnecessarily cloning the `RelationType` to capture it, creating heap allocations (specifically Arc clones within relation_type.clone()) on each update operation.
📊 Impact: Removes `RelationType` cloning during `UPDATE`s by deconstructing the existing `Relation` via `into_parts`, optimizing memory usage inside hot DML loops without lifetime headaches.
🔬 Measurement: Verify tests run fine using `cargo test` and `cargo bench --bench database`.

---
*PR created automatically by Jules for task [5131418722518382121](https://jules.google.com/task/5131418722518382121) started by @madmax983*