### PR TITLE
🪒 Razor: Remove unused dead code functions

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -21,3 +21,8 @@
 **Bloat:** Single-variant enum `RelationError` in `relvar-core/src/values/relation.rs` acting as a unit struct, with an unused variant `DuplicateTuple` and only one used variant `TypeMismatch`.
 **Cut:** Converted to unit struct `pub struct RelationError;` with `#[error("Tuple does not conform to relation type")]` directly. Removed the unused `DuplicateTuple` variant.
 **Saved:** Unnecessary enum matching, simplified error handling code significantly.
+
+## [Reduction]
+**Bloat:** Unused dead code functions `as_candidate_key`, `remove_component`, and `forward_pass`.
+**Cut:** Deleted the dead code.
+**Saved:** 40 lines of code.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,5 @@
+🪒 Razor: Remove unused dead code functions
+
+**Bloat:** Unused public functions `as_candidate_key`, `remove_component`, and `forward_pass`.
+**Cut:** Deleted the dead code.
+**Saved:** 40 lines of code.

--- a/relvar-core/src/constraints/key.rs
+++ b/relvar-core/src/constraints/key.rs
@@ -247,17 +247,6 @@ impl PrimaryKey {
         self.key.attributes()
     }
 
-    /// Get the underlying candidate key
-    ///
-    /// # Examples
-    ///
-    /// ```text
-    /// // Example
-    /// ```
-    pub fn as_candidate_key(&self) -> &CandidateKey {
-        &self.key
-    }
-
     /// Check if this key is satisfied by a relation
     ///
     /// # Examples

--- a/relvar/src/experimental/ecs.rs
+++ b/relvar/src/experimental/ecs.rs
@@ -201,31 +201,6 @@ impl<E: StorageEngine> World<E> {
         self.db.insert(&rel_name, new_tuple)
     }
 
-    /// Removes a component from a specific entity.
-    ///
-    /// This deletes the entity's data for this component from the underlying relation.
-    ///
-    /// # Errors
-    ///
-    /// Yields a `DatabaseError` if the underlying database delete operation fails.
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar::{Database, InMemoryEngine};
-    /// // Note: This is a placeholder example
-    /// ```
-    pub fn remove_component(
-        &mut self,
-        entity: Entity,
-        component_name: &str,
-    ) -> Result<(), DatabaseError> {
-        let rel_name = self.component_rel_name(component_name);
-        self.db.delete(&rel_name, |t| {
-            t.get_typed::<Entity>(ENTITY_ID_ATTR) == Some(entity)
-        })?;
-        Ok(())
-    }
-
     /// Obtains the component data for a specific entity.
     ///
     /// # Errors

--- a/relvar/src/experimental/neural_network.rs
+++ b/relvar/src/experimental/neural_network.rs
@@ -137,24 +137,6 @@ impl NeuralNetwork {
         Ok(())
     }
 
-    /// Computes the full forward pass through all layers.
-    ///
-    /// # Arguments
-    ///
-    /// * `num_layers` - The total number of layers to process.
-    /// # Examples
-    ///
-    /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
-    /// // Note: This is a placeholder example
-    /// ```
-    pub fn forward_pass(&mut self, num_layers: i64) -> Result<(), DatabaseError> {
-        for i in 0..num_layers {
-            self.forward_layer(i)?;
-        }
-        Ok(())
-    }
-
     /// Retrieves the activations for a specific layer.
     /// # Examples
     ///


### PR DESCRIPTION
🪒 Razor: Remove unused dead code functions

**Bloat:** Unused public functions `as_candidate_key`, `remove_component`, and `forward_pass`.
**Cut:** Deleted the dead code.
**Saved:** 40 lines of code.

---
*PR created automatically by Jules for task [5457092395791145411](https://jules.google.com/task/5457092395791145411) started by @madmax983*