### PR TITLE
⚒️ Forge: [Refactor] Extract calculate_ungrouped_capacity helper

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,7 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+
+## 2024-06-25 - Extract calculate_ungrouped_capacity helper
+**Learning:** `compute_ungrouped_tuples` in `relvar-core/src/algebra/group.rs` was becoming a God Function (over 50 lines), handling both the initial capacity pre-calculation pass and the nested tuple generation logic.
+**Action:** Extracted the capacity calculation into a new private helper function `calculate_ungrouped_capacity`. This reduces cognitive load and flattens the execution flow.

--- a/relvar-core/src/algebra/group.rs
+++ b/relvar-core/src/algebra/group.rs
@@ -412,14 +412,10 @@ fn build_ungroup_result_heading(
     Ok(result_heading)
 }
 
-fn compute_ungrouped_tuples(
+fn calculate_ungrouped_capacity(
     relation: &Relation,
     rva_name: &str,
-    result_heading: &TupleType,
-    _rva_relation_type: &RelationType,
-) -> Result<std::collections::HashSet<Tuple>, UngroupError> {
-    // Perform an initial pass to sum the cardinality of the target RVAs
-    // to pre-allocate the exact needed capacity, avoiding dynamic heap reallocations.
+) -> Result<usize, UngroupError> {
     let mut total_capacity = 0;
     for tuple in relation.tuples() {
         let val = tuple
@@ -430,6 +426,18 @@ fn compute_ungrouped_tuples(
             _ => return Err(UngroupError::NotRelationValued(rva_name.to_string())),
         }
     }
+    Ok(total_capacity)
+}
+
+fn compute_ungrouped_tuples(
+    relation: &Relation,
+    rva_name: &str,
+    result_heading: &TupleType,
+    _rva_relation_type: &RelationType,
+) -> Result<std::collections::HashSet<Tuple>, UngroupError> {
+    // Perform an initial pass to sum the cardinality of the target RVAs
+    // to pre-allocate the exact needed capacity, avoiding dynamic heap reallocations.
+    let total_capacity = calculate_ungrouped_capacity(relation, rva_name)?;
     let mut result_tuples = std::collections::HashSet::with_capacity(total_capacity);
     let result_heading_arc = std::sync::Arc::new(result_heading.clone());
 


### PR DESCRIPTION
🚮 Smell: `compute_ungrouped_tuples` in `relvar-core/src/algebra/group.rs` was becoming a God Function (over 50 lines), handling both the initial capacity pre-calculation pass and the nested tuple generation logic.
✨ Solution: Extracted the capacity calculation into a new private helper function `calculate_ungrouped_capacity`.
🧼 Benefit: Reduces cognitive load and flattens the execution flow within `compute_ungrouped_tuples`.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [14406374493893966362](https://jules.google.com/task/14406374493893966362) started by @madmax983*