### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,2 +1,18 @@
-1. **Submit the clean audit report.**
-   - Since no active vulnerabilities were found during the investigation of `unsafe` blocks, bounds checking, buffer limits, and data serialization (verifying that they either safely bounded or properly capped), I will submit the PR to confirm the codebase is secure under the given scope.
+1. **Document `Spreadsheet` in `relvar/src/experimental/spreadsheet.rs`**
+   - Use `replace_with_git_merge_diff` to add module level `//!` docs at the top of the file, explaining the spreadsheet engine concept, and also to add `## Examples` doc-tests on the `Spreadsheet` struct and its methods `new` and `evaluate` replacing the placeholder comments with actual working examples that show creating relations and evaluating a formula.
+
+2. **Verify changes**
+   - Execute `run_in_bash_session` with `cargo test`
+   - Execute `run_in_bash_session` with `cargo fmt --all`
+   - Execute `run_in_bash_session` with `cargo clippy --all-targets --all-features -- -D warnings`
+   - Execute `run_in_bash_session` with `cargo check`
+   - Execute `run_in_bash_session` with `cargo doc --open`
+
+3. **Create PR description**
+   - Create `pr_description.md` using `run_in_bash_session` to run `cat << 'EOF' > pr_description.md` with the PR title and description format.
+
+4. **Pre-commit checks**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+
+5. **Submit PR**
+   - Run `pr.py` to create a PR.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🎻 Bard: [documentation update]
+
+📖 Chapter: The `Spreadsheet` module and struct in experimental features
+🔦 Insight: Explained the relational spreadsheet engine concept, documented struct, new, and evaluate.
+🧪 Example: Added 3 executable doctests.
+🖼️ Preview: (Ran cargo doc --open locally)

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -1,3 +1,18 @@
+//! Relational Spreadsheet Engine
+//!
+//! This module provides an experimental `Spreadsheet` engine that evaluates formulas
+//! using pure relational algebra. It solves formula dependencies by computing a
+//! fixpoint over relation extensions and joins, avoiding explicit dependency graphs.
+//!
+//! # Concepts
+//!
+//! A spreadsheet is represented by two relations:
+//! 1. `values`: Contains the resolved cells (`id`, `val`).
+//! 2. `formulas`: Contains unresolved computations (`id`, `op`, `arg1`, `arg2`).
+//!
+//! Evaluation iteratively joins resolved values with formulas until no new values
+//! can be computed.
+
 use relvar_core::{
     error::DatabaseError,
     types::ScalarType,
@@ -9,6 +24,36 @@ use relvar_core::{
 /// Models a spreadsheet where cells can contain raw values or formulas referencing
 /// other cells. Evaluation is performed purely using relational joins and extensions
 /// until all cell values are resolved (fixpoint).
+///
+/// # Examples
+///
+/// ```
+/// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
+/// use relvar::experimental::spreadsheet::Spreadsheet;
+///
+/// // Create values relation
+/// let mut values = Relation::new(RelationType::new(
+///     TupleType::new().with_attribute("id", ScalarType::String)
+///                     .with_attribute("val", ScalarType::Float)
+/// ));
+/// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+///
+/// // Create formulas relation
+/// let mut formulas = Relation::new(RelationType::new(
+///     TupleType::new().with_attribute("id", ScalarType::String)
+///                     .with_attribute("op", ScalarType::String)
+///                     .with_attribute("arg1", ScalarType::String)
+///                     .with_attribute("arg2", ScalarType::String)
+/// ));
+/// formulas.insert(tuple! {
+///     id: "B1".to_string(), op: "ADD".to_string(),
+///     arg1: "A1".to_string(), arg2: "A1".to_string()
+/// }).unwrap();
+///
+/// let spreadsheet = Spreadsheet::new(values, formulas);
+/// let result = spreadsheet.evaluate().unwrap();
+/// assert_eq!(result.cardinality(), 2);
+/// ```
 pub struct Spreadsheet {
     /// Resolved values. Schema: `(id: String, val: Float)`
     pub values: Relation,
@@ -25,7 +70,18 @@ impl Spreadsheet {
     /// ```
     /// use relvar::{Relation, RelationType, ScalarType, TupleType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let values = Relation::new(RelationType::new(
+    ///     TupleType::new().with_attribute("id", ScalarType::String)
+    ///                     .with_attribute("val", ScalarType::Float)
+    /// ));
+    /// let formulas = Relation::new(RelationType::new(
+    ///     TupleType::new().with_attribute("id", ScalarType::String)
+    ///                     .with_attribute("op", ScalarType::String)
+    ///                     .with_attribute("arg1", ScalarType::String)
+    ///                     .with_attribute("arg2", ScalarType::String)
+    /// ));
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -33,12 +89,43 @@ impl Spreadsheet {
 
     /// Evaluates the spreadsheet until all possible formulas are resolved.
     ///
+    /// Returns a new [`Relation`] containing both the initially resolved values
+    /// and all newly computed values from the formulas.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `DatabaseError` if underlying relational algebra operations fail
+    /// (e.g., incompatible schemas during join or extension).
+    ///
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{Relation, RelationType, ScalarType, TupleType, tuple};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let mut values = Relation::new(RelationType::new(
+    ///     TupleType::new().with_attribute("id", ScalarType::String)
+    ///                     .with_attribute("val", ScalarType::Float)
+    /// ));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 100.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 200.0f64 }).unwrap();
+    ///
+    /// let mut formulas = Relation::new(RelationType::new(
+    ///     TupleType::new().with_attribute("id", ScalarType::String)
+    ///                     .with_attribute("op", ScalarType::String)
+    ///                     .with_attribute("arg1", ScalarType::String)
+    ///                     .with_attribute("arg2", ScalarType::String)
+    /// ));
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(),
+    ///     arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    ///
+    /// // The result contains A1, A2, and the new B1 (100 + 200 = 300)
+    /// assert_eq!(result.cardinality(), 3);
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
📖 Chapter: The `Spreadsheet` module and struct in experimental features
🔦 Insight: Explained the relational spreadsheet engine concept, documented struct, new, and evaluate.
🧪 Example: Added 3 executable doctests.
🖼️ Preview: (Ran cargo doc --open locally)

---
*PR created automatically by Jules for task [18397243308600858188](https://jules.google.com/task/18397243308600858188) started by @madmax983*