### PR TITLE
🎻 Bard: Document Spreadsheet

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -33,3 +33,6 @@
 ## 2025-05-06 - [The Ghost Knowledge Graph]
 **Confusion:** The experimental `KnowledgeGraph` module was completely undocumented, leaving users to guess how it connects to the relational model.
 **Clarification:** Wrote comprehensive module-level documentation and executable doctests for `KnowledgeGraph` and `TriplePattern` explaining the "Relational Semantic Web" concept.
+## 2025-05-20 - Documenting Spreadsheet
+**Confusion:** The experimental `Spreadsheet` module had placeholder examples and lacked executable doc-tests for its methods (`new` and `evaluate`), making it confusing for users to understand how to model cells and formulas relationally.
+**Clarification:** Replaced placeholders with executable `/// # Examples` doc-tests for `new`, and `evaluate`, clearly demonstrating how to construct values, define operations, and run evaluations.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,5 @@
+🎻 Bard: Document Spreadsheet
+
+📖 Chapter: The `Spreadsheet` module
+🔦 Insight: Clarified how to instantiate and evaluate spreadsheet cells using relational logic by replacing placeholder doc-tests.
+🧪 Example: Added 2 executable doctests for `Spreadsheet::new` and `Spreadsheet::evaluate`.

--- a/relvar/src/experimental/spreadsheet.rs
+++ b/relvar/src/experimental/spreadsheet.rs
@@ -25,7 +25,20 @@ impl Spreadsheet {
     /// ```
     /// use relvar::{Relation, RelationType, ScalarType, TupleType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let values = Relation::new(RelationType::new(val_heading));
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let formulas = Relation::new(RelationType::new(form_heading));
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
     /// ```
     pub fn new(values: Relation, formulas: Relation) -> Self {
         Self { values, formulas }
@@ -38,7 +51,28 @@ impl Spreadsheet {
     /// ```
     /// use relvar::{Relation, RelationType, ScalarType, TupleType};
     /// use relvar::experimental::spreadsheet::Spreadsheet;
-    /// // Note: This is a placeholder example
+    /// use relvar::tuple;
+    ///
+    /// let val_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("val", ScalarType::Float);
+    /// let mut values = Relation::new(RelationType::new(val_heading));
+    /// values.insert(tuple! { id: "A1".to_string(), val: 10.0f64 }).unwrap();
+    /// values.insert(tuple! { id: "A2".to_string(), val: 20.0f64 }).unwrap();
+    ///
+    /// let form_heading = TupleType::new()
+    ///     .with_attribute("id", ScalarType::String)
+    ///     .with_attribute("op", ScalarType::String)
+    ///     .with_attribute("arg1", ScalarType::String)
+    ///     .with_attribute("arg2", ScalarType::String);
+    /// let mut formulas = Relation::new(RelationType::new(form_heading));
+    /// formulas.insert(tuple! {
+    ///     id: "B1".to_string(), op: "ADD".to_string(), arg1: "A1".to_string(), arg2: "A2".to_string()
+    /// }).unwrap();
+    ///
+    /// let spreadsheet = Spreadsheet::new(values, formulas);
+    /// let result = spreadsheet.evaluate().unwrap();
+    /// assert_eq!(result.cardinality(), 3); // A1, A2, B1
     /// ```
     pub fn evaluate(&self) -> Result<Relation, DatabaseError> {
         let mut current_values = self.values.clone();


### PR DESCRIPTION
🎻 Bard: Document Spreadsheet

📖 Chapter: The `Spreadsheet` module
🔦 Insight: Clarified how to instantiate and evaluate spreadsheet cells using relational logic by replacing placeholder doc-tests.
🧪 Example: Added 2 executable doctests for `Spreadsheet::new` and `Spreadsheet::evaluate`.

---
*PR created automatically by Jules for task [12964494653751054014](https://jules.google.com/task/12964494653751054014) started by @madmax983*