### PR TITLE
🪒 Razor: Eliminate Factory Factory in MockRelation Builder

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -21,3 +21,8 @@
 **Bloat:** Single-variant enum `RelationError` in `relvar-core/src/values/relation.rs` acting as a unit struct, with an unused variant `DuplicateTuple` and only one used variant `TypeMismatch`.
 **Cut:** Converted to unit struct `pub struct RelationError;` with `#[error("Tuple does not conform to relation type")]` directly. Removed the unused `DuplicateTuple` variant.
 **Saved:** Unnecessary enum matching, simplified error handling code significantly.
+
+## [Reduction]
+**Bloat:** The `MockRelation` builder pattern in `relvar/src/experimental/mock.rs`.
+**Cut:** Replaced the stateful builder struct with a single `generate()` function on a unit struct.
+**Saved:** Boilerplate builder setup and chaining, making the code much more direct.

--- a/plan.md
+++ b/plan.md
@@ -1,2 +1,0 @@
-1. **Submit the clean audit report.**
-   - Since no active vulnerabilities were found during the investigation of `unsafe` blocks, bounds checking, buffer limits, and data serialization (verifying that they either safely bounded or properly capped), I will submit the PR to confirm the codebase is secure under the given scope.

--- a/pr.py
+++ b/pr.py
@@ -1,7 +1,9 @@
 import sys
-import os
 
 with open("pr_description.md") as f:
-    body = f.read()
+    lines = f.readlines()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+title = lines[0].strip()
+body = "".join(lines[1:]).strip()
+
+print(f"Submitting PR with title: {title}\n\n{body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,12 @@
+🪒 Razor: Eliminate Factory Factory in MockRelation Builder
+💡 **The Spark:**
+The `MockRelation` builder pattern in `relvar/src/experimental/mock.rs` is a classic "Factory Factory". It forces developers to instantiate a builder, configure it via chained methods (`count()`, `seed()`), and then call `generate()`.
+
+🚀 **The Feature:**
+Refactored `MockRelation` from a stateful builder struct into a stateless unit struct with a direct `generate()` function. This eliminates the unnecessary intermediate struct and provides a cleaner, functional API.
+
+🔮 **The Potential:**
+Simpler mock data generation code throughout the test suite.
+
+⚠️ **Risk:**
+None, this is a local refactoring in an experimental module. Tests pass perfectly.

--- a/relvar/src/experimental/mock.rs
+++ b/relvar/src/experimental/mock.rs
@@ -19,10 +19,7 @@
 //! );
 //!
 //! // 2. Generate random data
-//! let relation = MockRelation::new(rel_type)
-//!     .count(100)       // Generate 100 tuples
-//!     .seed(42)         // Use fixed seed for deterministic results
-//!     .generate();
+//! let relation = MockRelation::generate(rel_type, 100, Some(42));
 //!
 //! assert_eq!(relation.cardinality(), 100);
 //! ```
@@ -47,84 +44,46 @@ use std::collections::BTreeMap;
 ///         .with_attribute("name", ScalarType::String)
 /// );
 ///
-/// let relation = MockRelation::new(rel_type)
-///     .count(10)
-///     .seed(42)
-///     .generate();
+/// let relation = MockRelation::generate(rel_type, 10, Some(42));
 ///
 /// assert_eq!(relation.cardinality(), 10);
 /// ```
-pub struct MockRelation {
-    relation_type: RelationType,
-    count: usize,
-    seed: Option<u64>,
-}
+pub struct MockRelation;
 
 impl MockRelation {
-    /// Create a new MockRelation builder for the given relation type.
+    /// Generate a relation with random data.
+    ///
+    /// # Arguments
+    ///
+    /// * `relation_type` - The schema of the relation to generate.
+    /// * `count` - The number of tuples to generate. Duplicate tuples may reduce the final cardinality.
+    /// * `seed` - An optional random seed for deterministic generation.
+    ///
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
     /// use relvar::experimental::mock::MockRelation;
-    /// // Note: This is a placeholder example
-    /// ```
-    pub fn new(relation_type: RelationType) -> Self {
-        Self {
-            relation_type,
-            count: 0,
-            seed: None,
-        }
-    }
-
-    /// Set the number of tuples to generate.
+    /// use relvar_core::types::{RelationType, TupleType, ScalarType};
     ///
-    /// Note: Since relations are sets, duplicate tuples will be ignored.
-    /// If the random generation produces duplicates, the final cardinality
-    /// might be less than `count`.
-    /// # Examples
+    /// let rel_type = RelationType::new(
+    ///     TupleType::new()
+    ///         .with_attribute("id", ScalarType::Int)
+    ///         .with_attribute("name", ScalarType::String)
+    /// );
     ///
+    /// let relation = MockRelation::generate(rel_type, 10, Some(42));
+    /// assert_eq!(relation.cardinality(), 10);
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
-    /// use relvar::experimental::mock::MockRelation;
-    /// // Note: This is a placeholder example
-    /// ```
-    pub fn count(mut self, count: usize) -> Self {
-        self.count = count;
-        self
-    }
-
-    /// Set the random seed for deterministic generation.
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
-    /// use relvar::experimental::mock::MockRelation;
-    /// // Note: This is a placeholder example
-    /// ```
-    pub fn seed(mut self, seed: u64) -> Self {
-        self.seed = Some(seed);
-        self
-    }
-
-    /// Generate the relation.
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
-    /// use relvar::experimental::mock::MockRelation;
-    /// // Note: This is a placeholder example
-    /// ```
-    pub fn generate(self) -> Relation {
-        let mut relation = Relation::new(self.relation_type.clone());
-        let mut rng = if let Some(seed) = self.seed {
+    pub fn generate(relation_type: RelationType, count: usize, seed: Option<u64>) -> Relation {
+        let mut relation = Relation::new(relation_type.clone());
+        let mut rng = if let Some(seed) = seed {
             StdRng::seed_from_u64(seed)
         } else {
             StdRng::from_rng(&mut rand::rng())
         };
 
-        for _ in 0..self.count {
-            if let Some(tuple) = self.generate_tuple(&mut rng) {
+        for _ in 0..count {
+            if let Some(tuple) = Self::generate_tuple(&relation_type, &mut rng) {
                 let _ = relation.insert(tuple);
             }
         }
@@ -132,19 +91,19 @@ impl MockRelation {
         relation
     }
 
-    fn generate_tuple(&self, rng: &mut StdRng) -> Option<Tuple> {
+    fn generate_tuple(relation_type: &RelationType, rng: &mut StdRng) -> Option<Tuple> {
         let mut values = BTreeMap::new();
 
-        for attr_name in self.relation_type.heading().attribute_names() {
-            let scalar_type = self.relation_type.heading().get_attribute_type(attr_name)?;
-            let value = self.generate_value(scalar_type, rng);
+        for attr_name in relation_type.heading().attribute_names() {
+            let scalar_type = relation_type.heading().get_attribute_type(attr_name)?;
+            let value = Self::generate_value(scalar_type, rng);
             values.insert(attr_name.clone(), value);
         }
 
-        Tuple::new(self.relation_type.heading().clone(), values).ok()
+        Tuple::new(relation_type.heading().clone(), values).ok()
     }
 
-    fn generate_value(&self, scalar_type: &ScalarType, rng: &mut StdRng) -> ScalarValue {
+    fn generate_value(scalar_type: &ScalarType, rng: &mut StdRng) -> ScalarValue {
         match scalar_type {
             ScalarType::Int => ScalarValue::Int(rng.random()),
             ScalarType::Float => ScalarValue::Float(rng.random()),
@@ -168,7 +127,7 @@ impl MockRelation {
             }
             ScalarType::UserDefined { representation, .. } => {
                 // Recursively generate value for the representation
-                let inner_value = self.generate_value(representation, rng);
+                let inner_value = Self::generate_value(representation, rng);
                 ScalarValue::UserDefined {
                     type_def: scalar_type.clone(),
                     value: Box::new(inner_value),
@@ -177,6 +136,7 @@ impl MockRelation {
         }
     }
 }
+
 
 #[cfg(test)]
 mod tests {
@@ -192,10 +152,7 @@ mod tests {
                 .with_attribute("active", ScalarType::Bool),
         );
 
-        let relation = MockRelation::new(rel_type)
-            .count(50)
-            .seed(12345) // Deterministic
-            .generate();
+        let relation = MockRelation::generate(rel_type, 50, Some(12345));
 
         assert_eq!(relation.cardinality(), 50);
         assert_eq!(relation.degree(), 3);
@@ -222,7 +179,7 @@ mod tests {
                 .with_attribute("user_val", user_defined_type),
         );
 
-        let relation = MockRelation::new(rel_type).count(10).seed(42).generate();
+        let relation = MockRelation::generate(rel_type, 10, Some(42));
 
         assert_eq!(relation.degree(), 7);
         assert_eq!(relation.cardinality(), 10);
@@ -232,12 +189,9 @@ mod tests {
     fn test_determinism() {
         let rel_type = RelationType::new(TupleType::new().with_attribute("val", ScalarType::Float));
 
-        let rel1 = MockRelation::new(rel_type.clone())
-            .count(10)
-            .seed(42)
-            .generate();
+        let rel1 = MockRelation::generate(rel_type.clone(), 10, Some(42));
 
-        let rel2 = MockRelation::new(rel_type).count(10).seed(42).generate();
+        let rel2 = MockRelation::generate(rel_type, 10, Some(42));
 
         assert_eq!(rel1, rel2);
     }


### PR DESCRIPTION
💡 **The Spark:**
The `MockRelation` builder pattern in `relvar/src/experimental/mock.rs` is a classic "Factory Factory". It forces developers to instantiate a builder, configure it via chained methods (`count()`, `seed()`), and then call `generate()`.

🚀 **The Feature:**
Refactored `MockRelation` from a stateful builder struct into a stateless unit struct with a direct `generate()` function. This eliminates the unnecessary intermediate struct and provides a cleaner, functional API.

🔮 **The Potential:**
Simpler mock data generation code throughout the test suite. 

⚠️ **Risk:**
None, this is a local refactoring in an experimental module. Tests pass perfectly.

---
*PR created automatically by Jules for task [8591890566220200363](https://jules.google.com/task/8591890566220200363) started by @madmax983*