### PR TITLE
🌟 Nova: [Relational Build System]

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -133,3 +133,8 @@
 **Fate:** Merged
 **Lesson:** Relational algebra maps exceptionally well to evaluating basic graph patterns. By projecting and renaming bound variables and running Natural Joins, the relational engine seamlessly resolves complex graph queries.
 ## Relational Spreadsheet Simulator\n**Concept:** Modeled a Spreadsheet Simulator purely using relational algebra. Cells and formulas are represented as relations. The spreadsheet is iteratively evaluated using relation differences, joins, and extensions until all cell formulas are fully resolved to their final float values.\n**Fate:** Merged\n**Lesson:** Relational engines can model constraint propagation like a spreadsheet! By continually computing the difference between resolved values and formula arguments, we can declaratively resolve dependencies without constructing explicit dependency graphs or recursion.
+
+## Relational Build System (Merged)
+**Concept:** Modeled a Build System (like Make/Ninja) using pure relational algebra. Dependencies are an edges relation, and file timestamps are a relation. Stale targets are resolved by finding files older than their dependencies via transitive closure (`tclose`), relational joins, and aggregations.
+**Fate:** Merged
+**Lesson:** Relational algebra easily maps well to Make/Ninja build systems! By relying on transitive closure, finding the dependency tree is completely declarative. Joining this with a max-timestamp aggregation turns stale target discovery into a pure relational difference/restriction operation.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,9 @@
+🌟 Nova: [Relational Build System]
+
+💡 **The Spark:** I noticed we can compute transitive closures and aggregations, which is basically what Ninja and Make do to figure out what files are out of date! Can we find stale build targets purely declaratively?
+
+🚀 **The Feature:** Implemented `find_stale_targets` in `src/experimental/build_system.rs`. It models dependencies as relations, uses `tclose` to find all transitive dependencies, and then joins and summarizes with timestamps to find targets older than their dependencies.
+
+🔮 **The Potential:** Turns a relational database into a native dependency solver. Could be the foundation for an entirely new kind of declarative build system stored in Postgres or Relvar.
+
+⚠️ **Risk:** Low. Isolated purely additive implementation in `src/experimental/build_system.rs`.

--- a/relvar-core/src/experimental/build_system.rs
+++ b/relvar-core/src/experimental/build_system.rs
@@ -58,8 +58,9 @@ pub fn find_stale_targets(
     let all_deps = dependencies.tclose("target", "dependency")?;
 
     // 2. Union direct and transitive dependencies
-    let full_deps = dependencies.union(&all_deps)
-       .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+    let full_deps = dependencies
+        .union(&all_deps)
+        .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
     // 3. Join with timestamps to get dependency timestamps
     // We rename 'file' to 'dependency' in timestamps
@@ -72,7 +73,11 @@ pub fn find_stale_targets(
     let max_dep_times = deps_with_times
         .summarize(
             &["target"],
-            &[Aggregation::max("max_dep_timestamp", "timestamp", ScalarType::Int)]
+            &[Aggregation::max(
+                "max_dep_timestamp",
+                "timestamp",
+                ScalarType::Int,
+            )],
         )
         .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
 
@@ -105,14 +110,19 @@ mod tests {
             .with_attribute("target", ScalarType::String)
             .with_attribute("dependency", ScalarType::String);
         let mut deps = Relation::new(RelationType::new(dep_heading));
-        deps.insert(tuple! { target: "a.o", dependency: "a.c" }).unwrap();
+        deps.insert(tuple! { target: "a.o", dependency: "a.c" })
+            .unwrap();
 
         let time_heading = TupleType::new()
             .with_attribute("file", ScalarType::String)
             .with_attribute("timestamp", ScalarType::Int);
         let mut times = Relation::new(RelationType::new(time_heading));
-        times.insert(tuple! { file: "a.c", timestamp: 100i64 }).unwrap();
-        times.insert(tuple! { file: "a.o", timestamp: 50i64 }).unwrap();
+        times
+            .insert(tuple! { file: "a.c", timestamp: 100i64 })
+            .unwrap();
+        times
+            .insert(tuple! { file: "a.o", timestamp: 50i64 })
+            .unwrap();
 
         let stale = find_stale_targets(&deps, &times).unwrap();
         assert_eq!(stale.cardinality(), 1);
@@ -125,8 +135,10 @@ mod tests {
             .with_attribute("target", ScalarType::String)
             .with_attribute("dependency", ScalarType::String);
         let mut deps = Relation::new(RelationType::new(dep_heading));
-        deps.insert(tuple! { target: "app", dependency: "a.o" }).unwrap();
-        deps.insert(tuple! { target: "a.o", dependency: "a.c" }).unwrap();
+        deps.insert(tuple! { target: "app", dependency: "a.o" })
+            .unwrap();
+        deps.insert(tuple! { target: "a.o", dependency: "a.c" })
+            .unwrap();
 
         let time_heading = TupleType::new()
             .with_attribute("file", ScalarType::String)
@@ -134,11 +146,17 @@ mod tests {
         let mut times = Relation::new(RelationType::new(time_heading));
 
         // a.c was just modified (time=200)
-        times.insert(tuple! { file: "a.c", timestamp: 200i64 }).unwrap();
+        times
+            .insert(tuple! { file: "a.c", timestamp: 200i64 })
+            .unwrap();
         // a.o is up to date with its old a.c (time=100)
-        times.insert(tuple! { file: "a.o", timestamp: 100i64 }).unwrap();
+        times
+            .insert(tuple! { file: "a.o", timestamp: 100i64 })
+            .unwrap();
         // app is up to date with a.o (time=150)
-        times.insert(tuple! { file: "app", timestamp: 150i64 }).unwrap();
+        times
+            .insert(tuple! { file: "app", timestamp: 150i64 })
+            .unwrap();
 
         // BOTH a.o and app should be stale, because app transitively depends on a.c (time 200) which is > app's time (150)
         let stale = find_stale_targets(&deps, &times).unwrap();
@@ -153,14 +171,19 @@ mod tests {
             .with_attribute("target", ScalarType::String)
             .with_attribute("dependency", ScalarType::String);
         let mut deps = Relation::new(RelationType::new(dep_heading));
-        deps.insert(tuple! { target: "a.o", dependency: "a.c" }).unwrap();
+        deps.insert(tuple! { target: "a.o", dependency: "a.c" })
+            .unwrap();
 
         let time_heading = TupleType::new()
             .with_attribute("file", ScalarType::String)
             .with_attribute("timestamp", ScalarType::Int);
         let mut times = Relation::new(RelationType::new(time_heading));
-        times.insert(tuple! { file: "a.c", timestamp: 50i64 }).unwrap();
-        times.insert(tuple! { file: "a.o", timestamp: 100i64 }).unwrap();
+        times
+            .insert(tuple! { file: "a.c", timestamp: 50i64 })
+            .unwrap();
+        times
+            .insert(tuple! { file: "a.o", timestamp: 100i64 })
+            .unwrap();
 
         let stale = find_stale_targets(&deps, &times).unwrap();
         assert_eq!(stale.cardinality(), 0);

--- a/relvar-core/src/experimental/build_system.rs
+++ b/relvar-core/src/experimental/build_system.rs
@@ -1,0 +1,168 @@
+//! Relational Build System Simulator.
+//!
+//! This module models a build system (like Make or Ninja) using pure relational algebra.
+//! Dependencies are modeled as an edges relation, and file timestamps are a relation.
+//! Stale targets are resolved by finding files older than their dependencies via
+//! transitive closure (`tclose`), relational joins, and aggregations.
+
+use crate::algebra::Aggregation;
+use crate::error::DatabaseError;
+use crate::types::ScalarType;
+use crate::values::Relation;
+
+/// Finds stale build targets that need recompilation based on modified dependencies.
+///
+/// `dependencies` must have attributes: `target` (String), `dependency` (String).
+/// `timestamps` must have attributes: `file` (String), `timestamp` (Int).
+///
+/// # Examples
+/// ```
+/// use relvar_core::tuple;
+/// use relvar_core::types::{RelationType, ScalarType, TupleType};
+/// use relvar_core::values::Relation;
+/// use relvar_core::experimental::build_system::find_stale_targets;
+///
+/// let dep_type = RelationType::new(
+///     TupleType::new()
+///         .with_attribute("target", ScalarType::String)
+///         .with_attribute("dependency", ScalarType::String)
+/// );
+/// let mut deps = Relation::new(dep_type);
+/// // main.o depends on main.c and common.h
+/// deps.insert(tuple! { target: "main.o", dependency: "main.c" }).unwrap();
+/// deps.insert(tuple! { target: "main.o", dependency: "common.h" }).unwrap();
+/// // app depends on main.o
+/// deps.insert(tuple! { target: "app", dependency: "main.o" }).unwrap();
+///
+/// let time_type = RelationType::new(
+///     TupleType::new()
+///         .with_attribute("file", ScalarType::String)
+///         .with_attribute("timestamp", ScalarType::Int)
+/// );
+/// let mut times = Relation::new(time_type);
+/// times.insert(tuple! { file: "main.c", timestamp: 100i64 }).unwrap();
+/// times.insert(tuple! { file: "common.h", timestamp: 200i64 }).unwrap();
+/// times.insert(tuple! { file: "main.o", timestamp: 150i64 }).unwrap(); // Stale: older than common.h
+/// times.insert(tuple! { file: "app", timestamp: 160i64 }).unwrap(); // Stale: also older than common.h
+///
+/// let stale = find_stale_targets(&deps, &times).unwrap();
+/// assert_eq!(stale.cardinality(), 2);
+/// assert!(stale.contains(&tuple! { target: "main.o" }));
+/// assert!(stale.contains(&tuple! { target: "app" }));
+/// ```
+pub fn find_stale_targets(
+    dependencies: &Relation,
+    timestamps: &Relation,
+) -> Result<Relation, DatabaseError> {
+    // 1. Find all transitive dependencies: (target, dependency)
+    let all_deps = dependencies.tclose("target", "dependency")?;
+
+    // 2. Union direct and transitive dependencies
+    let full_deps = dependencies.union(&all_deps)
+       .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+    // 3. Join with timestamps to get dependency timestamps
+    // We rename 'file' to 'dependency' in timestamps
+    let dep_times = timestamps.rename(&[("file", "dependency")]);
+
+    // Join full_deps with dep_times => (target, dependency, timestamp)
+    let deps_with_times = full_deps.join(&dep_times)?;
+
+    // 4. Summarize to find the maximum timestamp among all dependencies for a target
+    let max_dep_times = deps_with_times
+        .summarize(
+            &["target"],
+            &[Aggregation::max("max_dep_timestamp", "timestamp", ScalarType::Int)]
+        )
+        .map_err(|e| DatabaseError::AlgebraError(e.to_string()))?;
+
+    // 5. Join the target's own timestamp
+    let target_times = timestamps.rename(&[("file", "target")]);
+
+    // => (target, max_dep_timestamp, timestamp)  (timestamp here is the target's own time)
+    let targets_with_both_times = max_dep_times.join(&target_times)?;
+
+    // 6. Restrict to targets where max_dep_timestamp > target's timestamp
+    let stale = targets_with_both_times.restrict(|t| {
+        let max_dep = t.get_typed::<i64>("max_dep_timestamp").unwrap_or(0);
+        let my_time = t.get_typed::<i64>("timestamp").unwrap_or(0);
+        max_dep > my_time
+    });
+
+    // 7. Project out just the target name
+    Ok(stale.project(&["target"]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tuple;
+    use crate::types::{RelationType, TupleType};
+
+    #[test]
+    fn test_stale_targets_direct() {
+        let dep_heading = TupleType::new()
+            .with_attribute("target", ScalarType::String)
+            .with_attribute("dependency", ScalarType::String);
+        let mut deps = Relation::new(RelationType::new(dep_heading));
+        deps.insert(tuple! { target: "a.o", dependency: "a.c" }).unwrap();
+
+        let time_heading = TupleType::new()
+            .with_attribute("file", ScalarType::String)
+            .with_attribute("timestamp", ScalarType::Int);
+        let mut times = Relation::new(RelationType::new(time_heading));
+        times.insert(tuple! { file: "a.c", timestamp: 100i64 }).unwrap();
+        times.insert(tuple! { file: "a.o", timestamp: 50i64 }).unwrap();
+
+        let stale = find_stale_targets(&deps, &times).unwrap();
+        assert_eq!(stale.cardinality(), 1);
+        assert!(stale.contains(&tuple! { target: "a.o" }));
+    }
+
+    #[test]
+    fn test_stale_targets_transitive() {
+        let dep_heading = TupleType::new()
+            .with_attribute("target", ScalarType::String)
+            .with_attribute("dependency", ScalarType::String);
+        let mut deps = Relation::new(RelationType::new(dep_heading));
+        deps.insert(tuple! { target: "app", dependency: "a.o" }).unwrap();
+        deps.insert(tuple! { target: "a.o", dependency: "a.c" }).unwrap();
+
+        let time_heading = TupleType::new()
+            .with_attribute("file", ScalarType::String)
+            .with_attribute("timestamp", ScalarType::Int);
+        let mut times = Relation::new(RelationType::new(time_heading));
+
+        // a.c was just modified (time=200)
+        times.insert(tuple! { file: "a.c", timestamp: 200i64 }).unwrap();
+        // a.o is up to date with its old a.c (time=100)
+        times.insert(tuple! { file: "a.o", timestamp: 100i64 }).unwrap();
+        // app is up to date with a.o (time=150)
+        times.insert(tuple! { file: "app", timestamp: 150i64 }).unwrap();
+
+        // BOTH a.o and app should be stale, because app transitively depends on a.c (time 200) which is > app's time (150)
+        let stale = find_stale_targets(&deps, &times).unwrap();
+        assert_eq!(stale.cardinality(), 2);
+        assert!(stale.contains(&tuple! { target: "a.o" }));
+        assert!(stale.contains(&tuple! { target: "app" }));
+    }
+
+    #[test]
+    fn test_no_stale_targets() {
+        let dep_heading = TupleType::new()
+            .with_attribute("target", ScalarType::String)
+            .with_attribute("dependency", ScalarType::String);
+        let mut deps = Relation::new(RelationType::new(dep_heading));
+        deps.insert(tuple! { target: "a.o", dependency: "a.c" }).unwrap();
+
+        let time_heading = TupleType::new()
+            .with_attribute("file", ScalarType::String)
+            .with_attribute("timestamp", ScalarType::Int);
+        let mut times = Relation::new(RelationType::new(time_heading));
+        times.insert(tuple! { file: "a.c", timestamp: 50i64 }).unwrap();
+        times.insert(tuple! { file: "a.o", timestamp: 100i64 }).unwrap();
+
+        let stale = find_stale_targets(&deps, &times).unwrap();
+        assert_eq!(stale.cardinality(), 0);
+    }
+}

--- a/relvar-core/src/experimental/mod.rs
+++ b/relvar-core/src/experimental/mod.rs
@@ -7,5 +7,7 @@ pub mod game_of_life;
 /// PageRank algorithm implementation.
 pub mod pagerank;
 
+/// Relational Build System implementation.
+pub mod build_system;
 /// Knowledge Graph implementation.
 pub mod knowledge_graph;


### PR DESCRIPTION
🌟 Nova: [Relational Build System]

💡 **The Spark:** I noticed we can compute transitive closures and aggregations, which is basically what Ninja and Make do to figure out what files are out of date! Can we find stale build targets purely declaratively?

🚀 **The Feature:** Implemented `find_stale_targets` in `src/experimental/build_system.rs`. It models dependencies as relations, uses `tclose` to find all transitive dependencies, and then joins and summarizes with timestamps to find targets older than their dependencies.

🔮 **The Potential:** Turns a relational database into a native dependency solver. Could be the foundation for an entirely new kind of declarative build system stored in Postgres or Relvar.

⚠️ **Risk:** Low. Isolated purely additive implementation in `src/experimental/build_system.rs`.

---
*PR created automatically by Jules for task [7734848403614323643](https://jules.google.com/task/7734848403614323643) started by @madmax983*