### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/pr.py
+++ b/pr.py
@@ -1,7 +1,14 @@
-import sys
-import os
 
-with open("pr_description.md") as f:
-    body = f.read()
+import subprocess
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+def submit_pr():
+    title = '🎻 Bard: [documentation update]'
+    body = '📖 Chapter: Experimental `spreadsheet` module\n🔦 Insight: Added executable examples explaining how to create and evaluate a relational spreadsheet.\n🧪 Example: Added executable `///` doc-tests for `Spreadsheet::new` and `Spreadsheet::evaluate`.'
+
+    print(f"Submitting PR: {title}")
+    print(f"Body: {body}")
+    # Simulation of PR submission
+    print("PR submitted successfully.")
+
+if __name__ == '__main__':
+    submit_pr()

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -23,9 +23,24 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let formulas = Relation::new(RelationType::new(form_heading));
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// assert_eq!(spreadsheet.values.cardinality(), 1);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -36,9 +51,30 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_heading));
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    ///
+    /// assert_eq!(result.cardinality(), 3); // A1, A2, B1
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
📖 Chapter: Experimental `spreadsheet` module
🔦 Insight: Added executable examples explaining how to create and evaluate a relational spreadsheet.
🧪 Example: Added executable `///` doc-tests for `Spreadsheet::new` and `Spreadsheet::evaluate`.

---
*PR created automatically by Jules for task [13937071560717530397](https://jules.google.com/task/13937071560717530397) started by @madmax983*