### PR TITLE
🗺️ Atlas: [Test Module Encapsulation]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -27,3 +27,6 @@
 ## 2024-05-19 - Fixing Public Module Leaks
 **Tangle:** Broad visibility (`pub mod`) across many test and internal modules leaked implementation details and complicated the dependency graph.
 **Blueprint:** Converted most top-level internal module definitions in `relvar-core` and `relvar-storage` and `relvar` to `pub(crate) mod` where appropriate, and fixed some lingering pub use statements.
+## 2024-05-24 - Test Module Encapsulation
+**Tangle:** Internal test sub-modules exposed via pub mod.
+**Blueprint:** Changed to pub(crate) mod to enforce boundaries.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🗺️ Atlas: [Test Module Encapsulation]
+
+🕸️ Tangle: Internal test sub-modules (`basic` and `common` in `relvar-core/src/query/tests/mod.rs`) were exposed via `pub mod`, leaking test implementation details.
+📐 Blueprint: Changed the visibility of these modules to `pub(crate) mod` to enforce strict module boundaries and prevent test leakage.
+🧱 Stability: Strict separation enforced, keeping internal test structures completely hidden.
+🔬 Verification: `cargo test` and `cargo doc` passed without issue, ensuring nothing in the rest of the workspace relied on this leaked API.

--- a/relvar-core/src/query/tests/mod.rs
+++ b/relvar-core/src/query/tests/mod.rs
@@ -1,2 +1,2 @@
-pub mod basic;
-pub mod common;
+pub(crate) mod basic;
+pub(crate) mod common;


### PR DESCRIPTION
🗺️ Atlas: [Test Module Encapsulation]

🕸️ Tangle: Internal test sub-modules (`basic` and `common` in `relvar-core/src/query/tests/mod.rs`) were exposed via `pub mod`, leaking test implementation details.
📐 Blueprint: Changed the visibility of these modules to `pub(crate) mod` to enforce strict module boundaries and prevent test leakage.
🧱 Stability: Strict separation enforced, keeping internal test structures completely hidden.
🔬 Verification: `cargo test` and `cargo doc` passed without issue, ensuring nothing in the rest of the workspace relied on this leaked API.

---
*PR created automatically by Jules for task [2649560201491661539](https://jules.google.com/task/2649560201491661539) started by @madmax983*