### PR TITLE
🔒 Warden: [security fix] Add recursion guards to ASTs to prevent stack overflow DoS

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -9,3 +9,6 @@
 ## 2026-04-24 - [Unsafe unwrap in StorageManager]
 **Threat:** Potential panic and crash if `get_or_open_heap_file` fails to retrieve or map a file correctly, resulting in an unhandled `.unwrap()` failure.
 **Defense:** Replaced `.unwrap()` with `HashMap::entry` to ensure safe, graceful error propagation rather than crashing the system without unreachable branches.
+## 2024-06-13 - [Denial of Service via Unbounded Recursion]
+**Threat:** Stack overflow Denial of Service (DoS) vulnerability triggered by malicious actors submitting deeply nested `Query` or `ConstraintExpression` AST structures. `postcard` has no default recursion depth limits, meaning deserialization of deep inputs directly overflows the call stack, crashing the server process.
+**Defense:** Applied `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` to the recursive `Box` fields in both `Query` and `ConstraintExpression` enums.

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -102,11 +102,24 @@ pub enum ConstraintExpression {
     },
 
     /// Logical AND: both expressions must be true
-    And(Box<ConstraintExpression>, Box<ConstraintExpression>),
+    And(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
     /// Logical OR: at least one expression must be true
-    Or(Box<ConstraintExpression>, Box<ConstraintExpression>),
+    Or(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
     /// Logical NOT: inverts the expression
-    Not(Box<ConstraintExpression>),
+    Not(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
 
     /// Set membership: attribute IN (value1, value2, ...)
     In(String, std::collections::HashSet<ScalarValue>),
@@ -936,5 +949,38 @@ mod like_tests {
         let result = expr.evaluate(&tuple);
         assert!(result.is_err());
         assert!(matches!(result, Err(ExpressionError::TypeMismatch(_, _))));
+    }
+}
+
+#[cfg(test)]
+mod recursion_tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_constraint_expression_deserialization_depth_limit() {
+        let mut q = ConstraintExpression::Not(Box::new(ConstraintExpression::In(
+            "test".to_string(),
+            HashSet::new(),
+        )));
+        for _ in 0..100 {
+            q = ConstraintExpression::Not(Box::new(q));
+        }
+
+        // Serialize with postcard
+        let bytes = postcard::to_stdvec(&q).unwrap();
+
+        // Deserialize
+        std::mem::forget(q); // Prevent Drop stack overflow
+        let result: Result<ConstraintExpression, _> = postcard::from_bytes(&bytes);
+
+        assert!(
+            result.is_err(),
+            "Deserialization should fail due to recursion limit"
+        );
+
+        if let Ok(q2) = result {
+            std::mem::forget(q2); // Should not reach here, but prevent Drop if it does
+        }
     }
 }

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -76,6 +76,7 @@ pub enum Query {
     /// relation where the `predicate` evaluates to true.
     Restrict {
         /// The input query to filter.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// The predicate condition.
         predicate: ConstraintExpression,
@@ -87,6 +88,7 @@ pub enum Query {
     /// the specified attributes.
     Project {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// The list of attribute names to keep.
         attributes: Vec<String>,
@@ -99,6 +101,7 @@ pub enum Query {
     /// self-join.
     Rename {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// Mapping of (old_name, new_name).
         mappings: Vec<(String, String)>,
@@ -111,8 +114,10 @@ pub enum Query {
     /// this becomes a Cartesian product.
     Join {
         /// The left relation.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         left: Box<Query>,
         /// The right relation.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         right: Box<Query>,
     },
 
@@ -122,6 +127,7 @@ pub enum Query {
     /// values (Sum, Count, Avg, Min, Max) for each group.
     Summarize {
         /// The input query.
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
         input: Box<Query>,
         /// Attributes to group by.
         group_by: Vec<String>,

--- a/relvar-core/src/query/tests/basic.rs
+++ b/relvar-core/src/query/tests/basic.rs
@@ -110,3 +110,30 @@ fn test_query_error_propagation() {
     let err = q_bad_sum.execute(&db);
     assert!(matches!(err, Err(QueryError::Algebra(_))));
 }
+
+#[test]
+fn test_query_deserialization_depth_limit() {
+    let mut q = Query::Scan("test".to_string());
+    for _ in 0..100 {
+        q = Query::Project {
+            input: Box::new(q),
+            attributes: vec!["a".to_string()],
+        };
+    }
+
+    // Serialize with postcard
+    let bytes = postcard::to_stdvec(&q).unwrap();
+
+    // Deserialize
+    std::mem::forget(q); // Prevent Drop stack overflow
+    let result: Result<Query, _> = postcard::from_bytes(&bytes);
+
+    assert!(
+        result.is_err(),
+        "Deserialization should fail due to recursion limit"
+    );
+
+    if let Ok(q2) = result {
+        std::mem::forget(q2); // Should not reach here, but prevent Drop if it does
+    }
+}

--- a/relvar-core/src/utils/mod.rs
+++ b/relvar-core/src/utils/mod.rs
@@ -2,6 +2,6 @@
 //!
 //! This module contains helper components that do not inherently belong to relational
 //! logic but are used across the codebase, such as memory bounds checking or recursion limits.
-pub(crate) mod recursion;
+pub mod recursion;
 
 pub use recursion::RecursionGuard;


### PR DESCRIPTION
🦠 **Threat:** Stack overflow Denial of Service (DoS) vulnerability triggered by malicious actors submitting deeply nested `Query` or `ConstraintExpression` AST structures. `postcard` has no default recursion depth limits, meaning deserialization of deep inputs directly overflows the call stack, crashing the server process.
🛡️ **Defense:** Applied `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` to the recursive `Box` fields in both `Query` and `ConstraintExpression` enums. Exported `recursion` module to be publicly accessible inside `relvar-core`.
💥 **Severity:** Critical - could crash the server with small payloads.
🧪 **Verification:** Added tests that create a deeply nested payload and attempt to deserialize it, verifying that it now gracefully returns an error (Deserialization failed due to recursion limit) rather than causing a stack overflow.

---
*PR created automatically by Jules for task [16806984254305822628](https://jules.google.com/task/16806984254305822628) started by @madmax983*