### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -33,3 +33,6 @@
 ## 2025-05-06 - [The Ghost Knowledge Graph]
 **Confusion:** The experimental `KnowledgeGraph` module was completely undocumented, leaving users to guess how it connects to the relational model.
 **Clarification:** Wrote comprehensive module-level documentation and executable doctests for `KnowledgeGraph` and `TriplePattern` explaining the "Relational Semantic Web" concept.
+## 2025-05-20 - The "Spreadsheet" Examples
+**Confusion:** The experimental `Spreadsheet` module had placeholder examples and missing doc-tests for the main struct and its methods (`new` and `evaluate`). This lack of examples made it confusing to understand how to initialize the values and formulas relations, and how the fixpoint evaluation resolves formulas.
+**Clarification:** Added executable `/// # Examples` doc-tests for `Spreadsheet`, `Spreadsheet::new`, and `Spreadsheet::evaluate`, demonstrating how to construct the necessary relations, insert initial data, and run the evaluation to completion.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🎻 Bard: [documentation update]
+
+📖 Chapter: The `Spreadsheet` module.
+🔦 Insight: Clarified how to initialize a relational spreadsheet and evaluate formulas to a fixpoint by replacing placeholder examples with actual working code.
+🧪 Example: Added 3 executable doctests for `Spreadsheet`, `Spreadsheet::new`, and `Spreadsheet::evaluate`.
+🖼️ Preview: Docs successfully generated with executable examples.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -9,6 +9,27 @@ use relvar_core::{
 /// Models a spreadsheet where cells can contain raw values or formulas referencing
 /// other cells. Evaluation is performed purely using relational joins and extensions
 /// until all cell values are resolved (fixpoint).
+///
+/// # Examples
+///
+/// ```
+/// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
+/// use relvar::experimental::spreadsheet::Spreadsheet;
+///
+/// let val_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("val", ScalarType::Float);
+/// let mut values = Relation::new(RelationType::new(val_heading));
+///
+/// let form_heading = TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("op", ScalarType::String)
+///     .with_attribute("arg1", ScalarType::String)
+///     .with_attribute("arg2", ScalarType::String);
+/// let mut formulas = Relation::new(RelationType::new(form_heading));
+///
+/// let spreadsheet = Spreadsheet::new(values, formulas);
+/// ```
 pub struct Spreadsheet {
     /// Resolved values. Schema: `(id: String, val: Float)`
     pub values: Relation,
@@ -25,7 +46,20 @@ impl Spreadsheet {
     /// ```
     /// use relvar::{Relation, RelationType, ScalarType, TupleType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let values = Relation::new(RelationType::new(val_heading));
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let formulas = Relation::new(RelationType::new(form_heading));
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -36,9 +70,31 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading.clone()));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_heading));
+    /// // B1 = A1 + A2
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    ///
+    /// assert_eq!(result.cardinality(), 3); // A1, A2, and B1
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
🎻 Bard: [documentation update]

📖 Chapter: The `Spreadsheet` module.
🔦 Insight: Clarified how to initialize a relational spreadsheet and evaluate formulas to a fixpoint by replacing placeholder examples with actual working code.
🧪 Example: Added 3 executable doctests for `Spreadsheet`, `Spreadsheet::new`, and `Spreadsheet::evaluate`.
🖼️ Preview: Docs successfully generated with executable examples.

---
*PR created automatically by Jules for task [9227754965519809498](https://jules.google.com/task/9227754965519809498) started by @madmax983*