### PR TITLE
⚒️ Forge: Extract God Functions in Raytracer

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -631,3 +631,7 @@ Build it right, make it fast, keep it simple.
 ## 2023-10-27 - Refactoring God Function `to_dot` in `SchemaVisualizer`
 **Learning:** The `to_dot` method for the `SchemaVisualizer` contained too much inline logic mapping schemas to dot graphs (Nodes and Edges), classifying as a "God Function", harming readability and testing.
 **Action:** Extract the Nodes and Edges mappings logic into separate `generate_nodes` and `generate_edges` private helpers inside the `SchemaVisualizer` struct, accepting `&mut String` to maintain efficiency.
+
+## 2024-07-01 - Extract God Functions in Raytracer
+**Learning:** `relvar/src/experimental/raytracer.rs` contained "God Functions" `compute_intersections` (67 lines) and `calculate_visible_pixels` (68 lines) which combined preparing relations, joining, extending, summarizing, and differencing. This mixed relational operations with math logic, harming readability.
+**Action:** Applied the "Three-Phase Operator" pattern by extracting their logic into private helper functions (`prepare_spheres`, `calculate_intersection_distances`, `filter_hits`, `find_closest_hits`, `map_colors`, and `apply_background`) to dramatically improve clarity without changing behavior.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,9 @@
+⚒️ Forge: Extract God Functions in Raytracer
+
+🚮 Smell: The `compute_intersections` and `calculate_visible_pixels` functions in `relvar/src/experimental/raytracer.rs` were long "God Functions" (over 65 lines each). They mixed multiple steps of relational operations (cross join, math calculations for distances, filtering hits, z-buffer logic, and background colors) into massive blocks of code, making them difficult to follow.
+
+✨ Solution: Refactored these functions by applying the "Three-Phase Operator" pattern. Extracted logical phases into focused, private helper functions: `prepare_spheres`, `calculate_intersection_distances`, `filter_hits`, `find_closest_hits`, `map_colors`, and `apply_background`.
+
+🧼 Benefit: Flattens the execution flow of the main methods. Each helper function now clearly states its relational intent and handles a specific phase, drastically reducing cognitive load and improving readability without altering runtime behavior.
+
+🛡️ Verification: Tests passed. No logic changed.

--- a/relvar/src/experimental/raytracer.rs
+++ b/relvar/src/experimental/raytracer.rs
@@ -190,28 +190,22 @@ impl Scene {
     }
 
     fn compute_intersections(&self, rays: &Relation) -> Result<Relation, DatabaseError> {
-        // 2. Prepare Spheres for Cross Join
-        // We use extend to add `dummy_join: 1` so natural join acts as a cross join.
-        let spheres_prepared = self
-            .spheres
-            .extend("dummy_join", ScalarType::Int, |_| ScalarValue::Int(1))
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-        // 3. Cross Join: All rays against all spheres
+        let spheres_prepared = self.prepare_spheres()?;
         let combinations = rays.join(&spheres_prepared)?;
+        self.calculate_intersection_distances(&combinations)
+    }
 
-        // 4. Calculate Intersections
-        // Mathematical derivation:
-        // Ray: P(t) = O + t*D
-        // Sphere: (P - C) \cdot (P - C) = r^2
-        // Subbing P(t) into Sphere equation gives:
-        // (D \cdot D)*t^2 + 2*(D \cdot (O - C))*t + (O - C) \cdot (O - C) - r^2 = 0
-        //
-        // Let a = D \cdot D (which is 1 since D is normalized)
-        // Let half_b = D \cdot (O - C)
-        // Let c = (O - C) \cdot (O - C) - r^2
-        // discriminant = half_b^2 - a*c
-        let intersections = combinations
+    fn prepare_spheres(&self) -> Result<Relation, DatabaseError> {
+        self.spheres
+            .extend("dummy_join", ScalarType::Int, |_| ScalarValue::Int(1))
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
+    }
+
+    fn calculate_intersection_distances(
+        &self,
+        combinations: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        combinations
             .extend("t", ScalarType::Float, |tup| {
                 let ox = tup.get_typed::<f64>("ox").unwrap_or(0.0);
                 let oy = tup.get_typed::<f64>("oy").unwrap_or(0.0);
@@ -252,9 +246,7 @@ impl Scene {
                     }
                 }
             })
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-        Ok(intersections)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
     }
 
     fn calculate_visible_pixels(
@@ -262,15 +254,20 @@ impl Scene {
         rays: &Relation,
         intersections: &Relation,
     ) -> Result<Relation, DatabaseError> {
-        // 5. Filter Hits
-        let hits = intersections.restrict(|t| {
+        let hits = self.filter_hits(intersections);
+        let closest_hits = self.find_closest_hits(&hits)?;
+        let rendered_hits = self.map_colors(&closest_hits, &hits)?;
+        self.apply_background(rays, &rendered_hits)
+    }
+
+    fn filter_hits(&self, intersections: &Relation) -> Relation {
+        intersections.restrict(|t| {
             let dist = t.get_typed::<f64>("t").unwrap_or(-1.0);
             dist > 0.0
-        });
+        })
+    }
 
-        // 6. Find Closest Hits (Z-Buffer)
-        // If there are hits, group by (x, y) and find min(t)
-        // We use min on 't' to find the closest intersection per ray.
+    fn find_closest_hits(&self, hits: &Relation) -> Result<Relation, DatabaseError> {
         let mut closest_hits_base = Relation::new(RelationType::new(
             TupleType::new()
                 .with_attribute("x", ScalarType::Int)
@@ -287,21 +284,24 @@ impl Scene {
                 .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
         }
 
-        // 7. Map Colors
-        // Rename min_t to t in closest_hits to natural join it back with hits.
-        // This acts like an INNER JOIN hits h ON h.x=c.x AND h.y=c.y AND h.t=c.min_t
-        let closest_renamed = closest_hits_base.rename(&[("min_t", "t")]);
+        Ok(closest_hits_base)
+    }
 
-        // Note: Multiple spheres could theoretically be exactly at distance t.
-        // Set semantics handle duplicates, but we could get multiple colors if
-        // different spheres occupy the exact same spot. For a basic raytracer, this is fine.
-        let visible_pixels = closest_renamed.join(&hits)?;
+    fn map_colors(
+        &self,
+        closest_hits: &Relation,
+        hits: &Relation,
+    ) -> Result<Relation, DatabaseError> {
+        let closest_renamed = closest_hits.rename(&[("min_t", "t")]);
+        let visible_pixels = closest_renamed.join(hits)?;
+        Ok(visible_pixels.project(&["x", "y", "r", "g", "b"]))
+    }
 
-        // Project down to final image attributes
-        let rendered_hits = visible_pixels.project(&["x", "y", "r", "g", "b"]);
-
-        // 8. Background Color
-        // Find rays that didn't hit anything: all rays MINUS rays that hit something
+    fn apply_background(
+        &self,
+        rays: &Relation,
+        rendered_hits: &Relation,
+    ) -> Result<Relation, DatabaseError> {
         let all_pixels = rays.project(&["x", "y"]);
         let hit_pixels = rendered_hits.project(&["x", "y"]);
 
@@ -309,7 +309,6 @@ impl Scene {
             .difference(&hit_pixels)
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
-        // Extend background with default sky blue color (135, 206, 235)
         let background_colored = background_pixels
             .extend("r", ScalarType::Int, |_| ScalarValue::Int(135))
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?
@@ -318,12 +317,9 @@ impl Scene {
             .extend("b", ScalarType::Int, |_| ScalarValue::Int(235))
             .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
-        // Combine hits and background
-        let final_image = rendered_hits
+        rendered_hits
             .union(&background_colored)
-            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
-
-        Ok(final_image)
+            .map_err(|e| DatabaseError::AlgebraError(e.to_string()))
     }
 
     /// Renders the scene to a relation of pixels.


### PR DESCRIPTION
⚒️ Forge: Extract God Functions in Raytracer

🚮 Smell: The `compute_intersections` and `calculate_visible_pixels` functions in `relvar/src/experimental/raytracer.rs` were long "God Functions" (over 65 lines each). They mixed multiple steps of relational operations (cross join, math calculations for distances, filtering hits, z-buffer logic, and background colors) into massive blocks of code, making them difficult to follow.

✨ Solution: Refactored these functions by applying the "Three-Phase Operator" pattern. Extracted logical phases into focused, private helper functions: `prepare_spheres`, `calculate_intersection_distances`, `filter_hits`, `find_closest_hits`, `map_colors`, and `apply_background`. 

🧼 Benefit: Flattens the execution flow of the main methods. Each helper function now clearly states its relational intent and handles a specific phase, drastically reducing cognitive load and improving readability without altering runtime behavior.

🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [3447300279805784211](https://jules.google.com/task/3447300279805784211) started by @madmax983*