### PR TITLE
🎻 Bard: [document Spreadsheet examples]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -33,3 +33,6 @@
 ## 2025-05-06 - [The Ghost Knowledge Graph]
 **Confusion:** The experimental `KnowledgeGraph` module was completely undocumented, leaving users to guess how it connects to the relational model.
 **Clarification:** Wrote comprehensive module-level documentation and executable doctests for `KnowledgeGraph` and `TriplePattern` explaining the "Relational Semantic Web" concept.
+## 2025-06-30 - The "Spreadsheet" Examples
+**Confusion:** The experimental `Spreadsheet` module had placeholder examples and lacked executable doc-tests for the struct and its methods (`new` and `evaluate`), making it confusing to understand how to model a spreadsheet with relational values and formulas.
+**Clarification:** Added executable `/// # Examples` doc-tests for `Spreadsheet` and its methods to clearly demonstrate how to construct the initial cell values and formula relations, and how they resolve via relational fixed-point evaluation.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🎻 Bard: [document Spreadsheet examples]
+
+📖 Chapter: The `Spreadsheet` module.
+🔦 Insight: Clarified how relational algebraic operations can be used to model and evaluate spreadsheet formulas dynamically.
+🧪 Example: Added 3 executable doctests for `Spreadsheet`, `Spreadsheet::new`, and `Spreadsheet::evaluate`.
+🖼️ Preview: Documentation is now fully executable and visually engaging.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -9,6 +9,29 @@ use relvar_core::{
 /// Models a spreadsheet where cells can contain raw values or formulas referencing
 /// other cells. Evaluation is performed purely using relational joins and extensions
 /// until all cell values are resolved (fixpoint).
+///
+/// # Examples
+///
+/// ```
+/// use relvar::{tuple, Relation, RelationType, TupleType, ScalarType};
+/// use relvar::experimental::spreadsheet::Spreadsheet;
+///
+/// let mut values = Relation::new(RelationType::new(TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("val", ScalarType::Float)));
+/// values.insert(tuple!{ id: "A1".to_string(), val: 10.0f64 }).unwrap();
+///
+/// let mut formulas = Relation::new(RelationType::new(TupleType::new()
+///     .with_attribute("id", ScalarType::String)
+///     .with_attribute("op", ScalarType::String)
+///     .with_attribute("arg1", ScalarType::String)
+///     .with_attribute("arg2", ScalarType::String)));
+/// formulas.insert(tuple!{
+///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A1".to_string()
+/// }).unwrap();
+///
+/// let spreadsheet = Spreadsheet { values, formulas };
+/// ```
 pub struct Spreadsheet {
     /// Resolved values. Schema: `(id: String, val: Float)`
     pub values: Relation,
@@ -23,9 +46,19 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{Relation, RelationType, TupleType, ScalarType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let values = Relation::new(RelationType::new(TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float)));
+    /// let formulas = Relation::new(RelationType::new(TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String)));
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -36,9 +69,27 @@ impl Spreadsheet {
     /// # Examples
     ///
     /// ```
-    /// use relvar::{Relation, RelationType, ScalarType, TupleType};
+    /// use relvar::{tuple, Relation, RelationType, TupleType, ScalarType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let mut values = Relation::new(RelationType::new(TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float)));
+    /// values.insert(tuple!{ id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple!{ id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let mut formulas = Relation::new(RelationType::new(TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String)));
+    /// formulas.insert(tuple!{
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    /// assert_eq!(result.cardinality(), 3);
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
🎻 Bard: [document Spreadsheet examples]

📖 Chapter: The `Spreadsheet` module.
🔦 Insight: Clarified how relational algebraic operations can be used to model and evaluate spreadsheet formulas dynamically.
🧪 Example: Added 3 executable doctests for `Spreadsheet`, `Spreadsheet::new`, and `Spreadsheet::evaluate`.
🖼️ Preview: Documentation is now fully executable and visually engaging.

---
*PR created automatically by Jules for task [14289916619096498322](https://jules.google.com/task/14289916619096498322) started by @madmax983*