### PR TITLE
🗺️ Atlas: [architectural change] Fixing public module leak in query tests

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -27,3 +27,6 @@
 ## 2024-05-19 - Fixing Public Module Leaks
 **Tangle:** Broad visibility (`pub mod`) across many test and internal modules leaked implementation details and complicated the dependency graph.
 **Blueprint:** Converted most top-level internal module definitions in `relvar-core` and `relvar-storage` and `relvar` to `pub(crate) mod` where appropriate, and fixed some lingering pub use statements.
+## 2026-06-18 - Fixing Public Module Leaks in Query Tests
+**Tangle:** The `relvar-core/src/query/tests/mod.rs` module incorrectly exposed its submodules as `pub mod`, leaking implementation details.
+**Blueprint:** Converted `pub mod` to `mod` and `pub(crate) mod` in the query tests module to enforce clean module boundaries.

--- a/plan.md
+++ b/plan.md
@@ -1,2 +1,6 @@
-1. **Submit the clean audit report.**
-   - Since no active vulnerabilities were found during the investigation of `unsafe` blocks, bounds checking, buffer limits, and data serialization (verifying that they either safely bounded or properly capped), I will submit the PR to confirm the codebase is secure under the given scope.
+1. **Analyze existing `pub mod` usage**: I noticed several modules are incorrectly defined as `pub mod` in the `relvar-core/src/query/tests/mod.rs` directory, specifically `pub mod basic;` and `pub mod common;`. Test modules should not leak as public modules.
+2. **Convert `pub mod` to `pub(crate) mod` or `mod` for test modules**: I will change `pub mod basic;` and `pub mod common;` in `relvar-core/src/query/tests/mod.rs` to just `mod basic;` and `pub(crate) mod common;`. Similarly for `relvar-core/src/database/tests/mod.rs`, `pub(crate) mod common;` can be `mod common;` (but `pub(crate)` is fine). The problem is `pub mod basic` and `pub mod common` leaking as public APIs.
+3. **Check test modules**: `relvar-core/src/query/tests/mod.rs` uses `pub mod`. It should just be `mod basic;` and `pub(crate) mod common;` (or just `mod`). `relvar-core/src/database/tests/mod.rs` uses `pub(crate) mod common;`.
+4. **Fix public module leaks**: I will rewrite `relvar-core/src/query/tests/mod.rs` to not use `pub mod`.
+5. **Compile and test**: Run `cargo check`, `cargo test`, and `cargo fmt`.
+6. **Pre-commit and PR**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done, then create the PR.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🗺️ Atlas: [architectural change] Fixing public module leak in query tests
+
+🕸️ Tangle: The query tests module incorrectly exposed `basic` and `common` submodules as `pub mod`, leaking test details into the public API.
+📐 Blueprint: Changed `pub mod basic` to `mod basic` and `pub mod common` to `pub(crate) mod common` to restrict visibility strictly to the test harness.
+🧱 Stability: Reduced coupling, cleaner public API boundary.
+🔬 Verification: Builds successfully, strict separation enforced.

--- a/relvar-core/src/query/tests/mod.rs
+++ b/relvar-core/src/query/tests/mod.rs
@@ -1,2 +1,2 @@
-pub mod basic;
-pub mod common;
+mod basic;
+pub(crate) mod common;


### PR DESCRIPTION
🗺️ Atlas: [architectural change] Fixing public module leak in query tests

🕸️ Tangle: The query tests module incorrectly exposed `basic` and `common` submodules as `pub mod`, leaking test details into the public API.
📐 Blueprint: Changed `pub mod basic` to `mod basic` and `pub mod common` to `pub(crate) mod common` to restrict visibility strictly to the test harness.
🧱 Stability: Reduced coupling, cleaner public API boundary.
🔬 Verification: Builds successfully, strict separation enforced.

---
*PR created automatically by Jules for task [12088210477815761001](https://jules.google.com/task/12088210477815761001) started by @madmax983*