### PR TITLE
🪒 Razor: [refactor key constraint error handling]

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -21,3 +21,7 @@
 **Bloat:** Single-variant enum `RelationError` in `relvar-core/src/values/relation.rs` acting as a unit struct, with an unused variant `DuplicateTuple` and only one used variant `TypeMismatch`.
 **Cut:** Converted to unit struct `pub struct RelationError;` with `#[error("Tuple does not conform to relation type")]` directly. Removed the unused `DuplicateTuple` variant.
 **Saved:** Unnecessary enum matching, simplified error handling code significantly.
+## [Reduction]
+**Bloat:** `KeyConstraints::would_violate_on_insert` returning `Result<Option<Vec<String>>, KeyConstraintError>` using `Ok(Some(...))` as an error condition.
+**Cut:** Refactored to return `Result<(), KeyConstraintError>` and directly returning `Err(KeyConstraintError::DuplicateKey(...))` on constraint violation.
+**Saved:** Unnecessary option unwrapping and conceptually confusing error handling.

--- a/finish_relvar.py
+++ b/finish_relvar.py
@@ -1,22 +1,17 @@
-import sys
-import glob
+import subprocess
 
-def process_file(path, replacements):
-    with open(path, 'r') as f:
-        content = f.read()
+def read_file(filepath):
+    with open(filepath, "r") as f:
+        return f.read()
 
-    for old, new in replacements:
-        content = content.replace(old, new)
+body = read_file("pr_description.md")
 
-    with open(path, 'w') as f:
-        f.write(content)
+title = ""
+for line in body.split("\n"):
+    if line.strip():
+        title = line.strip()
+        break
 
-process_file("relvar/src/lib.rs", [
-    ("pub mod experimental;", "pub(crate) mod experimental;"),
-    ("pub mod tools;", "pub(crate) mod tools;")
-])
-
-process_file("relvar-storage/src/lib.rs", [
-    ("pub mod persistent_engine;", "pub(crate) mod persistent_engine;"),
-    ("pub mod storage;", "pub(crate) mod storage;")
-])
+print(f"Using tool default_api:submit")
+print(f"Title: {title}")
+print(f"Description: {body}")

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🪒 Razor: [refactor key constraint error handling]
+
+💡 **The Spark:** The method `KeyConstraints::would_violate_on_insert` was returning `Result<Option<Vec<String>>, KeyConstraintError>` and using `Ok(Some(...))` to indicate a violation, which is a confusing anti-pattern.
+🚀 **The Feature:** Changed the return type to `Result<(), KeyConstraintError>` and made the method directly return `Err(KeyConstraintError::DuplicateKey(...))` on violation.
+🔭 **The Potential:** Simplifies error handling and eliminates conceptually confusing uses of `Option` inside `Result`.
+⚠️ **Risk:** Minimal, only internal API usage within tests was affected.

--- a/relvar-core/src/constraints/key.rs
+++ b/relvar-core/src/constraints/key.rs
@@ -59,11 +59,10 @@
 //!
 //! // Check if inserting a duplicate would violate the constraint
 //! let duplicate = tuple! { emp_id: 1i64, name: "Charlie" };  // emp_id=1 already exists!
-//! let violation = constraints.would_violate_on_insert(&relation, &duplicate).unwrap();
+//! let violation = constraints.would_violate_on_insert(&relation, &duplicate);
 //!
 //! // Violation detected - returns the violated key attributes
-//! assert!(violation.is_some());
-//! assert_eq!(violation.unwrap(), vec!["emp_id"]);
+//! assert!(violation.is_err());
 //! ```
 
 use crate::values::{Relation, Tuple};
@@ -389,22 +388,22 @@ impl KeyConstraints {
         &self,
         relation: &Relation,
         new_tuple: &Tuple,
-    ) -> Result<Option<Vec<String>>, KeyConstraintError> {
+    ) -> Result<(), KeyConstraintError> {
         // Check primary key
         if let Some(pk) = &self.primary_key
             && pk.would_violate(relation, new_tuple)?
         {
-            return Ok(Some(pk.attributes().to_vec()));
+            return Err(KeyConstraintError::DuplicateKey(pk.attributes().to_vec()));
         }
 
         // Check candidate keys
         for ck in &self.candidate_keys {
             if ck.would_violate(relation, new_tuple)? {
-                return Ok(Some(ck.attributes().to_vec()));
+                return Err(KeyConstraintError::DuplicateKey(ck.attributes().to_vec()));
             }
         }
 
-        Ok(None)
+        Ok(())
     }
 }
 
@@ -543,12 +542,13 @@ mod tests {
             .unwrap();
 
         let new_tuple = tuple! { emp_id: 1i64, name: "Bob", dept_id: 20i64 };
-        let violation = constraints
-            .would_violate_on_insert(&relation, &new_tuple)
-            .unwrap();
-
-        assert!(violation.is_some());
-        assert_eq!(violation.unwrap(), vec!["emp_id"]);
+        let violation = constraints.would_violate_on_insert(&relation, &new_tuple);
+        assert!(violation.is_err());
+        if let Err(KeyConstraintError::DuplicateKey(attrs)) = violation {
+            assert_eq!(attrs, vec!["emp_id"]);
+        } else {
+            panic!("Expected DuplicateKey error");
+        }
     }
 
     #[test]
@@ -577,10 +577,8 @@ mod tests {
 
         // Try to insert with duplicate email
         let new_tuple = tuple! { emp_id: 3i64, email: "alice@example.com", name: "Alice2" };
-        let violation = constraints
-            .would_violate_on_insert(&relation, &new_tuple)
-            .unwrap();
-        assert!(violation.is_some());
+        let violation = constraints.would_violate_on_insert(&relation, &new_tuple);
+        assert!(violation.is_err());
     }
 
     #[test]


### PR DESCRIPTION
🪒 Razor: [refactor key constraint error handling]

💡 **The Spark:** The method `KeyConstraints::would_violate_on_insert` was returning `Result<Option<Vec<String>>, KeyConstraintError>` and using `Ok(Some(...))` to indicate a violation, which is a confusing anti-pattern.
🚀 **The Feature:** Changed the return type to `Result<(), KeyConstraintError>` and made the method directly return `Err(KeyConstraintError::DuplicateKey(...))` on violation.
🔭 **The Potential:** Simplifies error handling and eliminates conceptually confusing uses of `Option` inside `Result`.
⚠️ **Risk:** Minimal, only internal API usage within tests was affected.


---
*PR created automatically by Jules for task [9767339682595862572](https://jules.google.com/task/9767339682595862572) started by @madmax983*