### PR TITLE
⚒️ Forge: Refactor God Function in Physics Engine

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,7 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+
+## 2026-06-30 - Refactor God Function in Physics Engine
+**Learning:** `relvar/src/experimental/physics.rs` contained a "God Function" `compute_pairwise_forces` (81 lines) which combined particle pair generation, self-interaction filtering, and mathematical gravity computation.
+**Action:** Applied the "Three-Phase Operator" pattern by extracting `generate_particle_pairs`, `filter_self_interactions`, and `calculate_pairwise_gravity` into separate helper functions. This drastically improved code clarity and structure.

--- a/relvar/src/experimental/physics.rs
+++ b/relvar/src/experimental/physics.rs
@@ -59,6 +59,12 @@ impl PhysicsEngine {
     }
 
     fn compute_pairwise_forces(&self) -> Result<Relation, DatabaseError> {
+        let pairs = self.generate_particle_pairs()?;
+        let interactions = self.filter_self_interactions(&pairs);
+        self.calculate_pairwise_gravity(&interactions)
+    }
+
+    fn generate_particle_pairs(&self) -> Result<Relation, DatabaseError> {
         // 1. Cross join particles with themselves to compute pairwise forces.
         // Rename attributes to distinguish particle 1 and particle 2.
         let p1 = self.particles.rename(&[
@@ -79,15 +85,22 @@ impl PhysicsEngine {
             ("mass", "m2"),
         ]);
 
-        let pairs = p1.join(&p2)?;
+        p1.join(&p2)
+    }
 
+    fn filter_self_interactions(&self, pairs: &Relation) -> Relation {
         // 2. Filter out self-interactions (id1 == id2)
-        let interactions = pairs.restrict(|t| {
+        pairs.restrict(|t| {
             let id1 = t.get_typed::<i64>("id1").unwrap();
             let id2 = t.get_typed::<i64>("id2").unwrap();
             id1 != id2
-        });
+        })
+    }
 
+    fn calculate_pairwise_gravity(
+        &self,
+        interactions: &Relation,
+    ) -> Result<Relation, DatabaseError> {
         // 3. Compute forces for each pair
         let g = self.g;
         interactions


### PR DESCRIPTION
⚒️ Forge: Refactor God Function in Physics Engine

🚮 Smell: The `compute_pairwise_forces` method in `physics.rs` was an 81-line "God Function" that combined cross-joining relations, filtering out self-interactions, and performing the mathematical calculations for gravitational force. This mixed relational operations with procedural logic, hurting readability.
✨ Solution: Applied the "Three-Phase Operator" pattern. Extracted the logic into three descriptive helper functions: `generate_particle_pairs`, `filter_self_interactions`, and `calculate_pairwise_gravity`.
🧼 Benefit: Significantly flattens the main algorithm, isolates concerns, and improves overall code readability without changing any behavior.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [3492516026474508959](https://jules.google.com/task/3492516026474508959) started by @madmax983*