### PR TITLE
🗺️ Atlas: [fix query test module boundary]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -27,3 +27,7 @@
 ## 2024-05-19 - Fixing Public Module Leaks
 **Tangle:** Broad visibility (`pub mod`) across many test and internal modules leaked implementation details and complicated the dependency graph.
 **Blueprint:** Converted most top-level internal module definitions in `relvar-core` and `relvar-storage` and `relvar` to `pub(crate) mod` where appropriate, and fixed some lingering pub use statements.
+
+## 2024-05-19 - Fixing Public Query Test Module Leaks
+**Tangle:** The `relvar-core/src/query/tests/mod.rs` file was exposing its sub-modules (`basic` and `common`) publicly via `pub mod`, leaking test implementation details.
+**Blueprint:** Changed the sub-module declarations from `pub mod` to private `mod` in `relvar-core/src/query/tests/mod.rs` to enforce strict module boundaries and prevent test details from leaking.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🗺️ Atlas: [fix query test module boundary]
+
+🕸️ Tangle: The `relvar-core/src/query/tests/mod.rs` file was exposing its sub-modules publicly via `pub mod`, which leaked test implementation details.
+📐 Blueprint: Converted the sub-module declarations from `pub mod` to private `mod` in `relvar-core/src/query/tests/mod.rs` to enforce proper module boundaries.
+🧱 Stability: Prevented test internals from leaking, ensuring strict module encapsulation.
+🔬 Verification: `cargo test` and `cargo check` pass successfully.

--- a/relvar-core/src/query/tests/mod.rs
+++ b/relvar-core/src/query/tests/mod.rs
@@ -1,2 +1,2 @@
-pub mod basic;
-pub mod common;
+mod basic;
+mod common;


### PR DESCRIPTION
🗺️ Atlas: [fix query test module boundary]

🕸️ Tangle: The `relvar-core/src/query/tests/mod.rs` file was exposing its sub-modules publicly via `pub mod`, which leaked test implementation details.
📐 Blueprint: Converted the sub-module declarations from `pub mod` to private `mod` in `relvar-core/src/query/tests/mod.rs` to enforce proper module boundaries.
🧱 Stability: Prevented test internals from leaking, ensuring strict module encapsulation.
🔬 Verification: `cargo test` and `cargo check` pass successfully.

---
*PR created automatically by Jules for task [2686875960728764515](https://jules.google.com/task/2686875960728764515) started by @madmax983*