### PR TITLE
🔒 Warden: [security fix] anyhow RUSTSEC-2026-0190

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -9,3 +9,7 @@
 ## 2026-04-24 - [Unsafe unwrap in StorageManager]
 **Threat:** Potential panic and crash if `get_or_open_heap_file` fails to retrieve or map a file correctly, resulting in an unhandled `.unwrap()` failure.
 **Defense:** Replaced `.unwrap()` with `HashMap::entry` to ensure safe, graceful error propagation rather than crashing the system without unreachable branches.
+
+## 2026-06-29 - [Update anyhow for RUSTSEC-2026-0190]
+**Threat:** Unsoundness in `Error::downcast_mut()` in `anyhow` version 1.0.102.
+**Defense:** Updated `anyhow` to 1.0.103.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🔒 Warden: [security fix] anyhow RUSTSEC-2026-0190
+
+🦠 Threat: Unsoundness in `Error::downcast_mut()` in `anyhow` crate version 1.0.102 (RUSTSEC-2026-0190).
+🛡️ Defense: Updated `anyhow` crate to 1.0.103 in Cargo.lock.
+💥 Severity: High - Unsoundness in a widely used error handling library could lead to undefined behavior or memory safety issues.
+🧪 Verification: Confirmed with `cargo audit` that no vulnerabilities remain.


### PR DESCRIPTION
🔒 Warden: [security fix] anyhow RUSTSEC-2026-0190

🦠 Threat: Unsoundness in `Error::downcast_mut()` in `anyhow` crate version 1.0.102 (RUSTSEC-2026-0190).
🛡️ Defense: Updated `anyhow` crate to 1.0.103 in Cargo.lock.
💥 Severity: High - Unsoundness in a widely used error handling library could lead to undefined behavior or memory safety issues.
🧪 Verification: Confirmed with `cargo audit` that no vulnerabilities remain.

---
*PR created automatically by Jules for task [12499301663073324893](https://jules.google.com/task/12499301663073324893) started by @madmax983*