### PR TITLE
🪒 Razor: Replace MockRelation Builder with function

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -21,3 +21,8 @@
 **Bloat:** Single-variant enum `RelationError` in `relvar-core/src/values/relation.rs` acting as a unit struct, with an unused variant `DuplicateTuple` and only one used variant `TypeMismatch`.
 **Cut:** Converted to unit struct `pub struct RelationError;` with `#[error("Tuple does not conform to relation type")]` directly. Removed the unused `DuplicateTuple` variant.
 **Saved:** Unnecessary enum matching, simplified error handling code significantly.
+
+## [Reduction]
+**Bloat:** `MockRelation` builder pattern in `relvar/src/experimental/mock.rs` that takes only 2 optional configuration arguments.
+**Cut:** Replaced the builder with a direct `generate_mock_relation` function, flattening the abstraction and enforcing KISS.
+**Saved:** Unnecessary struct definition and builder boilerplate.

--- a/plan_script.py
+++ b/plan_script.py
@@ -1,0 +1,24 @@
+plan = """1. **Refactor MockRelation Builder**
+   - In `relvar/src/experimental/mock.rs`, the `MockRelation` builder is bloat. It has a `new`, `count`, `seed`, and `generate` method.
+   - Refactor `MockRelation` to a simple struct with a static method or just `pub fn generate_mock_relation(...)`. Wait, the prompt specifically calls out: "Factory Factories: Builders for objects that take 2 arguments. (Just use new()).". So we should replace the builder pattern on `MockRelation` with a `pub fn new(relation_type: RelationType, count: usize, seed: Option<u64>) -> Relation` or `pub fn generate(...)` if we keep it a struct. Actually, I can just make `MockRelation::generate(relation_type: RelationType, count: usize, seed: Option<u64>) -> Relation` and remove the `MockRelation` struct altogether, or keep `MockRelation` with `generate` as a static function. Let's just remove the struct and make it a free function `pub fn generate_mock_relation(...)`, since it's just generating a `Relation`. Wait, "Just use new()" suggests making a constructor or a single function. Let's replace `MockRelation` with a function `pub fn generate_mock_relation(relation_type: RelationType, count: usize, seed: Option<u64>) -> Relation`. Wait, what about `generate_tuple` and `generate_value`? I can put them inside `generate_mock_relation` or as private helper functions.
+
+2. **Wait! Are there any other Builders taking 2 arguments?**
+   - No, I checked and didn't find any others.
+
+3. **Check `QueryBuilder`?**
+   - No, `QueryBuilder` is an AST (enum `Query` with `scan`, `restrict`, `project` methods). It is not a struct builder.
+
+4. **Verify Tests**:
+   - Update `relvar/src/experimental/mock.rs` tests to use `generate_mock_relation(...)` instead of the builder.
+   - Run `cargo test` and `cargo clippy`.
+
+5. **Journal**:
+   - Update `.jules/razor.md` with:
+     ```markdown
+     ## [Reduction]
+     **Bloat:** `MockRelation` builder pattern in `relvar/src/experimental/mock.rs` that takes only 2 optional configuration arguments.
+     **Cut:** Replaced the builder with a direct `generate_mock_relation` function, flattening the abstraction and enforcing KISS.
+     **Saved:** Unnecessary struct definition and builder boilerplate.
+     ```
+"""
+print(plan)

--- a/relvar/src/experimental/mock.rs
+++ b/relvar/src/experimental/mock.rs
@@ -7,7 +7,7 @@
 //! # Example
 //!
 //! ```
-//! use relvar::experimental::mock::MockRelation;
+//! use relvar::experimental::mock::generate_mock_relation;
 //! use relvar_core::types::{RelationType, TupleType, ScalarType};
 //!
 //! // 1. Define schema
@@ -18,11 +18,8 @@
 //!         .with_attribute("tag", ScalarType::String)
 //! );
 //!
-//! // 2. Generate random data
-//! let relation = MockRelation::new(rel_type)
-//!     .count(100)       // Generate 100 tuples
-//!     .seed(42)         // Use fixed seed for deterministic results
-//!     .generate();
+//! // 2. Generate random data (schema, count, optional seed)
+//! let relation = generate_mock_relation(rel_type, 100, Some(42));
 //!
 //! assert_eq!(relation.cardinality(), 100);
 //! ```
@@ -33,13 +30,17 @@ use relvar_core::types::{RelationType, ScalarType};
 use relvar_core::values::{Relation, ScalarValue, Tuple};
 use std::collections::BTreeMap;
 
-/// A builder for generating mock relations with random data.
+/// Generates a mock relation with random data.
+///
+/// Note: Since relations are sets, duplicate tuples will be ignored.
+/// If the random generation produces duplicates, the final cardinality
+/// might be less than `count`.
 ///
 /// # Examples
 ///
 /// ```
-/// use relvar::experimental::mock::MockRelation;
 /// use relvar_core::types::{RelationType, TupleType, ScalarType};
+/// use relvar::experimental::mock::generate_mock_relation;
 ///
 /// let rel_type = RelationType::new(
 ///     TupleType::new()
@@ -47,132 +48,71 @@ use std::collections::BTreeMap;
 ///         .with_attribute("name", ScalarType::String)
 /// );
 ///
-/// let relation = MockRelation::new(rel_type)
-///     .count(10)
-///     .seed(42)
-///     .generate();
+/// let relation = generate_mock_relation(rel_type, 10, Some(42));
 ///
 /// assert_eq!(relation.cardinality(), 10);
 /// ```
-pub struct MockRelation {
+pub fn generate_mock_relation(
     relation_type: RelationType,
     count: usize,
     seed: Option<u64>,
+) -> Relation {
+    let mut relation = Relation::new(relation_type.clone());
+    let mut rng = if let Some(s) = seed {
+        StdRng::seed_from_u64(s)
+    } else {
+        StdRng::from_rng(&mut rand::rng())
+    };
+
+    for _ in 0..count {
+        if let Some(tuple) = generate_tuple(&relation_type, &mut rng) {
+            let _ = relation.insert(tuple);
+        }
+    }
+
+    relation
 }
 
-impl MockRelation {
-    /// Create a new MockRelation builder for the given relation type.
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
-    /// use relvar::experimental::mock::MockRelation;
-    /// // Note: This is a placeholder example
-    /// ```
-    pub fn new(relation_type: RelationType) -> Self {
-        Self {
-            relation_type,
-            count: 0,
-            seed: None,
+fn generate_tuple(relation_type: &RelationType, rng: &mut StdRng) -> Option<Tuple> {
+    let mut values = BTreeMap::new();
+
+    for attr_name in relation_type.heading().attribute_names() {
+        let scalar_type = relation_type.heading().get_attribute_type(attr_name)?;
+        let value = generate_value(scalar_type, rng);
+        values.insert(attr_name.clone(), value);
+    }
+
+    Tuple::new(relation_type.heading().clone(), values).ok()
+}
+
+fn generate_value(scalar_type: &ScalarType, rng: &mut StdRng) -> ScalarValue {
+    match scalar_type {
+        ScalarType::Int => ScalarValue::Int(rng.random()),
+        ScalarType::Float => ScalarValue::Float(rng.random()),
+        ScalarType::String => {
+            // Generate a random string of length 5-15
+            let len = rng.random_range(5..=15);
+            let s: String = (0..len)
+                .map(|_| rng.sample(rand::distr::Alphanumeric) as char)
+                .collect();
+            ScalarValue::String(s)
         }
-    }
-
-    /// Set the number of tuples to generate.
-    ///
-    /// Note: Since relations are sets, duplicate tuples will be ignored.
-    /// If the random generation produces duplicates, the final cardinality
-    /// might be less than `count`.
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
-    /// use relvar::experimental::mock::MockRelation;
-    /// // Note: This is a placeholder example
-    /// ```
-    pub fn count(mut self, count: usize) -> Self {
-        self.count = count;
-        self
-    }
-
-    /// Set the random seed for deterministic generation.
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
-    /// use relvar::experimental::mock::MockRelation;
-    /// // Note: This is a placeholder example
-    /// ```
-    pub fn seed(mut self, seed: u64) -> Self {
-        self.seed = Some(seed);
-        self
-    }
-
-    /// Generate the relation.
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
-    /// use relvar::experimental::mock::MockRelation;
-    /// // Note: This is a placeholder example
-    /// ```
-    pub fn generate(self) -> Relation {
-        let mut relation = Relation::new(self.relation_type.clone());
-        let mut rng = if let Some(seed) = self.seed {
-            StdRng::seed_from_u64(seed)
-        } else {
-            StdRng::from_rng(&mut rand::rng())
-        };
-
-        for _ in 0..self.count {
-            if let Some(tuple) = self.generate_tuple(&mut rng) {
-                let _ = relation.insert(tuple);
-            }
+        ScalarType::Bool => ScalarValue::Bool(rng.random()),
+        ScalarType::Bytes => {
+            let len = rng.random_range(1..=32);
+            let bytes: Vec<u8> = (0..len).map(|_| rng.random()).collect();
+            ScalarValue::Bytes(bytes)
         }
-
-        relation
-    }
-
-    fn generate_tuple(&self, rng: &mut StdRng) -> Option<Tuple> {
-        let mut values = BTreeMap::new();
-
-        for attr_name in self.relation_type.heading().attribute_names() {
-            let scalar_type = self.relation_type.heading().get_attribute_type(attr_name)?;
-            let value = self.generate_value(scalar_type, rng);
-            values.insert(attr_name.clone(), value);
+        ScalarType::Relation(rel_type) => {
+            // Nested relation: return empty for now to avoid infinite recursion
+            ScalarValue::Relation(Relation::new(*rel_type.clone()))
         }
-
-        Tuple::new(self.relation_type.heading().clone(), values).ok()
-    }
-
-    fn generate_value(&self, scalar_type: &ScalarType, rng: &mut StdRng) -> ScalarValue {
-        match scalar_type {
-            ScalarType::Int => ScalarValue::Int(rng.random()),
-            ScalarType::Float => ScalarValue::Float(rng.random()),
-            ScalarType::String => {
-                // Generate a random string of length 5-15
-                let len = rng.random_range(5..=15);
-                let s: String = (0..len)
-                    .map(|_| rng.sample(rand::distr::Alphanumeric) as char)
-                    .collect();
-                ScalarValue::String(s)
-            }
-            ScalarType::Bool => ScalarValue::Bool(rng.random()),
-            ScalarType::Bytes => {
-                let len = rng.random_range(1..=32);
-                let bytes: Vec<u8> = (0..len).map(|_| rng.random()).collect();
-                ScalarValue::Bytes(bytes)
-            }
-            ScalarType::Relation(rel_type) => {
-                // Nested relation: return empty for now to avoid infinite recursion
-                ScalarValue::Relation(Relation::new(*rel_type.clone()))
-            }
-            ScalarType::UserDefined { representation, .. } => {
-                // Recursively generate value for the representation
-                let inner_value = self.generate_value(representation, rng);
-                ScalarValue::UserDefined {
-                    type_def: scalar_type.clone(),
-                    value: Box::new(inner_value),
-                }
+        ScalarType::UserDefined { representation, .. } => {
+            // Recursively generate value for the representation
+            let inner_value = generate_value(representation, rng);
+            ScalarValue::UserDefined {
+                type_def: scalar_type.clone(),
+                value: Box::new(inner_value),
             }
         }
     }
@@ -192,10 +132,7 @@ mod tests {
                 .with_attribute("active", ScalarType::Bool),
         );
 
-        let relation = MockRelation::new(rel_type)
-            .count(50)
-            .seed(12345) // Deterministic
-            .generate();
+        let relation = generate_mock_relation(rel_type, 50, Some(12345)); // Deterministic
 
         assert_eq!(relation.cardinality(), 50);
         assert_eq!(relation.degree(), 3);
@@ -222,7 +159,7 @@ mod tests {
                 .with_attribute("user_val", user_defined_type),
         );
 
-        let relation = MockRelation::new(rel_type).count(10).seed(42).generate();
+        let relation = generate_mock_relation(rel_type, 10, Some(42));
 
         assert_eq!(relation.degree(), 7);
         assert_eq!(relation.cardinality(), 10);
@@ -232,12 +169,8 @@ mod tests {
     fn test_determinism() {
         let rel_type = RelationType::new(TupleType::new().with_attribute("val", ScalarType::Float));
 
-        let rel1 = MockRelation::new(rel_type.clone())
-            .count(10)
-            .seed(42)
-            .generate();
-
-        let rel2 = MockRelation::new(rel_type).count(10).seed(42).generate();
+        let rel1 = generate_mock_relation(rel_type.clone(), 10, Some(42));
+        let rel2 = generate_mock_relation(rel_type, 10, Some(42));
 
         assert_eq!(rel1, rel2);
     }


### PR DESCRIPTION
💡 **The Spark:** The `MockRelation` builder in `relvar/src/experimental/mock.rs` only takes 2 arguments (`count` and `seed`) and is a clear example of an unnecessary "Factory Factory" pattern violating the KISS principle.
🚀 **The Feature:** Removed the `MockRelation` struct and its builder methods (`count`, `seed`, `generate`). Replaced it with a single, standalone `generate_mock_relation` function, flattening the abstraction.
🔭 **The Potential:** Simpler code without unnecessary builder boilerplate.
⚠️ **Risk:** Minimal, tests are updated and only test-facing mock functionality is affected.

---
*PR created automatically by Jules for task [13954283163909927092](https://jules.google.com/task/13954283163909927092) started by @madmax983*