### PR TITLE
⚒️ Forge: Refactored calculate_visible_pixels into smaller helpers

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,6 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+## 2026-05-20 - Refactor God Function in Raytracer calculate_visible_pixels
+**Learning:** `relvar/src/experimental/raytracer.rs` contained a "God Function" `calculate_visible_pixels` (68 lines) which combined hit filtering, color mapping (Z-buffer), and background pixel combination. This conflation of logical rendering phases harms readability and testability.
+**Action:** Applied the "Three-Phase Operator" pattern by extracting `filter_hits`, `map_colors`, and `combine_with_background` into separate private helper functions to drastically improve readability and modularity without changing behavior.

--- a/plan.md
+++ b/plan.md
@@ -1,2 +1,0 @@
-1. **Submit the clean audit report.**
-   - Since no active vulnerabilities were found during the investigation of `unsafe` blocks, bounds checking, buffer limits, and data serialization (verifying that they either safely bounded or properly capped), I will submit the PR to confirm the codebase is secure under the given scope.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+⚒️ Forge: Refactored calculate_visible_pixels into smaller helpers
+
+🚮 Smell: `calculate_visible_pixels` was a 68-line God function mixing hit filtering, color mapping, and background combining.
+✨ Solution: Applied the Three-Phase Operator pattern by extracting `filter_hits`, `map_colors`, and `combine_with_background`.
+🧼 Benefit: Improved readability and separation of concerns.
+🛡️ Verification: Tests passed. No logic changed.

--- a/relvar/src/experimental/raytracer.rs
+++ b/relvar/src/experimental/raytracer.rs
@@ -257,17 +257,15 @@ impl Scene {
         Ok(intersections)
     }
 
-    fn calculate_visible_pixels(
-        &self,
-        rays: &Relation,
-        intersections: &Relation,
-    ) -> Result<Relation, DatabaseError> {
+    fn filter_hits(&self, intersections: &Relation) -> Relation {
         // 5. Filter Hits
-        let hits = intersections.restrict(|t| {
+        intersections.restrict(|t| {
             let dist = t.get_typed::<f64>("t").unwrap_or(-1.0);
             dist > 0.0
-        });
+        })
+    }
 
+    fn map_colors(&self, hits: &Relation) -> Result<Relation, DatabaseError> {
         // 6. Find Closest Hits (Z-Buffer)
         // If there are hits, group by (x, y) and find min(t)
         // We use min on 't' to find the closest intersection per ray.
@@ -295,11 +293,19 @@ impl Scene {
         // Note: Multiple spheres could theoretically be exactly at distance t.
         // Set semantics handle duplicates, but we could get multiple colors if
         // different spheres occupy the exact same spot. For a basic raytracer, this is fine.
-        let visible_pixels = closest_renamed.join(&hits)?;
+        let visible_pixels = closest_renamed.join(hits)?;
 
         // Project down to final image attributes
         let rendered_hits = visible_pixels.project(&["x", "y", "r", "g", "b"]);
 
+        Ok(rendered_hits)
+    }
+
+    fn combine_with_background(
+        &self,
+        rays: &Relation,
+        rendered_hits: &Relation,
+    ) -> Result<Relation, DatabaseError> {
         // 8. Background Color
         // Find rays that didn't hit anything: all rays MINUS rays that hit something
         let all_pixels = rays.project(&["x", "y"]);
@@ -319,11 +325,19 @@ impl Scene {
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
         // Combine hits and background
-        let final_image = rendered_hits
+        rendered_hits
             .union(&background_colored)
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
 
-        Ok(final_image)
+    fn calculate_visible_pixels(
+        &self,
+        rays: &Relation,
+        intersections: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        let hits = self.filter_hits(intersections);
+        let rendered_hits = self.map_colors(&hits)?;
+        self.combine_with_background(rays, &rendered_hits)
     }
 
     /// Renders the scene to a relation of pixels.


### PR DESCRIPTION
⚒️ Forge: Refactored calculate_visible_pixels into smaller helpers

🚮 Smell: `calculate_visible_pixels` was a 68-line God function mixing hit filtering, color mapping, and background combining.
✨ Solution: Applied the Three-Phase Operator pattern by extracting `filter_hits`, `map_colors`, and `combine_with_background`.
🧼 Benefit: Improved readability and separation of concerns.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [6470792973483361480](https://jules.google.com/task/6470792973483361480) started by @madmax983*