### PR TITLE
⚡ Bolt: Optimize Query::Rename by using `rename_into`

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,5 @@
+⚡ Bolt: rename_into
+💡 What: Switched `Relation::rename` to `Relation::rename_into` in `Query::execute`.
+🎯 Why: In `Query::execute`, the intermediate relation is owned. Using `rename` cloned strings and tuples, while `rename_into` consumes the relation in-place and reuses the old strings if names didn't change.
+📊 Impact: Reduces heap allocations and `.clone()` overhead during query renaming operations.
+🔬 Measurement: Run `cargo test -p relvar-core`.

--- a/relvar-core/src/query/mod.rs
+++ b/relvar-core/src/query/mod.rs
@@ -235,7 +235,10 @@ impl Query {
                     .iter()
                     .map(|(a, b)| (a.as_str(), b.as_str()))
                     .collect();
-                Ok(relation.rename(&mappings_ref))
+                // ⚡ Bolt Optimization: Use `rename_into` to consume the owned intermediate relation.
+                // This avoids O(N) string cloning and heap allocations for attributes that are not
+                // being renamed, by reusing the existing String allocations in the BTreeMap.
+                Ok(relation.rename_into(&mappings_ref))
             }
             Query::Join { left, right } => {
                 let left_rel = left.execute(db)?;


### PR DESCRIPTION
⚡ Bolt: rename_into
💡 What: Switched `Relation::rename` to `Relation::rename_into` in `Query::execute`.
🎯 Why: In `Query::execute`, the intermediate relation is owned. Using `rename` cloned strings and tuples, while `rename_into` consumes the relation in-place and reuses the old strings if names didn't change.
📊 Impact: Reduces heap allocations and `.clone()` overhead during query renaming operations.
🔬 Measurement: Run `cargo test -p relvar-core`.

---
*PR created automatically by Jules for task [16580180149504880201](https://jules.google.com/task/16580180149504880201) started by @madmax983*