### PR TITLE
⚡ Bolt: Avoid `RelationType` clone during DML update

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,6 @@
 ## 2024-05-20 - String Allocations in Iterators
 **Learning:** `rename_into` previously consumed a tuple's BTreeMap entirely to scalar values by calling `.into_values()`. However, BTreeMaps also implement `into_iter()` which yields owned `(K, V)` pairs. We were discarding the `K` (the original String key) and creating a brand new String key for every column of every tuple, even if the rename mapping didn't touch it.
 **Action:** Always check if we can reuse the owned strings from an input collection instead of reflexively throwing them away and re-allocating them in an iterator pipeline.
+## 2026-06-17 - [Zero-cost parts destruction]
+**Learning:** Found an unnecessary `relation_type().clone()` when consuming a Relation to map over its tuples in `compute_relation_after_update` (DML). This incurs an unnecessary clone.
+**Action:** Created `Relation::into_parts(self) -> (RelationType, HashSet<Tuple>)` to consume the Relation without cloning its components, preserving zero-cost abstractions, avoiding heap allocation when accessing underlying tuples and type.

--- a/relvar-core/src/database/dml.rs
+++ b/relvar-core/src/database/dml.rs
@@ -36,11 +36,11 @@ where
     F: Fn(&Tuple) -> bool,
     U: Fn(&Tuple) -> Tuple,
 {
-    let relation_type = current_relation.relation_type().clone();
-    let expected_type = relation_type.tuple_type(); // Borrow instead of cloning Arc<TupleType>
     let initial_cardinality = current_relation.cardinality();
+    let (relation_type, tuples) = current_relation.into_parts();
+    let expected_type = relation_type.tuple_type(); // Borrow instead of cloning Arc<TupleType>
 
-    let (body, update_count) = current_relation.into_iter().try_fold(
+    let (body, update_count) = tuples.into_iter().try_fold(
         (
             std::collections::HashSet::with_capacity(initial_cardinality),
             0,

--- a/relvar-core/src/values/relation.rs
+++ b/relvar-core/src/values/relation.rs
@@ -663,6 +663,14 @@ impl Relation {
         self.body.retain(|tuple| predicate(tuple));
         self
     }
+
+    /// Consumes the relation, returning its type and its body (a set of tuples).
+    ///
+    /// This avoids cloning the relation type when both the type and the tuples
+    /// are needed, such as during DML operations.
+    pub fn into_parts(self) -> (RelationType, HashSet<Tuple>) {
+        (self.relation_type, self.body)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Introduced `Relation::into_parts(self) -> (RelationType, HashSet<Tuple>)` to consume a `Relation` into its constituent parts without cloning. Used this new method in `compute_relation_after_update` in `relvar-core/src/database/dml.rs`. This eliminates an unnecessary clone of `RelationType` (which involves heap allocation and deep copying of the schema) for every `UPDATE` operation, providing a zero-cost path to consume relations.

---
*PR created automatically by Jules for task [4636056908774025137](https://jules.google.com/task/4636056908774025137) started by @madmax983*