### PR TITLE
⚡ Bolt: Replace Vec<String> with Vec<&str> in join and semijoin common attributes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,6 @@
 ## 2024-05-20 - String Allocations in Iterators
 **Learning:** `rename_into` previously consumed a tuple's BTreeMap entirely to scalar values by calling `.into_values()`. However, BTreeMaps also implement `into_iter()` which yields owned `(K, V)` pairs. We were discarding the `K` (the original String key) and creating a brand new String key for every column of every tuple, even if the rename mapping didn't touch it.
 **Action:** Always check if we can reuse the owned strings from an input collection instead of reflexively throwing them away and re-allocating them in an iterator pipeline.
+## $(date +%Y-%m-%d) - [Avoid .cloned().collect() into Vec<String> for common attributes]
+**Learning:** When finding common attributes between two relation headings, `filter(...).cloned().collect::<Vec<String>>()` unnecessarily clones the strings into a new vector. Since the strings are owned by the `TupleType` and their lifetime covers the execution of the operation, we can map to `&str` references to eliminate string heap allocations per join operation.
+**Action:** Change `compute_common_attributes` to map `&String` to `&str` and return `Vec<&str>`, propagating this to `JoinKey` and internal helpers.

--- a/relvar-core/src/algebra/join.rs
+++ b/relvar-core/src/algebra/join.rs
@@ -262,12 +262,12 @@ impl Relation {
 }
 
 /// Helper to compute common attributes between two relations.
-fn compute_common_attributes(left: &Relation, right: &Relation) -> Vec<String> {
+fn compute_common_attributes<'a>(left: &'a Relation, right: &Relation) -> Vec<&'a str> {
     left.relation_type()
         .heading()
         .attribute_names()
         .filter(|attr| right.relation_type().heading().has_attribute(attr))
-        .cloned()
+        .map(|s| s.as_str())
         .collect()
 }
 
@@ -336,7 +336,7 @@ fn probe_and_combine_single<'a>(
 #[derive(Debug, Eq)]
 struct JoinKey<'t, 'a> {
     tuple: &'t Tuple,
-    attributes: &'a [String],
+    attributes: &'a [&'a str],
 }
 
 impl<'t, 'a> PartialEq for JoinKey<'t, 'a> {
@@ -345,7 +345,7 @@ impl<'t, 'a> PartialEq for JoinKey<'t, 'a> {
         // with the same common_attrs slice.
         for (i, attr) in self.attributes.iter().enumerate() {
             let v1 = self.tuple.get(attr);
-            let v2 = other.tuple.get(&other.attributes[i]);
+            let v2 = other.tuple.get(other.attributes[i]);
             if v1 != v2 {
                 return false;
             }
@@ -367,7 +367,7 @@ impl<'t, 'a> Hash for JoinKey<'t, 'a> {
 /// Helper to build the hash map for the join operation (Build Phase).
 fn build_join_map<'t, 'a>(
     build_rel: &'t Relation,
-    common_attrs: &'a [String],
+    common_attrs: &'a [&'a str],
 ) -> Result<HashMap<JoinKey<'t, 'a>, Vec<&'t Tuple>>, DatabaseError> {
     let mut build_map: HashMap<JoinKey<'t, 'a>, Vec<&Tuple>> =
         HashMap::with_capacity(build_rel.cardinality());
@@ -386,7 +386,7 @@ fn build_join_map<'t, 'a>(
 fn probe_and_combine<'t, 'a>(
     probe_rel: &'t Relation,
     build_map: &HashMap<JoinKey<'t, 'a>, Vec<&'t Tuple>>,
-    common_attrs: &'a [String],
+    common_attrs: &'a [&'a str],
     result_heading: &Arc<TupleType>,
 ) -> Result<HashSet<Tuple>, DatabaseError> {
     // Optimization: Pre-allocate a `HashSet` instead of a `Vec` to accumulate tuples.
@@ -426,7 +426,7 @@ fn determine_hash_join_sides<'a>(
 fn perform_hash_join(
     build_rel: &Relation,
     probe_rel: &Relation,
-    common_attrs: &[String],
+    common_attrs: &[&str],
     result_heading: &Arc<TupleType>,
 ) -> Result<HashSet<Tuple>, DatabaseError> {
     if common_attrs.len() == 1 {

--- a/relvar-core/src/algebra/semijoin.rs
+++ b/relvar-core/src/algebra/semijoin.rs
@@ -23,7 +23,7 @@ use std::hash::{Hash, Hasher};
 #[derive(Debug, Eq)]
 struct SemijoinKey<'t, 'a> {
     tuple: &'t Tuple,
-    attributes: &'a [String],
+    attributes: &'a [&'a str],
 }
 
 impl<'t, 'a> PartialEq for SemijoinKey<'t, 'a> {
@@ -32,7 +32,7 @@ impl<'t, 'a> PartialEq for SemijoinKey<'t, 'a> {
         // with the same common_attrs slice.
         for (i, attr) in self.attributes.iter().enumerate() {
             let v1 = self.tuple.get(attr);
-            let v2 = other.tuple.get(&other.attributes[i]);
+            let v2 = other.tuple.get(other.attributes[i]);
             if v1 != v2 {
                 return false;
             }
@@ -52,12 +52,12 @@ impl<'t, 'a> Hash for SemijoinKey<'t, 'a> {
 }
 
 /// Finds common attribute names between two relations' headings.
-fn common_attributes(a: &Relation, b: &Relation) -> Vec<String> {
+fn common_attributes<'a>(a: &'a Relation, b: &Relation) -> Vec<&'a str> {
     a.relation_type()
         .heading()
         .attribute_names()
         .filter(|attr| b.relation_type().heading().has_attribute(attr))
-        .cloned()
+        .map(|s| s.as_str())
         .collect()
 }
 
@@ -216,7 +216,14 @@ impl Relation {
     /// assert_eq!(result.cardinality(), 1); // Only emp 1 matches
     /// ```
     pub fn semijoin_into(self, other: &Relation) -> Self {
-        let common_attrs = common_attributes(&self, other);
+        // Clone the relation type to avoid borrowing self while filtering in-place
+        let self_rel_type = self.relation_type().clone();
+        let common_attrs: Vec<&str> = self_rel_type
+            .heading()
+            .attribute_names()
+            .filter(|attr| other.relation_type().heading().has_attribute(attr))
+            .map(|s| s.as_str())
+            .collect();
 
         // If no common attributes, we have a degenerate case (Cartesian product projection)
         if common_attrs.is_empty() {
@@ -440,7 +447,14 @@ impl Relation {
     /// assert_eq!(result.cardinality(), 1); // Bob (id 2) has no role
     /// ```
     pub fn semidifference_into(self, other: &Relation) -> Self {
-        let common_attrs = common_attributes(&self, other);
+        // Clone the relation type to avoid borrowing self while filtering in-place
+        let self_rel_type = self.relation_type().clone();
+        let common_attrs: Vec<&str> = self_rel_type
+            .heading()
+            .attribute_names()
+            .filter(|attr| other.relation_type().heading().has_attribute(attr))
+            .map(|s| s.as_str())
+            .collect();
 
         // Degenerate case handling
         if common_attrs.is_empty() {
@@ -1046,7 +1060,7 @@ mod tests {
         use std::hash::Hash;
 
         let t1 = tuple! { a: 1i64 };
-        let attributes = vec!["a".to_string(), "b".to_string()];
+        let attributes = vec!["a", "b"];
 
         let key1 = super::SemijoinKey {
             tuple: &t1,

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -235,7 +235,7 @@ impl Query {
                     .iter()
                     .map(|(a, b)| (a.as_str(), b.as_str()))
                     .collect();
-                Ok(relation.rename(&mappings_ref))
+                Ok(relation.rename_into(&mappings_ref))
             }
             Query::Join { left, right } => {
                 let left_rel = left.execute(db)?;


### PR DESCRIPTION
⚡ Bolt: Replace Vec<String> with Vec<&str> in join and semijoin common attributes

💡 **What:** Changed `compute_common_attributes` and `common_attributes` to return `Vec<&str>` instead of `Vec<String>`. Updated internal structures like `JoinKey` and `SemijoinKey` to use `&[&str]`.
🎯 **Why:** To eliminate the redundant heap allocations caused by `.cloned().collect::<Vec<String>>()` during join and semijoin operations. We can simply borrow the strings from the `TupleType` heading.
📊 **Impact:** Reduces `String` heap allocations by N (where N is the number of common attributes) for every hash join and semijoin operation.
🔬 **Measurement:** Run `cargo bench --bench algebra -- --test` to verify it passes without panicking.

---
*PR created automatically by Jules for task [16506924459657735399](https://jules.google.com/task/16506924459657735399) started by @madmax983*