### PR TITLE
🔒 Warden: [security fix] Fix deserialization bomb in Query and ConstraintExpression

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -9,3 +9,7 @@
 ## 2026-04-24 - [Unsafe unwrap in StorageManager]
 **Threat:** Potential panic and crash if `get_or_open_heap_file` fails to retrieve or map a file correctly, resulting in an unhandled `.unwrap()` failure.
 **Defense:** Replaced `.unwrap()` with `HashMap::entry` to ensure safe, graceful error propagation rather than crashing the system without unreachable branches.
+
+## 2024-06-16 - [Deserialization DoS on ASTs]
+**Threat:** A deserialization vulnerability existed in the `Query` and `ConstraintExpression` enums. Because they contain deeply recursive fields (`Box<Query>` and `Box<ConstraintExpression>`) and were using the default `#[derive(Deserialize)]`, an attacker could craft a deeply nested JSON payload that would trigger a stack overflow during `serde_json::from_str`, resulting in a Denial of Service.
+**Defense:** Replaced the direct `#[derive(Deserialize)]` on `Query` and `ConstraintExpression` with `#[serde(try_from = "...Unchecked")]`. The unchecked enums mirror the original definitions but apply `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` to all recursive `Box` fields. This limits the recursion depth (via `RecursionGuard`) and returns a safe error instead of crashing the process.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,15 @@
+🔒 Warden: [security fix] Fix deserialization bomb in Query and ConstraintExpression
+
+🦠 Threat
+A deserialization vulnerability existed in the `Query` and `ConstraintExpression` enums. Because they contain deeply recursive fields (`Box<Query>` and `Box<ConstraintExpression>`) and were using the default `#[derive(Deserialize)]`, an attacker could craft a deeply nested JSON payload that would trigger a stack overflow during `serde_json::from_str`, resulting in a Denial of Service.
+
+🛡️ Defense
+Replaced the direct `#[derive(Deserialize)]` on `Query` and `ConstraintExpression` with `#[serde(try_from = "...Unchecked")]`. The unchecked enums mirror the original definitions but apply `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` to all recursive `Box` fields. This limits the recursion depth (via `RecursionGuard`) and returns a safe error instead of crashing the process.
+
+💥 Severity
+Critical - could panic the server by crashing the process via stack overflow on untrusted JSON payloads.
+
+🧪 Verification
+Added fuzzing test case to verify `Query` and `ConstraintExpression` safely return an error rather than stack overflowing when parsing a payload with a depth of 20,000. Verified that `cargo check`, `cargo clippy`, and `cargo test` pass successfully.
+
+Note: Ignored the hardcoded title in the existing `pr.py` script.

--- a/relvar-core/src/constraints/expression.rs
+++ b/relvar-core/src/constraints/expression.rs
@@ -90,6 +90,7 @@ pub enum CmpOp {
 /// - **Set membership**: In
 /// - **Pattern matching**: Like
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(try_from = "ConstraintExpressionUnchecked")]
 pub enum ConstraintExpression {
     /// Comparison: left_attr op right_value_or_ref
     Cmp {
@@ -139,6 +140,57 @@ pub enum ConstraintExpression {
     /// assert!(!case_expr.evaluate(&tuple! { code: "abc" }).unwrap());
     /// ```
     Like(String, String),
+}
+
+#[derive(Debug, Deserialize)]
+enum ConstraintExpressionUnchecked {
+    Cmp {
+        left: String,
+        op: CmpOp,
+        right: ValueOrRef,
+    },
+    And(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
+    Or(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
+    Not(
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        Box<ConstraintExpression>,
+    ),
+    In(String, std::collections::HashSet<ScalarValue>),
+    Like(String, String),
+}
+
+impl TryFrom<ConstraintExpressionUnchecked> for ConstraintExpression {
+    type Error = String;
+    fn try_from(value: ConstraintExpressionUnchecked) -> Result<Self, Self::Error> {
+        match value {
+            ConstraintExpressionUnchecked::Cmp { left, op, right } => {
+                Ok(ConstraintExpression::Cmp { left, op, right })
+            }
+            ConstraintExpressionUnchecked::And(left, right) => {
+                Ok(ConstraintExpression::And(left, right))
+            }
+            ConstraintExpressionUnchecked::Or(left, right) => {
+                Ok(ConstraintExpression::Or(left, right))
+            }
+            ConstraintExpressionUnchecked::Not(expr) => Ok(ConstraintExpression::Not(expr)),
+            ConstraintExpressionUnchecked::In(left, values) => {
+                Ok(ConstraintExpression::In(left, values))
+            }
+            ConstraintExpressionUnchecked::Like(left, pattern) => {
+                Ok(ConstraintExpression::Like(left, pattern))
+            }
+        }
+    }
 }
 
 impl ConstraintExpression {

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -63,6 +63,7 @@ use thiserror::Error;
 /// let q = Query::scan("users");
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "QueryUnchecked")]
 pub enum Query {
     /// Scan a relation variable (base table).
     ///
@@ -144,6 +145,66 @@ pub enum QueryError {
     /// Error in relational algebra operation.
     #[error("Algebra error: {0}")]
     Algebra(String),
+}
+
+// Workaround for stack overflow on deep recursion.
+#[derive(Debug, Deserialize)]
+enum QueryUnchecked {
+    Scan(String),
+    Restrict {
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        input: Box<Query>,
+        predicate: ConstraintExpression,
+    },
+    Project {
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        input: Box<Query>,
+        attributes: Vec<String>,
+    },
+    Rename {
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        input: Box<Query>,
+        mappings: Vec<(String, String)>,
+    },
+    Join {
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        left: Box<Query>,
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        right: Box<Query>,
+    },
+    Summarize {
+        #[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]
+        input: Box<Query>,
+        group_by: Vec<String>,
+        aggregations: Vec<Aggregation>,
+    },
+}
+
+impl TryFrom<QueryUnchecked> for Query {
+    type Error = String;
+
+    fn try_from(value: QueryUnchecked) -> Result<Self, Self::Error> {
+        match value {
+            QueryUnchecked::Scan(name) => Ok(Query::Scan(name)),
+            QueryUnchecked::Restrict { input, predicate } => {
+                Ok(Query::Restrict { input, predicate })
+            }
+            QueryUnchecked::Project { input, attributes } => {
+                Ok(Query::Project { input, attributes })
+            }
+            QueryUnchecked::Rename { input, mappings } => Ok(Query::Rename { input, mappings }),
+            QueryUnchecked::Join { left, right } => Ok(Query::Join { left, right }),
+            QueryUnchecked::Summarize {
+                input,
+                group_by,
+                aggregations,
+            } => Ok(Query::Summarize {
+                input,
+                group_by,
+                aggregations,
+            }),
+        }
+    }
 }
 
 impl Query {

--- a/relvar-core/tests/warden_exploit_query_dos.rs
+++ b/relvar-core/tests/warden_exploit_query_dos.rs
@@ -1,0 +1,35 @@
+use relvar_core::constraints::ConstraintExpression;
+use relvar_core::query::Query;
+
+#[test]
+fn test_query_overflow_dos() {
+    let mut query_json = String::from(
+        r#"{"Restrict":{"predicate":{"Cmp":{"left":"id","op":"Eq","right":{"Value":{"Int":1}}}},"input":"#,
+    );
+    let n = 20000;
+    for _ in 0..n {
+        query_json.push_str(r#"{"Restrict":{"predicate":{"Cmp":{"left":"id","op":"Eq","right":{"Value":{"Int":1}}}},"input":"#);
+    }
+    query_json.push_str(r#"{"Scan":"USERS"}"#);
+    for _ in 0..n + 1 {
+        query_json.push('}');
+        query_json.push('}');
+    }
+
+    // Attempting to parse should fail gracefully
+    let res: Result<Query, _> = serde_json::from_str(&query_json);
+    assert!(res.is_err());
+
+    // Also test constraint expression
+    let mut query_json = String::from(r#"{"Not":"#);
+    let n = 20000;
+    for _ in 0..n {
+        query_json.push_str(r#"{"Not":"#);
+    }
+    query_json.push_str(r#"{"Cmp":{"left":"id","op":"Eq","right":{"Value":{"Int":1}}}}"#);
+    for _ in 0..n + 1 {
+        query_json.push('}');
+    }
+    let res: Result<ConstraintExpression, _> = serde_json::from_str(&query_json);
+    assert!(res.is_err());
+}


### PR DESCRIPTION
🔒 Warden: [security fix] Fix deserialization bomb in Query and ConstraintExpression

🦠 Threat
A deserialization vulnerability existed in the `Query` and `ConstraintExpression` enums. Because they contain deeply recursive fields (`Box<Query>` and `Box<ConstraintExpression>`) and were using the default `#[derive(Deserialize)]`, an attacker could craft a deeply nested JSON payload that would trigger a stack overflow during `serde_json::from_str`, resulting in a Denial of Service.

🛡️ Defense
Replaced the direct `#[derive(Deserialize)]` on `Query` and `ConstraintExpression` with `#[serde(try_from = "...Unchecked")]`. The unchecked enums mirror the original definitions but apply `#[serde(deserialize_with = "crate::utils::recursion::deserialize_guarded")]` to all recursive `Box` fields. This limits the recursion depth (via `RecursionGuard`) and returns a safe error instead of crashing the process.

💥 Severity
Critical - could panic the server by crashing the process via stack overflow on untrusted JSON payloads.

🧪 Verification
Added fuzzing test case to verify `Query` and `ConstraintExpression` safely return an error rather than stack overflowing when parsing a payload with a depth of 20,000. Verified that `cargo check`, `cargo clippy`, and `cargo test` pass successfully.

---
*PR created automatically by Jules for task [4088106932717429532](https://jules.google.com/task/4088106932717429532) started by @madmax983*