### PR TITLE
⚒️ Forge: Refactor God Function in Physics Engine

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,6 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+## $(date +%Y-%m-%d) - Refactored compute_pairwise_forces God Function
+**Learning:** The `compute_pairwise_forces` function in `relvar/src/experimental/physics.rs` was an 81-line "God Function" that handled both cross-joining particles and calculating complex gravitational forces within large `.extend()` closures. This conflated relational data preparation with heavy mathematical computation, hurting readability.
+**Action:** Applied the 'Three-Phase Operator' pattern to extract the logic into two distinct helper functions: `compute_interaction_pairs` (handles renaming, joining, and filtering) and `compute_force_components` (handles the mathematical `extend` closures). This flattens the execution flow of the main method.

--- a/relvar/src/experimental/physics.rs
+++ b/relvar/src/experimental/physics.rs
@@ -59,6 +59,11 @@ impl PhysicsEngine {
     }
 
     fn compute_pairwise_forces(&self) -> Result<Relation, DatabaseError> {
+        let interactions = self.compute_interaction_pairs()?;
+        self.compute_force_components(&interactions)
+    }
+
+    fn compute_interaction_pairs(&self) -> Result<Relation, DatabaseError> {
         // 1. Cross join particles with themselves to compute pairwise forces.
         // Rename attributes to distinguish particle 1 and particle 2.
         let p1 = self.particles.rename(&[
@@ -82,12 +87,14 @@ impl PhysicsEngine {
         let pairs = p1.join(&p2)?;
 
         // 2. Filter out self-interactions (id1 == id2)
-        let interactions = pairs.restrict(|t| {
+        Ok(pairs.restrict(|t| {
             let id1 = t.get_typed::<i64>("id1").unwrap();
             let id2 = t.get_typed::<i64>("id2").unwrap();
             id1 != id2
-        });
+        }))
+    }
 
+    fn compute_force_components(&self, interactions: &Relation) -> Result<Relation, DatabaseError> {
         // 3. Compute forces for each pair
         let g = self.g;
         interactions


### PR DESCRIPTION
⚒️ Forge: Refactor God Function in Physics Engine

🚮 Smell: The `compute_pairwise_forces` function in `relvar/src/experimental/physics.rs` was an 81-line "God Function" that combined complex cross-joins, filtering, and heavy mathematical closures for gravitational calculations into a single unreadable block.
✨ Solution: Applied the "Three-Phase Operator" pattern. Extracted the relational logic (joining, filtering) into `compute_interaction_pairs` and the mathematical processing (`extend` closures) into `compute_force_components`.
🧼 Benefit: Flattened the execution flow, making the boundaries between relational data preparation and mathematical execution explicit and much easier to read.
🛡️ Verification: Tests passed. No logic changed. Verified with `cargo test`, `cargo fmt`, and `cargo clippy`.

---
*PR created automatically by Jules for task [15844077458788852343](https://jules.google.com/task/15844077458788852343) started by @madmax983*