### PR TITLE
⚒️ Forge: Refactor nested logic with guard clauses

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,7 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+
+## $(date +%Y-%m-%d) - Flattened Guard Clauses in Validation and Ungrouping
+**Learning:** Functions like `validate_type_constraints` and `validate_key_constraints_single_tuple` had deep `if let Some` nesting combined with `&&` condition logic which made them pyramids of doom. Similarly, `compute_ungrouped_tuples` nested RVA processing tightly.
+**Action:** Extract deeply nested blocks using early returns (Guard Clauses) via `let Some(...) = ... else { return/continue; }`. This flattens logic, making the main execution path the un-indented bottom level of the function.

--- a/pr.py
+++ b/pr.py
@@ -2,6 +2,9 @@ import sys
 import os
 
 with open("pr_description.md") as f:
-    body = f.read()
+    lines = f.read().splitlines()
 
-print(f"Submitting PR with title: ⚡ Bolt: Avoid cloning heading per tuple in ungroup\n\n{body}")
+title = lines[0]
+body = '\n'.join(lines[1:])
+
+print(f"Submitting PR with title: {title}\n\n{body}")

--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -425,11 +425,12 @@ fn compute_ungrouped_tuples(
         let val = tuple
             .get(rva_name)
             .ok_or_else(|| UngroupError::AttributeNotFound(rva_name.to_string()))?;
-        match val {
-            ScalarValue::Relation(rel) => total_capacity += rel.cardinality(),
-            _ => return Err(UngroupError::NotRelationValued(rva_name.to_string())),
-        }
+        let ScalarValue::Relation(rel) = val else {
+            return Err(UngroupError::NotRelationValued(rva_name.to_string()));
+        };
+        total_capacity += rel.cardinality();
     }
+
     let mut result_tuples = std::collections::HashSet::with_capacity(total_capacity);
     let result_heading_arc = std::sync::Arc::new(result_heading.clone());
 
@@ -438,17 +439,18 @@ fn compute_ungrouped_tuples(
         let val = tuple
             .get(rva_name)
             .ok_or_else(|| UngroupError::AttributeNotFound(rva_name.to_string()))?;
-        let rva_relation = match val {
-            ScalarValue::Relation(rel) => rel,
-            _ => return Err(UngroupError::NotRelationValued(rva_name.to_string())),
+
+        let ScalarValue::Relation(rva_relation) = val else {
+            return Err(UngroupError::NotRelationValued(rva_name.to_string()));
         };
 
         // Pre-compute the invariant non-RVA attributes for this outer tuple
         let mut base_values = std::collections::BTreeMap::new();
         for (attr_name, val) in tuple.values().iter() {
-            if attr_name != rva_name {
-                base_values.insert(attr_name.clone(), val.clone());
+            if attr_name == rva_name {
+                continue;
             }
+            base_values.insert(attr_name.clone(), val.clone());
         }
 
         // For each tuple in the RVA, create a new tuple combining non-RVA and RVA attributes

--- a/relvar-core/src/constraints/manager.rs
+++ b/relvar-core/src/constraints/manager.rs
@@ -336,20 +336,26 @@ impl ConstraintManager {
         relation_name: &str,
         tuple: &Tuple,
     ) -> Result<(), ConstraintManagerError> {
-        if let Some(attr_constraints) = self.type_constraints.get(relation_name) {
-            for (attr_name, constraints) in attr_constraints {
-                if let Some(value) = tuple.get(attr_name)
-                    && !constraints.is_satisfied_by(value).map_err(|e| {
-                        ConstraintManagerError::TypeConstraintViolation(e.to_string())
-                    })?
-                {
-                    return Err(ConstraintManagerError::TypeConstraintViolation(format!(
-                        "Attribute {} violates constraint",
-                        attr_name
-                    )));
-                }
+        let Some(attr_constraints) = self.type_constraints.get(relation_name) else {
+            return Ok(());
+        };
+
+        for (attr_name, constraints) in attr_constraints {
+            let Some(value) = tuple.get(attr_name) else {
+                continue;
+            };
+
+            if !constraints
+                .is_satisfied_by(value)
+                .map_err(|e| ConstraintManagerError::TypeConstraintViolation(e.to_string()))?
+            {
+                return Err(ConstraintManagerError::TypeConstraintViolation(format!(
+                    "Attribute {} violates constraint",
+                    attr_name
+                )));
             }
         }
+
         Ok(())
     }
 
@@ -384,24 +390,27 @@ impl ConstraintManager {
         tuple: &Tuple,
         current_relation: &Relation,
     ) -> Result<(), ConstraintManagerError> {
-        if let Some(key_constraints) = self.key_constraints.get(relation_name) {
-            if let Some(pk) = key_constraints.primary_key()
-                && pk
-                    .would_violate(current_relation, tuple)
-                    .map_err(|e| ConstraintManagerError::TransactionError(e.to_string()))?
-            {
-                return Err(ConstraintManagerError::PrimaryKeyViolation);
-            }
+        let Some(key_constraints) = self.key_constraints.get(relation_name) else {
+            return Ok(());
+        };
 
-            for ck in key_constraints.candidate_keys() {
-                if ck
-                    .would_violate(current_relation, tuple)
-                    .map_err(|e| ConstraintManagerError::TransactionError(e.to_string()))?
-                {
-                    return Err(ConstraintManagerError::CandidateKeyViolation);
-                }
+        if let Some(pk) = key_constraints.primary_key()
+            && pk
+                .would_violate(current_relation, tuple)
+                .map_err(|e| ConstraintManagerError::TransactionError(e.to_string()))?
+        {
+            return Err(ConstraintManagerError::PrimaryKeyViolation);
+        }
+
+        for ck in key_constraints.candidate_keys() {
+            if ck
+                .would_violate(current_relation, tuple)
+                .map_err(|e| ConstraintManagerError::TransactionError(e.to_string()))?
+            {
+                return Err(ConstraintManagerError::CandidateKeyViolation);
             }
         }
+
         Ok(())
     }
 


### PR DESCRIPTION
🗑️ Smell: Nested `if let Some` blocks with conditional `&&` operations in `compute_ungrouped_tuples`, `validate_type_constraints`, and `validate_key_constraints_single_tuple`, making the flow hard to read.
✨ Solution: Extracted the deeply nested blocks using early returns (Guard Clauses) and explicit pattern matching to flatten the logic.
🧼 Benefit: Significantly reduces cognitive load and "Pyramid of Doom" nesting; execution flow is simpler and strictly typed.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [1784425043375065169](https://jules.google.com/task/1784425043375065169) started by @madmax983*