### PR TITLE
🎸 Bard: Documenting Spreadsheet

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -33,3 +33,6 @@
 ## 2025-05-06 - [The Ghost Knowledge Graph]
 **Confusion:** The experimental `KnowledgeGraph` module was completely undocumented, leaving users to guess how it connects to the relational model.
 **Clarification:** Wrote comprehensive module-level documentation and executable doctests for `KnowledgeGraph` and `TriplePattern` explaining the "Relational Semantic Web" concept.
+## 2026-06-19 - Documenting Spreadsheet
+**Confusion:** The experimental `Spreadsheet` had a placeholder example and missing doc-tests for its struct and methods, making it confusing to understand how to initialize the values and formulas relations and how to evaluate the spreadsheet.
+**Clarification:** Added executable `/// # Examples` doc-tests for `Spreadsheet` and its methods, demonstrating how to construct the necessary relations and perform an evaluation.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,5 @@
+🎸 Bard: Documenting Spreadsheet
+
+📖 Chapter: The `Spreadsheet` experimental module.
+🔦 Insight: The experimental `Spreadsheet` had placeholder examples and missing doc-tests for its struct and methods. It was unclear how to initialize the values and formulas relations, and how to execute the spreadsheet evaluation.
+🧪 Example: Added 3 executable doctests for `Spreadsheet`, `new`, and `evaluate` demonstrating initialization and relational fixpoint evaluation.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -9,6 +9,29 @@ use relvar_core::{
 /// Models a spreadsheet where cells can contain raw values or formulas referencing
 /// other cells. Evaluation is performed purely using relational joins and extensions
 /// until all cell values are resolved (fixpoint).
+///
+/// # Examples
+///
+/// ```
+/// use relvar_core::tuple;
+/// use relvar_core::types::{RelationType, TupleType, ScalarType};
+/// use relvar_core::values::Relation;
+/// use relvar::experimental::spreadsheet::Spreadsheet;
+///
+/// let val_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("val", ScalarType::Float);
+/// let values = Relation::new(RelationType::new(val_heading));
+///
+/// let form_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("op", ScalarType::String)
+///     .with_attribute("arg1", ScalarType::String)
+///     .with_attribute("arg2", ScalarType::String);
+/// let formulas = Relation::new(RelationType::new(form_heading));
+///
+/// let spreadsheet = Spreadsheet { values, formulas };
+/// ```
 pub struct Spreadsheet {
     /// Resolved values. Schema: `(id: String, val: Float)`
     pub values: Relation,
@@ -18,14 +41,32 @@ pub struct Spreadsheet {
 }
 
 impl Spreadsheet {
-    /// Creates a new Spreadsheet.
+    /// Initializes a relational spreadsheet engine by binding the known `values`
+    /// (the initial state) with the declarative `formulas` that define how unknown
+    /// cells are resolved dynamically.
     ///
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar_core::tuple;
+    /// use relvar_core::types::{RelationType, TupleType, ScalarType};
+    /// use relvar_core::values::Relation;
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let formulas = Relation::new(RelationType::new(form_heading));
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -36,9 +77,32 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar_core::tuple;
+    /// use relvar_core::types::{RelationType, TupleType, ScalarType};
+    /// use relvar_core::values::Relation;
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_heading));
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    ///
+    /// assert_eq!(result.cardinality(), 3);
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
🎸 Bard: Documenting Spreadsheet

📖 Chapter: The `Spreadsheet` experimental module.
🔦 Insight: The experimental `Spreadsheet` had placeholder examples and missing doc-tests for its struct and methods. It was unclear how to initialize the values and formulas relations, and how to execute the spreadsheet evaluation.
🧪 Example: Added 3 executable doctests for `Spreadsheet`, `new`, and `evaluate` demonstrating initialization and relational fixpoint evaluation.

---
*PR created automatically by Jules for task [2448262097682089660](https://jules.google.com/task/2448262097682089660) started by @madmax983*